### PR TITLE
Prescription medhud/sechud fix

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/Eyes/hud.yml
@@ -11,6 +11,7 @@
   - type: Construction
     graph: PrescriptionMedHud
     node: prescmedhud
+  - type: VisionCorrection
   - type: ShowHealthBars
     damageContainers:
     - Biological
@@ -31,6 +32,7 @@
     sprite: DeltaV/Clothing/Eyes/Hud/prescsechud.rsi
   - type: Clothing
     sprite: DeltaV/Clothing/Eyes/Hud/prescsechud.rsi
+  - type: VisionCorrection
   - type: Construction
     graph: PrescriptionSecHud
     node: prescsechud


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Fixed prescription huds not actually having the component that makes them actually have a purpose
---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Put actual prescription lenses in the prescription medhuds and sechuds
