### PR TITLE
Reenable Quick Swapping Items

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -417,7 +417,7 @@ namespace Content.Shared.CCVar
         ///     Whether item slots, such as power cell slots or AME fuel cell slots, should support quick swap if it is not otherwise specified in their YAML prototype.
         /// </summary>
         public static readonly CVarDef<bool> AllowSlotQuickSwap =
-            CVarDef.Create("game.slot_quick_swap", false, CVar.REPLICATED);
+            CVarDef.Create("game.slot_quick_swap", true, CVar.REPLICATED);
 
 #if EXCEPTION_TOLERANCE
         /// <summary>


### PR DESCRIPTION
# Description

Padding out gameplay by forcing a few extra clicks doesn't really add anything compelling, especially at the cost of frustrating interruptions in gameplay like falling down motionless whenever an IPC wants a battery upgrade. This changes the CVar back to true.


# TODO

- [x] Change the relevant CVar to "true"

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Reenabled item quick swapping for batteries and such.