### PR TITLE
Trait Languages Overhaul

### DIFF
--- a/Resources/Locale/en-US/loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/loadouts/itemgroups.ftl
@@ -102,4 +102,5 @@ character-item-group-LoadoutMusicianInstruments = Musician Instruments
 
 # Traits - Languages
 character-item-group-TraitsLanguagesBasic = Basic Languages
+character-item-group-TraitsLanguagesRacial = Racial Languages
 character-item-group-TraitsAccents = Accents

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -327,6 +327,38 @@ trait-description-ValyrianStandard =
     It is rarely spoken outside of the worlds of its native speakers, and has in modern times been supplanted by the 'Conlangs of the Sol Alliance.
     Its speakers are those who wish to uphold the traditions and beliefs of ancient peoples from before the colonial era.
 
+trait-name-Nekomimetic = Nekomimetic
+trait-description-Nekomimetic = To the casual observer, this language is an incomprehensible mess of broken Japanese. To the Felinids and Oni, it's somehow comprehensible.
+
+trait-name-Canilunzt = Canilunzt
+trait-description-Canilunzt = The guttural language spoken and utilized by the inhabitants of the Vazzend system,
+    composed of growls, barks, yaps, and heavy utilization of ears and tail movements. Vulpkanin speak this language with ease.
+
+trait-name-Bubblish = Bubblish
+trait-description-Bubblish = The language of Slimes. Being a mixture of bubbling noises and pops it's very difficult to speak for humans without the use of mechanical aids.
+
+trait-name-Mouse = Mouse
+trait-description-Mouse = Squeeek!
+
+trait-name-Rootspeak = Rootspeak
+trait-description-Rootspeak = The strange whistling-style language spoken by the Diona.
+
+trait-name-Moffic = Moffic
+trait-description-Moffic = The language of the mothpeople borders on complete unintelligibility.
+
+trait-name-Draconic = Sinta'Unathi
+trait-description-Draconic =
+    The common language of Moghes - composed of sibilant hisses and rattles. Spoken natively by Unathi.
+
+trait-name-RobotTalk = Robot Binary
+trait-description-RobotTalk = A language consisting of harsh binary chirps, whistles, hisses, and whines. Organic tongues cannot speak it without aid from special translators.
+
+trait-name-Marish = Marish
+trait-description-Marish = An Language that can be used to speak in Empathy, Sharing eachother emotions with only one word, Shadowkins speaks this language with ease, tho its is nearly impossible to replicate it or learn it.
+
+trait-name-Arachnic = Arachnic
+trait-description-Arachnic = The language of arachnids is composed of mostly clicks and hisses, it almost has a rhythmic character to it at times.
+
 trait-name-LowPotential = Low Psi-Potential
 trait-description-LowPotential =
     You possess an unusually weak connection to the noösphere, which makes it more difficult to obtain new psionic powers.

--- a/Resources/Prototypes/CharacterItemGroups/languageGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/languageGroups.yml
@@ -13,9 +13,57 @@
     - type: trait
       id: Elyran
     - type: trait
+      id: Azaziba
+    - type: trait
       id: ValyrianStandard
     - type: trait
-      id: Azaziba
+      id: Nekomimetic
+    - type: trait
+      id: Canilunzt
+    - type: trait
+      id: Bubblish
+    - type: trait
+      id: Rootspeak
+    - type: trait
+      id: Moffic
+    - type: trait
+      id: Draconic
+    - type: trait
+      id: RobotTalk
+    - type: trait
+      id: Arachnic
+    - type: trait
+      id: Marish
+    - type: trait
+      id: Mouse
+
+
+- type: characterItemGroup
+  id: TraitsLanguagesRacial
+  maxItems: 1
+  items:
+    - type: trait
+      id: ValyrianStandard
+    - type: trait
+      id: Nekomimetic
+    - type: trait
+      id: Canilunzt
+    - type: trait
+      id: Bubblish
+    - type: trait
+      id: Rootspeak
+    - type: trait
+      id: Moffic
+    - type: trait
+      id: Draconic
+    - type: trait
+      id: RobotTalk
+    - type: trait
+      id: Arachnic
+    - type: trait
+      id: Marish
+    - type: trait
+      id: Mouse
 
 - type: characterItemGroup
   id: TraitsAccents

--- a/Resources/Prototypes/Traits/languages.yml
+++ b/Resources/Prototypes/Traits/languages.yml
@@ -33,10 +33,6 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
   languagesSpoken:
     - Tradeband
   languagesUnderstood:
@@ -67,18 +63,6 @@
     - Elyran
 
 - type: trait
-  id: ValyrianStandard
-  category: TraitsSpeechLanguages
-  points: 1
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: TraitsLanguagesBasic
-  languagesSpoken:
-    - ValyrianStandard
-  languagesUnderstood:
-    - ValyrianStandard
-
-- type: trait
   id: Azaziba
   category: TraitsSpeechLanguages
   points: 1
@@ -92,3 +76,181 @@
     - Azaziba
   languagesUnderstood:
     - Azaziba
+
+- type: trait
+  id: ValyrianStandard
+  category: TraitsSpeechLanguages
+  points: -2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesRacial
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Harpy
+  languagesSpoken:
+    - ValyrianStandard
+  languagesUnderstood:
+    - ValyrianStandard
+
+- type: trait
+  id: Nekomimetic
+  category: TraitsSpeechLanguages
+  points: -2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesRacial
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Felinid
+        - Oni
+  languagesSpoken:
+    - Nekomimetic
+  languagesUnderstood:
+    - Nekomimetic
+
+- type: trait
+  id: Canilunzt
+  category: TraitsSpeechLanguages
+  points: -2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesRacial
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Vulpkanin
+  languagesSpoken:
+    - Canilunzt
+  languagesUnderstood:
+    - Canilunzt
+
+- type: trait
+  id: Bubblish
+  category: TraitsSpeechLanguages
+  points: -2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesRacial
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - SlimePerson
+  languagesSpoken:
+    - Bubblish
+  languagesUnderstood:
+    - Bubblish
+
+- type: trait
+  id: Rootspeak
+  category: TraitsSpeechLanguages
+  points: -2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesRacial
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Diona
+  languagesSpoken:
+    - Rootspeak
+  languagesUnderstood:
+    - Rootspeak
+
+- type: trait
+  id: Moffic
+  category: TraitsSpeechLanguages
+  points: -2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesRacial
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Moth
+  languagesSpoken:
+    - Moffic
+  languagesUnderstood:
+    - Moffic
+
+- type: trait
+  id: Draconic
+  category: TraitsSpeechLanguages
+  points: -2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesRacial
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Reptilian
+  languagesSpoken:
+    - Draconic
+  languagesUnderstood:
+    - Draconic
+
+- type: trait
+  id: RobotTalk
+  category: TraitsSpeechLanguages
+  points: -2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesRacial
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - IPC
+  languagesSpoken:
+    - RobotTalk
+  languagesUnderstood:
+    - RobotTalk
+
+- type: trait
+  id: Arachnic
+  category: TraitsSpeechLanguages
+  points: -2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesRacial
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Arachnid
+        - Arachne
+  languagesSpoken:
+    - Arachnic
+  languagesUnderstood:
+    - Arachnic
+
+- type: trait
+  id: Marish
+  category: TraitsSpeechLanguages
+  points: -2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesRacial
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Shadowkin
+  languagesSpoken:
+    - Marish
+  languagesUnderstood:
+    - Marish
+
+- type: trait
+  id: Mouse
+  category: TraitsSpeechLanguages
+  points: -2
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: TraitsLanguagesRacial
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Rodentia
+  languagesSpoken:
+    - Mouse
+  languagesUnderstood:
+    - Mouse


### PR DESCRIPTION

# Description

Fixes existing language traits and adds Racial languages to 

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Fix Valryian Trait
- [x] Add other racial languages to trait page
- [x] Make Regular Languages (Sign Language, Freespeak, etc) and Racial Languages separate groups

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<h1>Media</h1>

![Medal_fqq6O0SvuG](https://github.com/user-attachments/assets/fbda1fc8-4062-4dff-800f-f14dbf01705a)
![Medal_nGP6rQQJzz](https://github.com/user-attachments/assets/926c0e0a-d21d-4707-89c5-0d15e54d0f75)
![Medal_BxzBZZmPV1](https://github.com/user-attachments/assets/fbcbcce6-0321-4115-95ad-90c39a781324)

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed Valyrian Standard trait, no more free point
- add: Added racial languages to traits menu for 2 points
