### PR TITLE
Changed Default Jug Count to 8

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -1,7 +1,7 @@
 - type: vendingMachineInventory
   id: ChemVendInventory
   startingInventory:
-    Jug: 4
+    Jug: 8
     JugAluminium: 2
     JugCarbon: 4
     JugChlorine: 1
@@ -28,7 +28,7 @@
 - type: vendingMachineInventory
   id: ChemVendInventorySyndicate
   startingInventory:
-    Jug: 4
+    Jug: 8
     JugAluminium: 2
     JugCarbon: 4
     JugChlorine: 1


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

ChemVend jug count is now 8.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked default ChemVend jug count to 8.