### PR TITLE
IPCs can open the midi menu 

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
@@ -207,6 +207,9 @@
           type: HumanoidMarkingModifierBoundUserInterface
         enum.StrippingUiKey.Key:
           type: StrippableBoundUserInterface
+        enum.InstrumentUiKey.Key:
+            type: InstrumentBoundUserInterface
+            requireInputValidation: false
         enum.RadialSelectorUiKey.Key:
           type: RadialSelectorMenuBUI
         enum.ListViewSelectorUiKey.Key:

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -167,7 +167,7 @@
 - type: trait
   id: Singer
   category: Auditory
-  points: -2
+  points: 0
   requirements:
     - !type:CharacterSpeciesRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -173,7 +173,6 @@
       inverted: true
       species:
         - Harpy
-        - IPC # because for some reason, fuck IPCs in relation to UI? TODO: fix this
   functions:
     - !type:TraitAddComponent
       components:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

IPCs are now able to use the midi menu and take the singer trait.
Singer trait is now 0 trait points to take.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: The Singer trait now costs 0 points.
- tweak: IPCs can now take the Singer trait again.
- fix: Fixed IPCs being unable to open the midi instrument menu.
