### PR TITLE
Asterisk Wire Fix

### DIFF
--- a/Resources/Maps/TheDen/asterisk.yml
+++ b/Resources/Maps/TheDen/asterisk.yml
@@ -5098,7 +5098,7 @@ entities:
       pos: 39.5,10.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -916.047
+      secondsUntilStateChange: -1033.6802
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -5461,7 +5461,7 @@ entities:
       pos: -45.5,6.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1835.0765
+      secondsUntilStateChange: -1952.7097
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -15574,6 +15574,11 @@ entities:
     - type: Transform
       pos: 42.5,14.5
       parent: 2
+  - uid: 11187
+    components:
+    - type: Transform
+      pos: 39.5,8.5
+      parent: 2
   - uid: 11208
     components:
     - type: Transform
@@ -15600,13 +15605,6 @@ entities:
     components:
     - type: Transform
       pos: 34.354755,18.5525
-      parent: 2
-- proto: CableApcStack1
-  entities:
-  - uid: 11216
-    components:
-    - type: Transform
-      pos: 39.5,8.5
       parent: 2
 - proto: CableHV
   entities:
@@ -21349,8 +21347,6 @@ entities:
     - type: Transform
       pos: 38.5,-16.5
       parent: 2
-- proto: CableMVStack1
-  entities:
   - uid: 7782
     components:
     - type: Transform


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Fixed Wiring on Asterisk to prevent power outages in the bridge and gravity generators at roundstart.

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Description.

---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Juniper
- fix: [Asterisk] Fixed wiring in engineering at roundstart. (no more powerless bridge and grav)
