### PR TITLE
Fixes

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -652,7 +652,7 @@ namespace Content.Client.Lobby.UI
             UpdateHairPickers();
             UpdateCMarkingsHair();
             UpdateCMarkingsFacialHair();
-            UpdateHeightWidthSliders(); // breaks here
+            UpdateHeightWidthSliders();
             UpdateWeight();
             UpdateCharacterRequired();
 
@@ -1351,18 +1351,18 @@ namespace Content.Client.Lobby.UI
 
         private void UpdateHeightWidthSliders()
         {
-            var species = _species.Find(x => x.ID == Profile?.Species) ?? _species.First();
-
             if (Profile is null)
                 return;
+            
+            var species = _species.Find(x => x.ID == Profile?.Species) ?? _species.First();
 
             HeightSlider.MinValue = species.MinHeight;
             HeightSlider.MaxValue = species.MaxHeight;
-            HeightSlider.Value = (float) Profile?.Height!;
+            HeightSlider.Value = Profile?.Height ?? species.DefaultHeight;
 
             WidthSlider.MinValue = species.MinWidth;
             WidthSlider.MaxValue = species.MaxWidth;
-            WidthSlider.Value = (float) Profile?.Width!;
+            WidthSlider.Value = Profile?.Width ?? species.DefaultWidth;
 
             var height = MathF.Round(species.AverageHeight * HeightSlider.Value);
             HeightLabel.Text = Loc.GetString("humanoid-profile-editor-height-label", ("height", (int) height));

--- a/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
+++ b/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
@@ -20,9 +20,9 @@ public sealed class SalvageMagnetBoundUserInterface : BoundUserInterface
     protected override void Open()
     {
         base.Open();
-        _window = new OfferingWindow();
+
+        _window = this.CreateWindow<OfferingWindow>();
         _window.Title = Loc.GetString("salvage-magnet-window-title");
-        _window.OnClose += Close;
         _window.OpenCenteredLeft();
     }
 


### PR DESCRIPTION
# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed the bug where switching characters made your width/height change to incorrect values.
- fix: Fixed the salvage magnet opening ten times.