### PR TITLE
NanoChat Fix

### DIFF
--- a/Content.Server/DeltaV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/DeltaV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.DeltaV.CartridgeLoader.Cartridges;
 using Content.Shared.DeltaV.NanoChat;
 using Content.Shared.PDA;
 using Content.Shared.Radio.Components;
+using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 
@@ -25,7 +26,8 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedNanoChatSystem _nanoChat = default!;
     [Dependency] private readonly StationSystem _station = default!;
-
+    [Dependency] private readonly UserInterfaceSystem _ui = default!;
+    
     // Messages in notifications get cut off after this point
     // no point in storing it on the comp
     private const int NotificationMaxLength = 64;
@@ -383,6 +385,11 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
 
         if (_nanoChat.GetCurrentChat((recipient, recipient.Comp)) != senderNumber)
+            HandleUnreadNotification(recipient, message);
+
+        if (
+            _nanoChat.GetCurrentChat((recipient, recipient.Comp)) == senderNumber
+            && !_ui.IsUiOpen(recipient.Owner, PdaUiKey.Key))
             HandleUnreadNotification(recipient, message);
 
         var msgEv = new NanoChatMessageReceivedEvent(recipient);

--- a/Content.Server/DeltaV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/DeltaV/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -27,7 +27,7 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
     [Dependency] private readonly SharedNanoChatSystem _nanoChat = default!;
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
-    
+
     // Messages in notifications get cut off after this point
     // no point in storing it on the comp
     private const int NotificationMaxLength = 64;
@@ -385,11 +385,6 @@ public sealed class NanoChatCartridgeSystem : EntitySystem
 
 
         if (_nanoChat.GetCurrentChat((recipient, recipient.Comp)) != senderNumber)
-            HandleUnreadNotification(recipient, message);
-
-        if (
-            _nanoChat.GetCurrentChat((recipient, recipient.Comp)) == senderNumber
-            && !_ui.IsUiOpen(recipient.Owner, PdaUiKey.Key))
             HandleUnreadNotification(recipient, message);
 
         var msgEv = new NanoChatMessageReceivedEvent(recipient);

--- a/Content.Shared/DeltaV/NanoChat/SharedNanoChatSystem.cs
+++ b/Content.Shared/DeltaV/NanoChat/SharedNanoChatSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.DeltaV.CartridgeLoader.Cartridges;
 using Content.Shared.Examine;
+using Content.Shared.PDA;
 using Robust.Shared.Timing;
 
 namespace Content.Shared.DeltaV.NanoChat;
@@ -10,6 +11,7 @@ namespace Content.Shared.DeltaV.NanoChat;
 public abstract class SharedNanoChatSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
 
     public override void Initialize()
     {
@@ -137,6 +139,10 @@ public abstract class SharedNanoChatSystem : EntitySystem
     public uint? GetCurrentChat(Entity<NanoChatCardComponent?> card)
     {
         if (!Resolve(card, ref card.Comp))
+            return null;
+
+        // If the UI is not open, no one is technically selected.
+        if (!_ui.IsUiOpen(card.Owner, PdaUiKey.Key))
             return null;
 
         return card.Comp.CurrentChat;


### PR DESCRIPTION
# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed NanoChat not notifying you if you had someone selected but your PDA was closed.
