### PR TITLE
Disable Default Shadowkin Powers

### DIFF
--- a/Content.Server/Shadowkin/ShadowkinSystem.cs
+++ b/Content.Server/Shadowkin/ShadowkinSystem.cs
@@ -138,9 +138,6 @@ public sealed class ShadowkinSystem : EntitySystem
         magic.ManaGain = 0.25f;
         magic.MindbreakingFeedback = "shadowkin-blackeye";
         magic.NoMana = "shadowkin-tired";
-
-        if (_prototypeManager.TryIndex<PsionicPowerPrototype>("ShadowkinPowers", out var shadowkinPowers))
-            _psionicAbilitiesSystem.InitializePsionicPower(uid, shadowkinPowers);
     }
 
     // FloofStation Edit

--- a/Resources/Prototypes/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/shadowkin.yml
@@ -235,9 +235,6 @@
       mana: 100
       maxMana: 200
       noMana: shadowkin-tired
-    - type: InnatePsionicPowers
-      powersToAdd:
-        - ShadowkinPowers
     - type: LanguageKnowledge
       speaks:
         - TauCetiBasic


### PR DESCRIPTION
# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- remove: Removed the default Dark Swap Shadowkin power
