### PR TITLE
Update humanoid-character-profile.ftl

### DIFF
--- a/Resources/Locale/en-US/preferences/humanoid-character-profile.ftl
+++ b/Resources/Locale/en-US/preferences/humanoid-character-profile.ftl
@@ -5,5 +5,6 @@ humanoid-character-profile-summary =
     This is {$name}. {$gender ->
     [male] He is
     [female] She is
+    [neuter] It is
     *[other] They are
 } {$age} years old.


### PR DESCRIPTION
Fixes the pronouns in the character preview to not show they/them pronouns for characters that use it/its

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This just adds another condition in the fluent file that controls the character preview text.

Essentially, characters that use it/its pronouns will go from:

"This is [character]. They are X years old."

to

"This is [character]. It is X years old."

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Probably test it, maybe.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Azzy
- fix: Fixed they/them pronouns being displayed for it/its characters in the character preview.