### PR TITLE
CMO Turtlenecks Loadout (Again)

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/chiefMedicalOfficer.yml
@@ -91,3 +91,7 @@
       id: LoadoutChiefMedicalOfficerJumpsuit
     - type: loadout
       id: LoadoutChiefMedicalOfficerJumpskirt
+    - type: loadout
+      id: LoadoutChiefMedicalOfficerTurtleskirt # The Den
+    - type: loadout
+      id: LoadoutChiefMedicalOfficerTurtlesuit # The Den

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
@@ -212,3 +212,29 @@
         - ChiefMedicalOfficer
   items:
     - ClothingUniformJumpskirtCMO
+
+- type: loadout 
+  id: LoadoutChiefMedicalOfficerTurtleskirt # The Den // LETS HOPE IT STICKS THIS TIME
+  category: JobsMedicalChiefMedicalOfficer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefMedicalOfficerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefMedicalOfficer
+  items:
+    - ClothingUniformJumpskirtCMOTurtle
+
+- type: loadout
+  id: LoadoutChiefMedicalOfficerTurtlesuit # The Den
+  category: JobsMedicalChiefMedicalOfficer
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChiefMedicalOfficerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefMedicalOfficer
+  items:
+    - ClothingUniformJumpsuitCMOTurtle


### PR DESCRIPTION
# Description

Re-adds CMO Turtleneck to the loadout (I swear to fucking god if I have to re-add it again I am going to commit many war crimes)

---

# TODO

- [x] turtle neck 👍

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: CMO Turtleneck back to loadout