### PR TITLE
Tweaked Striking Calluses To Be Usable By Other Species

### DIFF
--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -391,9 +391,9 @@
       inverted: true
       jobs:
         - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-    - !type:CharacterSpeciesRequirement
-      species:
-        - Human # Entirely arbitrary, I've decided I want a trait unique to humans. Since they don't normally get anything exciting.
+    #- !type:CharacterSpeciesRequirement
+    #  species:
+    #    - Human # Entirely arbitrary, I've decided I want a trait unique to humans. Since they don't normally get anything exciting.
                 # When we get the Character Records system in, I also want to make this require certain Backgrounds.
     - !type:CharacterTraitRequirement
       inverted: true
@@ -408,6 +408,21 @@
         - !type:CharacterJobRequirement
           jobs:
             - Boxer
+    - !type:CharacterLogicOrRequirement
+      requirements:
+        - !type:CharacterSpeciesRequirement
+          inverted: true
+          species:
+            - Arachne
+            - Harpy
+            - Felinid
+            - Reptilian
+            - Shadowkin
+            - Rodentia
+        - !type:CharacterTraitRequirement
+          traits:
+            - NaturalWeaponRemoval
+            - MartialArtist
   functions:
     - !type:TraitReplaceComponent
       components:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Tweaked Striking Calluses so that other species can use it, as long as they have blunt unarmed attacks either by default or through the Natural Weapons Removal trait.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Changed Striking Calluses to be usable by other species, requiring having blunt unarmed attacks (Whether by default or by having the Natural Weapons Removal trait). Fisticuffs for everyone!
