### PR TITLE
Cargo Shuttle Fixed

### DIFF
--- a/Resources/Maps/Shuttles/cargo.yml
+++ b/Resources/Maps/Shuttles/cargo.yml
@@ -24,6 +24,7 @@ entities:
     - type: MovedGrids
     - type: Broadphase
     - type: OccluderTree
+    - type: LoadedMap
   - uid: 2
     components:
     - type: MetaData
@@ -188,44 +189,44 @@ entities:
     - type: GasTileOverlay
 - proto: AirAlarm
   entities:
-  - uid: 99
+  - uid: 3
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 2
     - type: DeviceList
       devices:
-      - 193
-      - 192
-      - 191
+      - 118
+      - 9
+      - 119
 - proto: AirCanister
   entities:
-  - uid: 3
+  - uid: 4
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
 - proto: AirlockGlassShuttle
   entities:
-  - uid: 4
+  - uid: 5
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,3.5
       parent: 2
-  - uid: 5
+  - uid: 6
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,1.5
       parent: 2
-  - uid: 6
+  - uid: 7
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,3.5
       parent: 2
-  - uid: 7
+  - uid: 8
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -233,7 +234,7 @@ entities:
       parent: 2
 - proto: AirSensor
   entities:
-  - uid: 192
+  - uid: 9
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -243,35 +244,55 @@ entities:
       configurators:
       - invalid
       deviceLists:
-      - 99
+      - 3
 - proto: APCHyperCapacity
   entities:
-  - uid: 8
+  - uid: 10
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 2
 - proto: AtmosDeviceFanTiny
   entities:
-  - uid: 9
+  - uid: 11
     components:
     - type: Transform
       pos: -5.5,1.5
       parent: 2
-  - uid: 10
+  - uid: 12
     components:
     - type: Transform
       pos: -5.5,3.5
       parent: 2
-  - uid: 11
+  - uid: 13
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 2
-  - uid: 12
+  - uid: 14
     components:
     - type: Transform
       pos: 0.5,1.5
+      parent: 2
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 0.5,0.5
       parent: 2
 - proto: BlastDoor
   entities:
@@ -283,8 +304,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 122
-  - uid: 123
+      - 145
+  - uid: 16
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -292,8 +313,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 14
-  - uid: 124
+      - 142
+  - uid: 17
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -301,8 +322,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 16
-  - uid: 176
+      - 143
+  - uid: 18
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -310,202 +331,185 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 121
+      - 144
 - proto: CableApcExtension
   entities:
-  - uid: 13
+  - uid: 19
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 2
-  - uid: 17
+  - uid: 20
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 2
-  - uid: 18
+  - uid: 21
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
-  - uid: 19
+  - uid: 22
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 2
-  - uid: 20
+  - uid: 23
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 2
-  - uid: 22
+  - uid: 24
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 2
-  - uid: 24
+  - uid: 25
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 2
-  - uid: 25
+  - uid: 26
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 2
-  - uid: 26
+  - uid: 27
     components:
     - type: Transform
       pos: -2.5,4.5
       parent: 2
-  - uid: 27
+  - uid: 28
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 2
-  - uid: 28
+  - uid: 29
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 2
-  - uid: 29
+  - uid: 30
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 2
-  - uid: 30
+  - uid: 31
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 2
-  - uid: 31
+  - uid: 32
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 2
-  - uid: 32
+  - uid: 33
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 2
-  - uid: 33
+  - uid: 34
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 2
-  - uid: 34
+  - uid: 35
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 2
-  - uid: 35
+  - uid: 36
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 2
-  - uid: 36
+  - uid: 37
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 2
-  - uid: 37
+  - uid: 38
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
-  - uid: 38
+  - uid: 39
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 2
-  - uid: 39
+  - uid: 40
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 40
+  - uid: 41
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
-  - uid: 41
+  - uid: 42
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
-  - uid: 42
+  - uid: 43
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 2
-  - uid: 43
+  - uid: 44
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 2
-  - uid: 44
+  - uid: 45
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 2
-  - uid: 45
+  - uid: 46
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 2
-  - uid: 46
+  - uid: 47
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 2
-  - uid: 47
+  - uid: 48
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 2
-  - uid: 48
+  - uid: 49
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 2
-  - uid: 49
+  - uid: 50
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 2
-  - uid: 50
+  - uid: 51
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 2
-  - uid: 143
+  - uid: 52
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 2
-  - uid: 168
+  - uid: 53
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
 - proto: CableHV
-  entities:
-  - uid: 51
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 2
-  - uid: 52
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 2
-  - uid: 53
-    components:
-    - type: Transform
-      pos: -2.5,-3.5
-      parent: 2
-- proto: CableMV
   entities:
   - uid: 54
     components:
@@ -515,66 +519,83 @@ entities:
   - uid: 55
     components:
     - type: Transform
-      pos: -1.5,-1.5
+      pos: -2.5,-2.5
       parent: 2
   - uid: 56
     components:
     - type: Transform
-      pos: -2.5,-1.5
+      pos: -2.5,-3.5
       parent: 2
+- proto: CableMV
+  entities:
   - uid: 57
     components:
     - type: Transform
-      pos: -2.5,-0.5
+      pos: -1.5,-2.5
       parent: 2
   - uid: 58
     components:
     - type: Transform
-      pos: -2.5,0.5
+      pos: -1.5,-1.5
       parent: 2
   - uid: 59
     components:
     - type: Transform
-      pos: -2.5,1.5
+      pos: -2.5,-1.5
       parent: 2
   - uid: 60
     components:
     - type: Transform
-      pos: -2.5,2.5
+      pos: -2.5,-0.5
       parent: 2
   - uid: 61
     components:
     - type: Transform
-      pos: -2.5,3.5
+      pos: -2.5,0.5
       parent: 2
   - uid: 62
     components:
     - type: Transform
-      pos: -2.5,4.5
+      pos: -2.5,1.5
       parent: 2
   - uid: 63
     components:
     - type: Transform
-      pos: -2.5,5.5
+      pos: -2.5,2.5
       parent: 2
   - uid: 64
     components:
     - type: Transform
-      pos: -2.5,6.5
+      pos: -2.5,3.5
       parent: 2
   - uid: 65
     components:
     - type: Transform
-      pos: -1.5,6.5
+      pos: -2.5,4.5
       parent: 2
   - uid: 66
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 2
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 69
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 2
 - proto: CableTerminal
   entities:
-  - uid: 67
+  - uid: 70
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -582,94 +603,94 @@ entities:
       parent: 2
 - proto: CargoPallet
   entities:
-  - uid: 68
+  - uid: 71
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 2
-  - uid: 69
+  - uid: 72
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 2
-  - uid: 70
+  - uid: 73
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 2
-  - uid: 71
+  - uid: 74
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 2
-  - uid: 72
+  - uid: 75
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 2
-  - uid: 73
+  - uid: 76
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 2
-  - uid: 74
+  - uid: 77
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 2
-  - uid: 75
+  - uid: 78
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 2
-  - uid: 76
+  - uid: 79
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 2
-  - uid: 77
+  - uid: 80
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 2
-  - uid: 78
+  - uid: 81
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 2
-  - uid: 79
+  - uid: 82
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 2
 - proto: ChairPilotSeat
   entities:
-  - uid: 80
+  - uid: 83
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,7.5
       parent: 2
-  - uid: 195
+  - uid: 84
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
-  - uid: 196
+  - uid: 85
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 2
 - proto: ComputerShuttle
   entities:
-  - uid: 81
+  - uid: 86
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 2
 - proto: ConveyorBelt
   entities:
-  - uid: 82
+  - uid: 87
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -677,8 +698,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 139
-  - uid: 83
+      - 160
+  - uid: 88
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -686,8 +707,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 139
-  - uid: 84
+      - 160
+  - uid: 89
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -695,8 +716,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 139
-  - uid: 85
+      - 160
+  - uid: 90
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -704,8 +725,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 137
-  - uid: 86
+      - 158
+  - uid: 91
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -713,8 +734,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 137
-  - uid: 87
+      - 158
+  - uid: 92
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -722,8 +743,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 137
-  - uid: 88
+      - 158
+  - uid: 93
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -731,8 +752,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 138
-  - uid: 89
+      - 159
+  - uid: 94
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -740,8 +761,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 140
-  - uid: 90
+      - 161
+  - uid: 95
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -749,8 +770,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 140
-  - uid: 91
+      - 161
+  - uid: 96
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -758,8 +779,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 140
-  - uid: 92
+      - 161
+  - uid: 97
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -767,8 +788,8 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 138
-  - uid: 93
+      - 159
+  - uid: 98
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -776,10 +797,10 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       links:
-      - 138
+      - 159
 - proto: Crowbar
   entities:
-  - uid: 194
+  - uid: 99
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -787,7 +808,7 @@ entities:
       parent: 2
 - proto: GasOutletInjector
   entities:
-  - uid: 179
+  - uid: 100
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -795,91 +816,91 @@ entities:
       parent: 2
 - proto: GasPipeBend
   entities:
-  - uid: 94
+  - uid: 101
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-1.5
       parent: 2
-  - uid: 180
+  - uid: 102
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-2.5
       parent: 2
-  - uid: 181
+  - uid: 103
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 2
-  - uid: 190
+  - uid: 104
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 2
 - proto: GasPipeStraight
   entities:
-  - uid: 95
+  - uid: 105
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,0.5
       parent: 2
-  - uid: 96
+  - uid: 106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,1.5
       parent: 2
-  - uid: 175
+  - uid: 107
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 2
-  - uid: 182
+  - uid: 108
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-1.5
       parent: 2
-  - uid: 183
+  - uid: 109
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-0.5
       parent: 2
-  - uid: 184
+  - uid: 110
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,0.5
       parent: 2
-  - uid: 185
+  - uid: 111
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,1.5
       parent: 2
-  - uid: 186
+  - uid: 112
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,2.5
       parent: 2
-  - uid: 187
+  - uid: 113
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,3.5
       parent: 2
-  - uid: 188
+  - uid: 114
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,4.5
       parent: 2
-  - uid: 189
+  - uid: 115
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -887,7 +908,7 @@ entities:
       parent: 2
 - proto: GasPort
   entities:
-  - uid: 98
+  - uid: 116
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -895,7 +916,7 @@ entities:
       parent: 2
 - proto: GasPressurePump
   entities:
-  - uid: 97
+  - uid: 117
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -903,7 +924,7 @@ entities:
       parent: 2
 - proto: GasVentPump
   entities:
-  - uid: 193
+  - uid: 118
     components:
     - type: Transform
       pos: -2.5,2.5
@@ -912,10 +933,10 @@ entities:
       configurators:
       - invalid
       deviceLists:
-      - 99
+      - 3
 - proto: GasVentScrubber
   entities:
-  - uid: 191
+  - uid: 119
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -925,84 +946,58 @@ entities:
       configurators:
       - invalid
       deviceLists:
-      - 99
+      - 3
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 100
+  - uid: 120
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 2
 - proto: GravityGeneratorMini
   entities:
-  - uid: 101
+  - uid: 121
     components:
     - type: Transform
       pos: -1.5,-1.5
       parent: 2
 - proto: Grille
   entities:
-  - uid: 102
+  - uid: 122
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 2
-  - uid: 103
+  - uid: 123
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 2
-  - uid: 104
+  - uid: 124
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 2
-  - uid: 105
+  - uid: 125
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 2
-  - uid: 106
+  - uid: 126
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 2
 - proto: Gyroscope
   entities:
-  - uid: 107
+  - uid: 127
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 2
-- proto: PlasticFlapsAirtightClear
-  entities:
-  - uid: 108
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,0.5
-      parent: 2
-  - uid: 109
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,0.5
-      parent: 2
-  - uid: 110
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,4.5
-      parent: 2
-  - uid: 111
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,4.5
-      parent: 2
 - proto: Poweredlight
   entities:
-  - uid: 112
+  - uid: 132
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1010,7 +1005,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 113
+  - uid: 133
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1018,7 +1013,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 114
+  - uid: 134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1026,7 +1021,7 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 115
+  - uid: 135
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1036,50 +1031,50 @@ entities:
       powerLoad: 0
 - proto: Rack
   entities:
-  - uid: 197
+  - uid: 136
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 2
 - proto: ShuttleWindow
   entities:
-  - uid: 116
+  - uid: 137
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 2
-  - uid: 117
+  - uid: 138
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 2
-  - uid: 118
+  - uid: 139
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 2
-  - uid: 119
+  - uid: 140
     components:
     - type: Transform
       pos: -3.5,9.5
       parent: 2
-  - uid: 120
+  - uid: 141
     components:
     - type: Transform
       pos: -3.5,8.5
       parent: 2
 - proto: SignalButton
   entities:
-  - uid: 14
+  - uid: 142
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        123:
+        16:
         - Pressed: Toggle
-  - uid: 16
+  - uid: 143
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1087,18 +1082,18 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        124:
+        17:
         - Pressed: Toggle
-  - uid: 121
+  - uid: 144
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        176:
+        18:
         - Pressed: Toggle
-  - uid: 122
+  - uid: 145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1110,73 +1105,73 @@ entities:
         - Pressed: Toggle
 - proto: SMESBasic
   entities:
-  - uid: 125
+  - uid: 146
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 2
 - proto: SubstationBasic
   entities:
-  - uid: 126
+  - uid: 147
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 2
 - proto: TableReinforced
   entities:
-  - uid: 127
+  - uid: 148
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 2
-  - uid: 128
+  - uid: 149
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 2
 - proto: Thruster
   entities:
-  - uid: 129
+  - uid: 150
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-2.5
       parent: 2
-  - uid: 130
+  - uid: 151
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,7.5
       parent: 2
-  - uid: 131
+  - uid: 152
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,7.5
       parent: 2
-  - uid: 132
+  - uid: 153
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 2
-  - uid: 133
+  - uid: 154
     components:
     - type: Transform
       pos: -4.5,9.5
       parent: 2
-  - uid: 134
+  - uid: 155
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 2
-  - uid: 135
+  - uid: 156
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-4.5
       parent: 2
-  - uid: 136
+  - uid: 157
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1184,29 +1179,10 @@ entities:
       parent: 2
 - proto: TwoWayLever
   entities:
-  - uid: 137
+  - uid: 158
     components:
     - type: Transform
       pos: -3.5,1.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        87:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        86:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        85:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-  - uid: 138
-    components:
-    - type: Transform
-      pos: -1.5,1.5
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
@@ -1214,40 +1190,6 @@ entities:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        88:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        93:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-  - uid: 139
-    components:
-    - type: Transform
-      pos: -1.5,3.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        82:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        83:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-        84:
-        - Left: Forward
-        - Right: Reverse
-        - Middle: Off
-  - uid: 140
-    components:
-    - type: Transform
-      pos: -3.5,3.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
         91:
         - Left: Forward
         - Right: Reverse
@@ -1256,195 +1198,248 @@ entities:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        97:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        93:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        98:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        87:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        88:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
         89:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        96:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        95:
+        - Left: Forward
+        - Right: Reverse
+        - Middle: Off
+        94:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
 - proto: WallShuttle
   entities:
-  - uid: 21
+  - uid: 162
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 2
-  - uid: 141
+  - uid: 163
     components:
     - type: Transform
       pos: -5.5,8.5
       parent: 2
-  - uid: 142
+  - uid: 164
     components:
     - type: Transform
       pos: -4.5,8.5
       parent: 2
-  - uid: 144
+  - uid: 165
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 2
-  - uid: 145
+  - uid: 166
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 2
-  - uid: 146
+  - uid: 167
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 2
-  - uid: 147
+  - uid: 168
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 2
-  - uid: 148
+  - uid: 169
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 2
-  - uid: 149
+  - uid: 170
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 2
-  - uid: 150
+  - uid: 171
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 2
-  - uid: 151
+  - uid: 172
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 2
-  - uid: 152
+  - uid: 173
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 2
-  - uid: 153
+  - uid: 174
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 2
-  - uid: 154
+  - uid: 175
     components:
     - type: Transform
       pos: -5.5,-1.5
       parent: 2
-  - uid: 155
+  - uid: 176
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 2
-  - uid: 156
+  - uid: 177
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 2
-  - uid: 157
+  - uid: 178
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 2
-  - uid: 158
+  - uid: 179
     components:
     - type: Transform
       pos: -4.5,7.5
       parent: 2
-  - uid: 159
+  - uid: 180
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 2
-  - uid: 160
+  - uid: 181
     components:
     - type: Transform
       pos: -5.5,6.5
       parent: 2
-  - uid: 161
+  - uid: 182
     components:
     - type: Transform
       pos: -5.5,-0.5
       parent: 2
-  - uid: 162
+  - uid: 183
     components:
     - type: Transform
       pos: -5.5,5.5
       parent: 2
-  - uid: 163
+  - uid: 184
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 2
-  - uid: 164
+  - uid: 185
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 2
-  - uid: 165
+  - uid: 186
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 2
-  - uid: 166
+  - uid: 187
     components:
     - type: Transform
       pos: -5.5,2.5
       parent: 2
-  - uid: 167
+  - uid: 188
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 2
-  - uid: 169
+  - uid: 189
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 2
-  - uid: 170
+  - uid: 190
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 2
-  - uid: 171
+  - uid: 191
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 2
 - proto: WindoorCargoLocked
   entities:
-  - uid: 172
+  - uid: 192
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 2
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 173
+  - uid: 193
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 2
-  - uid: 174
+  - uid: 194
     components:
     - type: Transform
       pos: -3.5,7.5
       parent: 2
-  - uid: 177
+  - uid: 195
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-4.5
       parent: 2
-  - uid: 178
+  - uid: 196
     components:
     - type: Transform
       pos: -2.5,-4.5
       parent: 2
 - proto: Wrench
   entities:
-  - uid: 23
+  - uid: 197
     components:
     - type: Transform
       rot: 3.141592653589793 rad

--- a/Resources/Maps/Shuttles/cargo.yml
+++ b/Resources/Maps/Shuttles/cargo.yml
@@ -7,17 +7,30 @@ tilemap:
   89: FloorShuttleWhite
   93: FloorSteel
   108: FloorTechMaint
+  1: Lattice
   126: Plating
 entities:
 - proto: ""
   entities:
-  - uid: 173
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Map Entity
+    - type: Transform
+    - type: Map
+      mapPaused: True
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
+  - uid: 2
     components:
     - type: MetaData
       name: Cargo shuttle
     - type: Transform
       pos: 2.2710133,-2.4148211
-      parent: invalid
+      parent: 1
     - type: MapGrid
       chunks:
         -1,0:
@@ -30,7 +43,7 @@ entities:
           version: 6
         -1,-1:
           ind: -1,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAQAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAA
           version: 6
         0,-1:
           ind: 0,-1
@@ -106,40 +119,54 @@ entities:
       version: 2
       data:
         tiles:
-          -2,-1:
-            0: 52428
-          -1,-1:
-            0: 65535
-          -1,-2:
-            0: 61440
+          -2,0:
+            0: 51400
           -2,1:
-            0: 52428
+            0: 16520
+          -2,-1:
+            0: 32832
           -1,0:
             0: 65535
           -1,1:
-            0: 65535
-          -1,2:
-            0: 255
-          0,-1:
-            0: 4369
-          0,1:
-            0: 4369
-          0,2:
-            0: 1
-          0,0:
-            0: 4369
-          -2,0:
-            0: 52428
+            0: 30719
           -2,2:
-            0: 140
+            0: 128
+          -1,-1:
+            0: 63346
+          -1,2:
+            0: 130
+          0,0:
+            0: 4112
+          0,1:
+            0: 4096
           -2,-2:
             0: 32768
+          -1,-2:
+            1: 8192
+            0: 32768
+          0,-1:
+            0: 16
         uniqueMixes:
         - volume: 2500
           temperature: 293.15
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -159,1097 +186,1268 @@ entities:
     - type: GravityShake
       shakeTimes: 10
     - type: GasTileOverlay
-- proto: AirCanister
+- proto: AirAlarm
   entities:
-  - uid: 172
-    components:
-    - type: Transform
-      pos: -3.5,-1.5
-      parent: 173
-    - type: AtmosDevice
-      joinedGrid: 173
-- proto: AirlockGlassShuttle
-  entities:
-  - uid: 45
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,3.5
-      parent: 173
-  - uid: 50
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,1.5
-      parent: 173
-  - uid: 52
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,3.5
-      parent: 173
-  - uid: 53
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,1.5
-      parent: 173
-- proto: APCHyperCapacity
-  entities:
-  - uid: 79
-    components:
-    - type: Transform
-      pos: -0.5,6.5
-      parent: 173
-- proto: AtmosDeviceFanTiny
-  entities:
-  - uid: 168
-    components:
-    - type: Transform
-      pos: -5.5,1.5
-      parent: 173
-  - uid: 169
-    components:
-    - type: Transform
-      pos: -5.5,3.5
-      parent: 173
-  - uid: 170
-    components:
-    - type: Transform
-      pos: 0.5,3.5
-      parent: 173
-  - uid: 171
-    components:
-    - type: Transform
-      pos: 0.5,1.5
-      parent: 173
-- proto: BlastDoor
-  entities:
-  - uid: 1
-    components:
-    - type: Transform
-      pos: 0.5,4.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 57
-  - uid: 3
-    components:
-    - type: Transform
-      pos: -5.5,0.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 55
-  - uid: 54
-    components:
-    - type: Transform
-      pos: 0.5,0.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 58
-  - uid: 56
-    components:
-    - type: Transform
-      pos: -5.5,4.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 2
-- proto: CableApcExtension
-  entities:
-  - uid: 100
-    components:
-    - type: Transform
-      pos: -0.5,6.5
-      parent: 173
-  - uid: 101
-    components:
-    - type: Transform
-      pos: -1.5,6.5
-      parent: 173
-  - uid: 102
-    components:
-    - type: Transform
-      pos: -2.5,6.5
-      parent: 173
-  - uid: 103
-    components:
-    - type: Transform
-      pos: -2.5,5.5
-      parent: 173
-  - uid: 104
-    components:
-    - type: Transform
-      pos: -2.5,8.5
-      parent: 173
-  - uid: 105
-    components:
-    - type: Transform
-      pos: -3.5,8.5
-      parent: 173
-  - uid: 106
-    components:
-    - type: Transform
-      pos: -1.5,8.5
-      parent: 173
-  - uid: 107
-    components:
-    - type: Transform
-      pos: -3.5,6.5
-      parent: 173
-  - uid: 108
-    components:
-    - type: Transform
-      pos: -3.5,7.5
-      parent: 173
-  - uid: 109
-    components:
-    - type: Transform
-      pos: -2.5,4.5
-      parent: 173
-  - uid: 110
-    components:
-    - type: Transform
-      pos: -2.5,3.5
-      parent: 173
-  - uid: 111
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 173
-  - uid: 112
-    components:
-    - type: Transform
-      pos: -2.5,1.5
-      parent: 173
-  - uid: 113
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 173
-  - uid: 114
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 173
-  - uid: 115
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 173
-  - uid: 116
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 173
-  - uid: 117
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 173
-  - uid: 118
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 173
-  - uid: 119
-    components:
-    - type: Transform
-      pos: -2.5,-4.5
-      parent: 173
-  - uid: 120
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 173
-  - uid: 121
-    components:
-    - type: Transform
-      pos: -3.5,-4.5
-      parent: 173
-  - uid: 122
-    components:
-    - type: Transform
-      pos: -3.5,-3.5
-      parent: 173
-  - uid: 123
-    components:
-    - type: Transform
-      pos: -4.5,7.5
-      parent: 173
-  - uid: 124
-    components:
-    - type: Transform
-      pos: -0.5,7.5
-      parent: 173
-  - uid: 125
-    components:
-    - type: Transform
-      pos: -1.5,3.5
-      parent: 173
-  - uid: 126
-    components:
-    - type: Transform
-      pos: -0.5,3.5
-      parent: 173
-  - uid: 127
-    components:
-    - type: Transform
-      pos: -1.5,1.5
-      parent: 173
-  - uid: 128
-    components:
-    - type: Transform
-      pos: -0.5,1.5
-      parent: 173
-  - uid: 129
-    components:
-    - type: Transform
-      pos: -3.5,1.5
-      parent: 173
-  - uid: 130
-    components:
-    - type: Transform
-      pos: -4.5,1.5
-      parent: 173
-  - uid: 131
-    components:
-    - type: Transform
-      pos: -3.5,3.5
-      parent: 173
-  - uid: 132
-    components:
-    - type: Transform
-      pos: -4.5,3.5
-      parent: 173
-  - uid: 163
-    components:
-    - type: Transform
-      pos: -4.5,-3.5
-      parent: 173
-- proto: CableHV
-  entities:
-  - uid: 80
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 173
-  - uid: 81
-    components:
-    - type: Transform
-      pos: -2.5,-2.5
-      parent: 173
-  - uid: 86
-    components:
-    - type: Transform
-      pos: -2.5,-3.5
-      parent: 173
-- proto: CableMV
-  entities:
-  - uid: 87
-    components:
-    - type: Transform
-      pos: -1.5,-2.5
-      parent: 173
-  - uid: 88
-    components:
-    - type: Transform
-      pos: -1.5,-1.5
-      parent: 173
-  - uid: 89
-    components:
-    - type: Transform
-      pos: -2.5,-1.5
-      parent: 173
-  - uid: 90
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 173
-  - uid: 91
-    components:
-    - type: Transform
-      pos: -2.5,0.5
-      parent: 173
-  - uid: 92
-    components:
-    - type: Transform
-      pos: -2.5,1.5
-      parent: 173
-  - uid: 93
-    components:
-    - type: Transform
-      pos: -2.5,2.5
-      parent: 173
-  - uid: 94
-    components:
-    - type: Transform
-      pos: -2.5,3.5
-      parent: 173
-  - uid: 95
-    components:
-    - type: Transform
-      pos: -2.5,4.5
-      parent: 173
-  - uid: 96
-    components:
-    - type: Transform
-      pos: -2.5,5.5
-      parent: 173
-  - uid: 97
-    components:
-    - type: Transform
-      pos: -2.5,6.5
-      parent: 173
-  - uid: 98
-    components:
-    - type: Transform
-      pos: -1.5,6.5
-      parent: 173
   - uid: 99
     components:
     - type: Transform
+      pos: -4.5,6.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 193
+      - 192
+      - 191
+- proto: AirCanister
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 2
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 2
+  - uid: 5
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 2
+- proto: AirSensor
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 99
+- proto: APCHyperCapacity
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
       pos: -0.5,6.5
-      parent: 173
-- proto: CableTerminal
+      parent: 2
+- proto: AtmosDeviceFanTiny
   entities:
-  - uid: 82
+  - uid: 9
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,-3.5
-      parent: 173
-- proto: CargoPallet
+      pos: -5.5,1.5
+      parent: 2
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 2
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+- proto: BlastDoor
   entities:
-  - uid: 151
+  - uid: 15
     components:
     - type: Transform
-      pos: -4.5,5.5
-      parent: 173
-  - uid: 152
-    components:
-    - type: Transform
-      pos: -3.5,5.5
-      parent: 173
-  - uid: 153
-    components:
-    - type: Transform
-      pos: -1.5,5.5
-      parent: 173
-  - uid: 154
-    components:
-    - type: Transform
-      pos: -0.5,5.5
-      parent: 173
-  - uid: 155
-    components:
-    - type: Transform
-      pos: -0.5,2.5
-      parent: 173
-  - uid: 156
-    components:
-    - type: Transform
-      pos: -1.5,2.5
-      parent: 173
-  - uid: 157
-    components:
-    - type: Transform
-      pos: -1.5,-0.5
-      parent: 173
-  - uid: 158
-    components:
-    - type: Transform
-      pos: -0.5,-0.5
-      parent: 173
-  - uid: 159
-    components:
-    - type: Transform
-      pos: -3.5,2.5
-      parent: 173
-  - uid: 160
-    components:
-    - type: Transform
-      pos: -4.5,2.5
-      parent: 173
-  - uid: 161
-    components:
-    - type: Transform
-      pos: -4.5,-0.5
-      parent: 173
-  - uid: 162
-    components:
-    - type: Transform
-      pos: -3.5,-0.5
-      parent: 173
-- proto: ChairPilotSeat
-  entities:
-  - uid: 141
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,7.5
-      parent: 173
-- proto: ComputerShuttle
-  entities:
-  - uid: 78
-    components:
-    - type: Transform
-      pos: -2.5,8.5
-      parent: 173
-- proto: ConveyorBelt
-  entities:
-  - uid: 38
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,4.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 36
-  - uid: 39
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,4.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 36
-  - uid: 40
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -1.5,4.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 36
-  - uid: 41
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
       pos: -5.5,0.5
-      parent: 173
+      parent: 2
     - type: DeviceLinkSink
       links:
-      - 34
-  - uid: 42
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,0.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 34
-  - uid: 43
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,0.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 34
-  - uid: 46
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,0.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 35
-  - uid: 47
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,4.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 37
-  - uid: 48
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,4.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 37
-  - uid: 49
+      - 122
+  - uid: 123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,4.5
-      parent: 173
+      parent: 2
     - type: DeviceLinkSink
       links:
-      - 37
-  - uid: 51
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,0.5
-      parent: 173
-    - type: DeviceLinkSink
-      links:
-      - 35
-  - uid: 167
+      - 14
+  - uid: 124
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
-      parent: 173
+      parent: 2
     - type: DeviceLinkSink
       links:
-      - 35
-- proto: GasPipeBend
-  entities:
-  - uid: 134
+      - 16
+  - uid: 176
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,-1.5
-      parent: 173
-- proto: GasPipeStraight
+      pos: 0.5,4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 121
+- proto: CableApcExtension
   entities:
-  - uid: 136
+  - uid: 13
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,0.5
-      parent: 173
-  - uid: 137
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,1.5
-      parent: 173
-  - uid: 140
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,-0.5
-      parent: 173
-- proto: GasPort
-  entities:
-  - uid: 135
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
       pos: -3.5,-1.5
-      parent: 173
-    - type: AtmosDevice
-      joinedGrid: 173
-- proto: GasVentPump
-  entities:
-  - uid: 138
+      parent: 2
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 2
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+  - uid: 22
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 2
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 2
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 2
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 28
     components:
     - type: Transform
       pos: -2.5,2.5
-      parent: 173
-    - type: AtmosDevice
-      joinedGrid: 173
-- proto: GeneratorBasic15kW
-  entities:
-  - uid: 83
+      parent: 2
+  - uid: 29
     components:
     - type: Transform
-      pos: -2.5,-3.5
-      parent: 173
-- proto: GravityGeneratorMini
-  entities:
-  - uid: 146
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 34
     components:
     - type: Transform
       pos: -1.5,-1.5
-      parent: 173
-- proto: Grille
-  entities:
-  - uid: 73
+      parent: 2
+  - uid: 35
     components:
     - type: Transform
-      pos: -3.5,8.5
-      parent: 173
-  - uid: 74
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 36
     components:
     - type: Transform
-      pos: -3.5,9.5
-      parent: 173
-  - uid: 75
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 37
     components:
     - type: Transform
-      pos: -2.5,9.5
-      parent: 173
-  - uid: 76
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 38
     components:
     - type: Transform
-      pos: -1.5,9.5
-      parent: 173
-  - uid: 77
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 39
     components:
     - type: Transform
-      pos: -1.5,8.5
-      parent: 173
-- proto: Gyroscope
-  entities:
-  - uid: 133
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 40
     components:
     - type: Transform
-      pos: -3.5,-2.5
-      parent: 173
-- proto: PlasticFlapsAirtightClear
-  entities:
+      pos: -4.5,7.5
+      parent: 2
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 2
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 43
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
   - uid: 44
     components:
     - type: Transform
-      pos: 0.5,0.5
-      parent: 173
-  - uid: 164
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 45
     components:
     - type: Transform
-      pos: -5.5,0.5
-      parent: 173
-  - uid: 165
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 46
     components:
     - type: Transform
-      pos: -5.5,4.5
-      parent: 173
-  - uid: 166
+      pos: -3.5,1.5
+      parent: 2
+  - uid: 47
     components:
     - type: Transform
-      pos: 0.5,4.5
-      parent: 173
-- proto: Poweredlight
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 48
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 2
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 2
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 2
+  - uid: 143
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 2
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+- proto: CableHV
   entities:
-  - uid: 147
+  - uid: 51
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,2.5
-      parent: 173
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 148
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 52
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -4.5,2.5
-      parent: 173
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 149
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 53
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,7.5
-      parent: 173
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 150
+      pos: -2.5,-3.5
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 54
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,7.5
-      parent: 173
-    - type: ApcPowerReceiver
-      powerLoad: 0
-- proto: ShuttleWindow
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 2
+  - uid: 61
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 63
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 2
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 2
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+- proto: CableTerminal
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 2
+- proto: CargoPallet
   entities:
   - uid: 68
     components:
     - type: Transform
-      pos: -1.5,8.5
-      parent: 173
+      pos: -4.5,5.5
+      parent: 2
   - uid: 69
     components:
     - type: Transform
-      pos: -1.5,9.5
-      parent: 173
+      pos: -3.5,5.5
+      parent: 2
   - uid: 70
     components:
     - type: Transform
-      pos: -2.5,9.5
-      parent: 173
+      pos: -1.5,5.5
+      parent: 2
   - uid: 71
     components:
     - type: Transform
-      pos: -3.5,9.5
-      parent: 173
+      pos: -0.5,5.5
+      parent: 2
   - uid: 72
     components:
     - type: Transform
-      pos: -3.5,8.5
-      parent: 173
-- proto: SignalButton
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 2
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 2
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 2
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+- proto: ChairPilotSeat
   entities:
-  - uid: 2
+  - uid: 80
     components:
     - type: Transform
-      pos: -5.5,5.5
-      parent: 173
-    - type: DeviceLinkSource
-      linkedPorts:
-        56:
-        - Pressed: Toggle
-  - uid: 55
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 2
+  - uid: 195
     components:
     - type: Transform
-      pos: -5.5,-0.5
-      parent: 173
-    - type: DeviceLinkSource
-      linkedPorts:
-        3:
-        - Pressed: Toggle
-  - uid: 57
+      pos: -1.5,6.5
+      parent: 2
+  - uid: 196
     components:
     - type: Transform
-      pos: 0.5,5.5
-      parent: 173
-    - type: DeviceLinkSource
-      linkedPorts:
-        1:
-        - Pressed: Toggle
-  - uid: 58
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 173
-    - type: DeviceLinkSource
-      linkedPorts:
-        54:
-        - Pressed: Toggle
-- proto: SMESBasic
+      pos: -3.5,6.5
+      parent: 2
+- proto: ComputerShuttle
   entities:
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 2
+- proto: ConveyorBelt
+  entities:
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 139
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 139
   - uid: 84
     components:
     - type: Transform
-      pos: -2.5,-2.5
-      parent: 173
-- proto: SubstationBasic
-  entities:
+      rot: 1.5707963267948966 rad
+      pos: -1.5,4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 139
   - uid: 85
     components:
     - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 137
+  - uid: 86
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 137
+  - uid: 87
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 137
+  - uid: 88
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 138
+  - uid: 89
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 140
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 140
+  - uid: 91
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 140
+  - uid: 92
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 138
+  - uid: 93
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 138
+- proto: Crowbar
+  entities:
+  - uid: 194
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.641858,-1.5760336
+      parent: 2
+- proto: GasOutletInjector
+  entities:
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 2
+- proto: GasPipeBend
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,-2.5
-      parent: 173
+      parent: 2
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 2
+- proto: GasPipeStraight
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,1.5
+      parent: 2
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 2
+  - uid: 188
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 189
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 2
+- proto: GasPort
+  entities:
+  - uid: 98
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 2
+- proto: GasPressurePump
+  entities:
+  - uid: 97
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-0.5
+      parent: 2
+- proto: GasVentPump
+  entities:
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 99
+- proto: GasVentScrubber
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,6.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 99
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+- proto: Grille
+  entities:
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 2
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 2
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 2
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 2
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 2
+- proto: Gyroscope
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 2
+- proto: PlasticFlapsAirtightClear
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 110
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 2
+  - uid: 111
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 2
+- proto: Poweredlight
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+  - uid: 115
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 2
+    - type: ApcPowerReceiver
+      powerLoad: 0
+- proto: Rack
+  entities:
+  - uid: 197
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+- proto: ShuttleWindow
+  entities:
+  - uid: 116
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 2
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 2
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 2
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 2
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 2
+- proto: SignalButton
+  entities:
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        123:
+        - Pressed: Toggle
+  - uid: 16
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        124:
+        - Pressed: Toggle
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        176:
+        - Pressed: Toggle
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        15:
+        - Pressed: Toggle
+- proto: SMESBasic
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+- proto: SubstationBasic
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
 - proto: TableReinforced
   entities:
-  - uid: 143
+  - uid: 127
     components:
     - type: Transform
       pos: -3.5,7.5
-      parent: 173
-  - uid: 144
+      parent: 2
+  - uid: 128
     components:
     - type: Transform
       pos: -1.5,7.5
-      parent: 173
+      parent: 2
 - proto: Thruster
   entities:
-  - uid: 12
+  - uid: 129
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-2.5
-      parent: 173
-  - uid: 13
+      parent: 2
+  - uid: 130
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,7.5
-      parent: 173
-  - uid: 14
+      parent: 2
+  - uid: 131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,7.5
-      parent: 173
-  - uid: 15
+      parent: 2
+  - uid: 132
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
-      parent: 173
-  - uid: 59
+      parent: 2
+  - uid: 133
     components:
     - type: Transform
       pos: -4.5,9.5
-      parent: 173
-  - uid: 60
+      parent: 2
+  - uid: 134
     components:
     - type: Transform
       pos: -0.5,9.5
-      parent: 173
-  - uid: 61
+      parent: 2
+  - uid: 135
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-4.5
-      parent: 173
-  - uid: 62
+      parent: 2
+  - uid: 136
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-4.5
-      parent: 173
+      parent: 2
 - proto: TwoWayLever
   entities:
-  - uid: 34
+  - uid: 137
     components:
     - type: Transform
       pos: -3.5,1.5
-      parent: 173
+      parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        43:
+        87:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        42:
+        86:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        41:
+        85:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-  - uid: 35
+  - uid: 138
     components:
     - type: Transform
       pos: -1.5,1.5
-      parent: 173
+      parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        51:
+        92:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        46:
+        88:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        167:
+        93:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-  - uid: 36
+  - uid: 139
     components:
     - type: Transform
       pos: -1.5,3.5
-      parent: 173
+      parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        38:
+        82:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        39:
+        83:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        40:
+        84:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-  - uid: 37
+  - uid: 140
     components:
     - type: Transform
       pos: -3.5,3.5
-      parent: 173
+      parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        49:
+        91:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        48:
+        90:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
-        47:
+        89:
         - Left: Forward
         - Right: Reverse
         - Middle: Off
 - proto: WallShuttle
   entities:
-  - uid: 4
-    components:
-    - type: Transform
-      pos: -5.5,8.5
-      parent: 173
-  - uid: 5
-    components:
-    - type: Transform
-      pos: -4.5,8.5
-      parent: 173
-  - uid: 6
-    components:
-    - type: Transform
-      pos: -0.5,8.5
-      parent: 173
-  - uid: 7
-    components:
-    - type: Transform
-      pos: 0.5,8.5
-      parent: 173
-  - uid: 8
-    components:
-    - type: Transform
-      pos: -0.5,-3.5
-      parent: 173
-  - uid: 9
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 173
-  - uid: 10
-    components:
-    - type: Transform
-      pos: -4.5,-3.5
-      parent: 173
-  - uid: 11
-    components:
-    - type: Transform
-      pos: -5.5,-3.5
-      parent: 173
-  - uid: 16
-    components:
-    - type: Transform
-      pos: -0.5,-1.5
-      parent: 173
-  - uid: 17
-    components:
-    - type: Transform
-      pos: -0.5,-2.5
-      parent: 173
-  - uid: 18
-    components:
-    - type: Transform
-      pos: -4.5,-1.5
-      parent: 173
-  - uid: 19
-    components:
-    - type: Transform
-      pos: 0.5,-1.5
-      parent: 173
-  - uid: 20
-    components:
-    - type: Transform
-      pos: -4.5,-2.5
-      parent: 173
   - uid: 21
     components:
     - type: Transform
-      pos: -5.5,-1.5
-      parent: 173
-  - uid: 22
+      pos: -0.5,8.5
+      parent: 2
+  - uid: 141
     components:
     - type: Transform
-      pos: -0.5,7.5
-      parent: 173
-  - uid: 23
-    components:
-    - type: Transform
-      pos: -0.5,6.5
-      parent: 173
-  - uid: 24
-    components:
-    - type: Transform
-      pos: 0.5,6.5
-      parent: 173
-  - uid: 25
-    components:
-    - type: Transform
-      pos: -4.5,7.5
-      parent: 173
-  - uid: 26
-    components:
-    - type: Transform
-      pos: -4.5,6.5
-      parent: 173
-  - uid: 27
-    components:
-    - type: Transform
-      pos: -5.5,6.5
-      parent: 173
-  - uid: 28
-    components:
-    - type: Transform
-      pos: -5.5,-0.5
-      parent: 173
-  - uid: 29
-    components:
-    - type: Transform
-      pos: -5.5,5.5
-      parent: 173
-  - uid: 30
-    components:
-    - type: Transform
-      pos: 0.5,5.5
-      parent: 173
-  - uid: 31
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
-      parent: 173
-  - uid: 32
-    components:
-    - type: Transform
-      pos: 0.5,2.5
-      parent: 173
-  - uid: 33
-    components:
-    - type: Transform
-      pos: -5.5,2.5
-      parent: 173
-  - uid: 63
-    components:
-    - type: Transform
-      pos: -3.5,-4.5
-      parent: 173
-  - uid: 64
-    components:
-    - type: Transform
-      pos: -2.5,-4.5
-      parent: 173
-  - uid: 65
-    components:
-    - type: Transform
-      pos: -1.5,-4.5
-      parent: 173
-  - uid: 66
-    components:
-    - type: Transform
-      pos: -3.5,-3.5
-      parent: 173
-  - uid: 67
-    components:
-    - type: Transform
-      pos: -1.5,-3.5
-      parent: 173
-- proto: WindoorCargoLocked
-  entities:
-  - uid: 139
-    components:
-    - type: Transform
-      pos: -2.5,7.5
-      parent: 173
-- proto: WindowReinforcedDirectional
-  entities:
+      pos: -5.5,8.5
+      parent: 2
   - uid: 142
     components:
     - type: Transform
-      pos: -1.5,7.5
-      parent: 173
+      pos: -4.5,8.5
+      parent: 2
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 2
   - uid: 145
     components:
     - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 147
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 2
+  - uid: 148
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+  - uid: 149
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 2
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 2
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 2
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 2
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 2
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -5.5,6.5
+      parent: 2
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 2
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 2
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 2
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+- proto: WindoorCargoLocked
+  entities:
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 2
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 2
+  - uid: 174
+    components:
+    - type: Transform
       pos: -3.5,7.5
-      parent: 173
+      parent: 2
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+- proto: Wrench
+  entities:
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.529358,-1.5535336
+      parent: 2
 ...


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but
the order/format should be kept the same
Remove these comments before submitting
-->

Howdy y'all, I noticed the cargo shuttle blast doors only open, not
close. I'm going to fix that. I realigned them correctly ~~with the
airtight plastic flap and~~ with Tiny fans fixed the problem with the
air system. There was only air coming in, but no waste air out. I added
two chairs and some tools.



https://github.com/user-attachments/assets/4615ebb1-12aa-4c96-a2c4-d52d898bbee3


---

<!--
This is default collapsed, readers click to expand it and see all your
media
The PR media section can get very large at times, so this is a good way
to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)
![Screenshot 2025-01-06
012814](https://github.com/user-attachments/assets/c0af2571-9469-43c6-98f5-14b2d3d9e693)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears
in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Mike32oz
- add: Added an air alarm and sensor additional tools.
- tweak: Tweaked cargo shuttle blast doors
- fix: Fixed cargo shuttle Air/Waste distro
- remove: Removed tippy the clown (my nemesis) airtight plastic flap