### PR TITLE
Salvage Argenti Fix

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -41,6 +41,5 @@
   components:
   - type: RevolverAmmoProvider
     capacity: 8
-    proto: CartridgeRifle
     chambers: [ False, False, False, False, False, False, False, False ]
     ammoSlots: [ null, null, null, null, null, null, null, null ]


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Removes the loaded ammo in the Argenti you can buy from the Salvage Vend, as originall

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Unloaded the ammo from the Argentis in the Salvage Vend.