### PR TITLE
Weight Traits Tweaks

### DIFF
--- a/Resources/Prototypes/Floof/Traits/physical.yml
+++ b/Resources/Prototypes/Floof/Traits/physical.yml
@@ -95,6 +95,10 @@
     species:
     - Felinid # They don't need to be lighter
     - Rodentia
+  - !type:CharacterTraitRequirement
+    inverted: true
+    traits:
+    - Heavyweight
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/_DEN/Traits/physical.yml
+++ b/Resources/Prototypes/_DEN/Traits/physical.yml
@@ -12,6 +12,10 @@
     inverted: true
     species:
     - Oni
+  - !type:CharacterTraitRequirement
+    inverted: true
+    traits:
+    - Lightweight
   functions:
     - !type:TraitAddComponent
       components:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Makes the Heavyweight and Lightweight Trait mutually exclusive from each other.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked Weight Traits to be mutually exclusive.