### PR TITLE
Small Fixes and Rat King AI Tweak

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -10,16 +10,17 @@
     baseSprintSpeed : 5.00
   - type: InputMover
   - type: MobMover
-  - type: HTN
-    rootTask:
-      task: SimpleHostileCompound
+#  - type: HTN
+#    rootTask:
+#      task: SimpleHostileCompound
   - type: Reactive
     groups:
       Flammable: [Touch]
       Extinguish: [Touch]
   - type: NpcFactionMember
     factions:
-    - SimpleHostile
+    - Passive
+#    - SimpleHostile
   - type: Sprite
     drawdepth: SmallMobs
     sprite: Mobs/Animals/regalrat.rsi

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -379,6 +379,12 @@
   - type: Pda
     id: QuartermasterIDCard
     state: pda-qm
+    penSlot:
+      startingItem: PenLo
+      priority: -1
+      whitelist:
+        tags:
+        - Write
   - type: PdaBorderColor
     borderColor: "#e39751"
     accentVColor: "#a23e3e"
@@ -431,12 +437,6 @@
   - type: Pda
     id: CargoIDCard
     state: pda-cargo
-    penSlot:
-      startingItem: PenLo
-      priority: -1
-      whitelist:
-        tags:
-        - Write
   - type: PdaBorderColor
     borderColor: "#e39751"
   - type: Icon

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -371,6 +371,7 @@
       inverted: true
       traits:
         - Claws
+        - StrikingCalluses
   functions:
     - !type:TraitModifyUnarmed
       soundHit:
@@ -398,6 +399,7 @@
       inverted: true
       traits:
         - Talons
+        - StrikingCalluses
   functions:
     - !type:TraitModifyUnarmed
       soundHit:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Claws and Talons are unusable when Striking Calluses are taken as a trait, Fixed Fancy Logistics Officer pen to appear in the proper PDAs, Changed Rat King AI to Passive to prevent situations where player controlled Rat Kings become completely hostile with the usual insane AI targeting upon disconnection or use of the ghost command.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked Rat King AI to be Passive to prevent unwanted hostile AI on player disconnect or ghost.
- fix: Fixed Talons and Claws to be exclusive from Striking Calluses.
