### PR TITLE
New Subtle OOC Channel And Change Subtle Color (with Images)

### DIFF
--- a/Content.Client/Chat/Managers/ChatManager.cs
+++ b/Content.Client/Chat/Managers/ChatManager.cs
@@ -61,6 +61,10 @@ namespace Content.Client.Chat.Managers
                     _consoleHost.ExecuteCommand($"subtle \"{CommandParsing.Escape(str)}\"");
                     break;
 
+                case ChatSelectChannel.SubtleOOC: // Den
+                    _consoleHost.ExecuteCommand($"subtleooc \"{CommandParsing.Escape(str)}\"");
+                    break;
+
                 case ChatSelectChannel.Dead:
                     if (_systems.GetEntitySystemOrNull<GhostSystem>() is {IsGhost: true})
                         goto case ChatSelectChannel.Local;

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.cs
@@ -83,8 +83,8 @@ public sealed class ChatUIController : UIController
         {SharedChatSystem.LOOCPrefix, ChatSelectChannel.LOOC},
         {SharedChatSystem.OOCPrefix, ChatSelectChannel.OOC},
         {SharedChatSystem.EmotesPrefix, ChatSelectChannel.Emotes},
-        {SharedChatSystem.EmotesAltPrefix, ChatSelectChannel.Emotes},
         {SharedChatSystem.SubtlePrefix, ChatSelectChannel.Subtle}, // Floofstation
+        {SharedChatSystem.SubtleOOCPrefix, ChatSelectChannel.SubtleOOC}, // Den
         {SharedChatSystem.AdminPrefix, ChatSelectChannel.Admin},
         {SharedChatSystem.RadioCommonPrefix, ChatSelectChannel.Radio},
         {SharedChatSystem.DeadPrefix, ChatSelectChannel.Dead},
@@ -100,6 +100,7 @@ public sealed class ChatUIController : UIController
         {ChatSelectChannel.OOC, SharedChatSystem.OOCPrefix},
         {ChatSelectChannel.Emotes, SharedChatSystem.EmotesPrefix},
         {ChatSelectChannel.Subtle, SharedChatSystem.SubtlePrefix}, // Floofstation
+        {ChatSelectChannel.SubtleOOC, SharedChatSystem.SubtleOOCPrefix}, // Den
         {ChatSelectChannel.Admin, SharedChatSystem.AdminPrefix},
         {ChatSelectChannel.Radio, SharedChatSystem.RadioCommonPrefix},
         {ChatSelectChannel.Dead, SharedChatSystem.DeadPrefix},
@@ -544,12 +545,14 @@ public sealed class ChatUIController : UIController
             if (_ghost is not {IsGhost: true})
             {
                 FilterableChannels |= ChatChannel.Subtle;
+                FilterableChannels |= ChatChannel.SubtleOOC;
 
                 CanSendChannels |= ChatSelectChannel.Local;
                 CanSendChannels |= ChatSelectChannel.Whisper;
                 CanSendChannels |= ChatSelectChannel.Radio;
                 CanSendChannels |= ChatSelectChannel.Emotes;
                 CanSendChannels |= ChatSelectChannel.Subtle; // Floofstation
+                CanSendChannels |= ChatSelectChannel.SubtleOOC;
             }
         }
 
@@ -563,6 +566,7 @@ public sealed class ChatUIController : UIController
         if (_admin.HasFlag(AdminFlags.Pii) && _ghost is { IsGhost: true })
         {
             FilterableChannels |= ChatChannel.Subtle;
+            FilterableChannels |= ChatChannel.SubtleOOC;
         }
 
         // only admins can see / filter asay

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -15,6 +15,7 @@ public sealed partial class ChannelFilterPopup : Popup
         ChatChannel.Local,
         ChatChannel.Whisper,
         ChatChannel.Subtle,
+        ChatChannel.SubtleOOC,
         ChatChannel.Emotes,
         ChatChannel.Radio,
         ChatChannel.Telepathic, //Nyano - Summary: adds telepathic chat to where it belongs in order in the chat.

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorPopup.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelSelectorPopup.cs
@@ -13,6 +13,7 @@ public sealed class ChannelSelectorPopup : Popup
         ChatSelectChannel.Whisper,
         ChatSelectChannel.Emotes,
         ChatSelectChannel.Subtle, // Floofstation
+        ChatSelectChannel.SubtleOOC,
         ChatSelectChannel.Radio,
         ChatSelectChannel.Telepathic, //Nyano - Summary: determines the order in which telepathic shows.
         ChatSelectChannel.LOOC,

--- a/Content.Server/Chat/Commands/SubtleCommand.cs
+++ b/Content.Server/Chat/Commands/SubtleCommand.cs
@@ -13,6 +13,8 @@ namespace Content.Server.Chat.Commands
         public string Description => "Perform an subtle action.";
         public string Help => "subtle <text>";
 
+        private const string SubtleColor = "#d3d3ff";
+
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (shell.Player is not { } player)
@@ -38,7 +40,7 @@ namespace Content.Server.Chat.Commands
                 return;
 
             IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>()
-                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.Subtle, ChatTransmitRange.NoGhosts, false, shell, player);
+                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.Subtle, ChatTransmitRange.NoGhosts, false, shell, player, color: SubtleColor);
         }
     }
 }

--- a/Content.Server/Chat/Commands/SubtleOOCCommand.cs
+++ b/Content.Server/Chat/Commands/SubtleOOCCommand.cs
@@ -38,7 +38,7 @@ namespace Content.Server.Chat.Commands
                 return;
 
             IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>()
-                .TrySendInGameICMessage(playerEntity, "ooc: " + message, InGameICChatType.Subtle, ChatTransmitRange.NoGhosts, false, shell, player);
+                .TrySendInGameICMessage(playerEntity, "ooc: " + message, InGameICChatType.Subtle, ChatTransmitRange.NoGhosts, false, shell, player, color: "#7da0fa");
         }
     }
 }

--- a/Content.Server/Chat/Commands/SubtleOOCCommand.cs
+++ b/Content.Server/Chat/Commands/SubtleOOCCommand.cs
@@ -13,6 +13,8 @@ namespace Content.Server.Chat.Commands
         public string Description => "Perform an subtle action.";
         public string Help => "subtleooc <text>";
 
+        private const string SubtleOOCColor = "#ff7782";
+
         public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
             if (shell.Player is not { } player)
@@ -38,7 +40,7 @@ namespace Content.Server.Chat.Commands
                 return;
 
             IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>()
-                .TrySendInGameICMessage(playerEntity, "ooc: " + message, InGameICChatType.Subtle, ChatTransmitRange.NoGhosts, false, shell, player, color: "#7da0fa");
+                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.SubtleOOC, ChatTransmitRange.NoGhosts, false, shell, player, color: SubtleOOCColor);
         }
     }
 }

--- a/Content.Server/Chat/Commands/SubtleOOCCommand.cs
+++ b/Content.Server/Chat/Commands/SubtleOOCCommand.cs
@@ -1,0 +1,44 @@
+using Content.Server.Chat.Systems;
+using Content.Shared.Administration;
+using Content.Shared.Chat;
+using Robust.Shared.Console;
+using Robust.Shared.Enums;
+
+namespace Content.Server.Chat.Commands
+{
+    [AnyCommand]
+    internal sealed class SubtleOOCCommand : IConsoleCommand
+    {
+        public string Command => "subtleooc";
+        public string Description => "Perform an subtle action.";
+        public string Help => "subtleooc <text>";
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            if (shell.Player is not { } player)
+            {
+                shell.WriteError("This command cannot be run from the server.");
+                return;
+            }
+
+            if (player.Status != SessionStatus.InGame)
+                return;
+
+            if (player.AttachedEntity is not {} playerEntity)
+            {
+                shell.WriteError("You don't have an entity!");
+                return;
+            }
+
+            if (args.Length < 1)
+                return;
+
+            var message = string.Join(" ", args).Trim();
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<ChatSystem>()
+                .TrySendInGameICMessage(playerEntity, "ooc: " + message, InGameICChatType.Subtle, ChatTransmitRange.NoGhosts, false, shell, player);
+        }
+    }
+}

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -79,6 +79,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     public const string DefaultAnnouncementSound = "/Audio/Announcements/announce.ogg";
     public const float DefaultObfuscationFactor = 0.2f; // Percentage of symbols in a whispered message that can be seen even by "far" listeners
     public readonly Color DefaultSpeakColor = Color.White;
+    public readonly string DefaultSubtleColor = "#856efa";
 
     private bool _loocEnabled = true;
     private bool _deadLoocEnabled;
@@ -277,6 +278,9 @@ public sealed partial class ChatSystem : SharedChatSystem
                 break;
             case InGameICChatType.Subtle:
                 SendEntitySubtle(source, message, range, nameOverride, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker);
+                break;
+            case InGameICChatType.SubtleOOC:
+                SendEntitySubtle(source, $"ooc: {message}", range, nameOverride, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker);
                 break;
             //Nyano - Summary: case adds the telepathic chat sending ability.
             case InGameICChatType.Telepathic:
@@ -627,6 +631,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         var wrappedMessage = Loc.GetString("chat-manager-entity-subtle-wrap-message",
             ("entityName", name),
             ("entity", ent),
+            ("color", DefaultSubtleColor),
             ("message", FormattedMessage.RemoveMarkup(action)));
 
         foreach (var (session, data) in GetRecipients(source, WhisperClearRange))

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -186,7 +186,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         string? nameOverride = null,
         bool checkRadioPrefix = true,
         bool ignoreActionBlocker = false,
-        LanguagePrototype? languageOverride = null
+        LanguagePrototype? languageOverride = null,
+        string? color = null
         )
     {
         if (HasComp<GhostComponent>(source))
@@ -280,7 +281,7 @@ public sealed partial class ChatSystem : SharedChatSystem
                 SendEntitySubtle(source, message, range, nameOverride, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker);
                 break;
             case InGameICChatType.SubtleOOC:
-                SendEntitySubtle(source, $"ooc: {message}", range, nameOverride, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker);
+                SendEntitySubtle(source, $"ooc: {message}", range, nameOverride, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker, color: color);
                 break;
             //Nyano - Summary: case adds the telepathic chat sending ability.
             case InGameICChatType.Telepathic:
@@ -617,9 +618,13 @@ public sealed partial class ChatSystem : SharedChatSystem
         string? nameOverride,
         bool hideLog = false,
         bool ignoreActionBlocker = false,
-        NetUserId? author = null
+        NetUserId? author = null,
+        string? color = null
         )
     {
+        if (color == null)
+            color = DefaultSubtleColor;
+
         if (!_actionBlocker.CanEmote(source) && !ignoreActionBlocker)
             return;
 
@@ -631,7 +636,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         var wrappedMessage = Loc.GetString("chat-manager-entity-subtle-wrap-message",
             ("entityName", name),
             ("entity", ent),
-            ("color", DefaultSubtleColor),
+            ("color", color),
             ("message", FormattedMessage.RemoveMarkup(action)));
 
         foreach (var (session, data) in GetRecipients(source, WhisperClearRange))

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -79,7 +79,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     public const string DefaultAnnouncementSound = "/Audio/Announcements/announce.ogg";
     public const float DefaultObfuscationFactor = 0.2f; // Percentage of symbols in a whispered message that can be seen even by "far" listeners
     public readonly Color DefaultSpeakColor = Color.White;
-    public readonly string DefaultSubtleColor = "#856efa";
+    public readonly string DefaultSubtleColor = "#7dc2fa";
 
     private bool _loocEnabled = true;
     private bool _deadLoocEnabled;

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -79,7 +79,6 @@ public sealed partial class ChatSystem : SharedChatSystem
     public const string DefaultAnnouncementSound = "/Audio/Announcements/announce.ogg";
     public const float DefaultObfuscationFactor = 0.2f; // Percentage of symbols in a whispered message that can be seen even by "far" listeners
     public readonly Color DefaultSpeakColor = Color.White;
-    public readonly string DefaultSubtleColor = "#7dc2fa";
 
     private bool _loocEnabled = true;
     private bool _deadLoocEnabled;
@@ -278,7 +277,7 @@ public sealed partial class ChatSystem : SharedChatSystem
                 SendEntityEmote(source, message, range, nameOverride, language, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker);
                 break;
             case InGameICChatType.Subtle:
-                SendEntitySubtle(source, message, range, nameOverride, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker);
+                SendEntitySubtle(source, message, range, nameOverride, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker, color: color);
                 break;
             case InGameICChatType.SubtleOOC:
                 SendEntitySubtle(source, $"ooc: {message}", range, nameOverride, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker, color: color);
@@ -622,9 +621,6 @@ public sealed partial class ChatSystem : SharedChatSystem
         string? color = null
         )
     {
-        if (color == null)
-            color = DefaultSubtleColor;
-
         if (!_actionBlocker.CanEmote(source) && !ignoreActionBlocker)
             return;
 
@@ -636,8 +632,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         var wrappedMessage = Loc.GetString("chat-manager-entity-subtle-wrap-message",
             ("entityName", name),
             ("entity", ent),
-            ("color", color),
-            ("message", FormattedMessage.RemoveMarkup(action)));
+            ("color", color ?? DefaultSpeakColor.ToHex()),
+            ("message", FormattedMessage.RemoveMarkupPermissive(action)));
 
         foreach (var (session, data) in GetRecipients(source, WhisperClearRange))
         {

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -232,7 +232,7 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         var language = languageOverride ?? _language.GetLanguage(source);
 
-        bool shouldCapitalize = (desiredType != InGameICChatType.Emote && desiredType != InGameICChatType.Subtle);
+        bool shouldCapitalize = (desiredType != InGameICChatType.Emote && desiredType != InGameICChatType.Subtle && desiredType != InGameICChatType.SubtleOOC);
         bool shouldPunctuate = _configurationManager.GetCVar(CCVars.ChatPunctuation);
         // Capitalizing the word I only happens in English, so we check language here
         bool shouldCapitalizeTheWordI = (!CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Parent.Name == "en")

--- a/Content.Shared/Chat/ChatChannel.cs
+++ b/Content.Shared/Chat/ChatChannel.cs
@@ -96,6 +96,11 @@ namespace Content.Shared.Chat
         Subtle = 1 << 16,
 
         /// <summary>
+        ///     Subtle - Floofstation
+        /// </summary>
+        SubtleOOC = 1 << 17,
+
+        /// <summary>
         ///     Channels considered to be IC.
         /// </summary>
         IC = Local | Whisper | Radio | Dead | Emotes | Subtle | Damage | Visual | Telepathic | Notifications, //Nyano - Summary: Adds telepathic as an 'IC' labelled chat..

--- a/Content.Shared/Chat/ChatSelectChannel.cs
+++ b/Content.Shared/Chat/ChatSelectChannel.cs
@@ -47,6 +47,11 @@
         Subtle = ChatChannel.Subtle,
 
         /// <summary>
+        ///     Subtle - Floofstation
+        /// </summary>
+        SubtleOOC = ChatChannel.SubtleOOC,
+
+        /// <summary>
         ///     Deadchat
         /// </summary>
         Dead = ChatChannel.Dead,

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -13,7 +13,6 @@ public abstract class SharedChatSystem : EntitySystem
 {
     public const char RadioCommonPrefix = ';';
     public const char RadioChannelPrefix = ':';
-    public const char RadioChannelAltPrefix = '.';
     public const char LocalPrefix = '>';
     public const char ConsolePrefix = '/';
     public const char DeadPrefix = '\\';
@@ -22,6 +21,7 @@ public abstract class SharedChatSystem : EntitySystem
     public const char EmotesPrefix = '@';
     public const char EmotesAltPrefix = '*';
     public const char SubtlePrefix = '-';
+    public const char SubtleOOCPrefix = '.';
     public const char AdminPrefix = ']';
     public const char WhisperPrefix = ',';
     public const char TelepathicPrefix = '='; //Nyano - Summary: Adds the telepathic channel's prefix.
@@ -117,7 +117,7 @@ public abstract class SharedChatSystem : EntitySystem
             return true;
         }
 
-        if (!(input.StartsWith(RadioChannelPrefix) || input.StartsWith(RadioChannelAltPrefix)))
+        if (!input.StartsWith(RadioChannelPrefix))
             return false;
 
         if (input.Length < 2 || char.IsWhiteSpace(input[1]))
@@ -275,6 +275,7 @@ public enum InGameICChatType : byte
     Speak,
     Emote,
     Subtle, // Floofstation
+    SubtleOOC, // Den
     Whisper,
     Telepathic
 }

--- a/Resources/Locale/en-US/_DEN/chat/ui/chat-box.ftl
+++ b/Resources/Locale/en-US/_DEN/chat/ui/chat-box.ftl
@@ -1,0 +1,2 @@
+hud-chatbox-channel-SubtleOOC = Subtle OOC
+hud-chatbox-select-channel-SubtleOOC = Subtle OOC

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -38,9 +38,9 @@ chat-manager-entity-me-wrap-message = [italic]{ PROPER($entity) ->
      [true] {$entityName} {$message}[/italic]
     }
 
-chat-manager-entity-subtle-wrap-message = [italic]{ PROPER($entity) ->
-    *[false] the {$entityName} subtly {$message}[/italic]
-     [true] {$entityName} subtly {$message}[/italic]
+chat-manager-entity-subtle-wrap-message = [italic][color={$color}]{ PROPER($entity) ->
+    *[false] the {$entityName} {$message}[/color][/italic]
+     [true] {$entityName} {$message}[/color][/italic]
     }
 
 chat-manager-entity-looc-wrap-message = LOOC: {$entityName}: {$message}


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds a new chat channel: Subtle OOC. This is to be used as LOOC but as private as subtle is and with the range of subtle.

![image](https://github.com/user-attachments/assets/49c4a780-d5ef-40f4-8c8e-82ba000e3212)

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added the Subtle OOC channel, replacing the alternate radio prefix (``.``)
- tweak: Tweaked the color of the subtle messages, removed the "subtly" prefix from your messages.
