### PR TITLE
Name/Pronoun Customization+

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -82,19 +82,19 @@
                                 <OptionButton Name="PronounsButton" HorizontalAlignment="Right" />
                             </BoxContainer>
                             <!-- Customizable, cosmetic pronouns -->
-                            <BoxContainer HorizontalExpand="True">
+                            <BoxContainer Name="CosmeticPronousContainer" HorizontalExpand="True">
                                 <Label Text="{Loc 'humanoid-profile-editor-display-pronouns-label'}" />
                                 <Control HorizontalExpand="True"/>
-                                <LineEdit Name="DisplayPronounsNameEdit" MinSize="270 0" HorizontalAlignment="Right" />
+                                <LineEdit Name="CosmeticPronounsNameEdit" MinSize="270 0" HorizontalAlignment="Right" />
                             </BoxContainer>
                             <!-- Station AI name -->
-                            <BoxContainer HorizontalExpand="True">
+                            <BoxContainer Name="StationAiNameContainer" HorizontalExpand="True">
                                 <Label Text="{Loc 'humanoid-profile-editor-station-ai-name-label'}" />
                                 <Control HorizontalExpand="True"/>
                                 <LineEdit Name="StationAINameEdit" MinSize="270 0" HorizontalAlignment="Right" />
                             </BoxContainer>
                             <!-- Cyborg name -->
-                            <BoxContainer HorizontalExpand="True">
+                            <BoxContainer Name="CyborgNameContainer" HorizontalExpand="True">
                                 <Label Text="{Loc 'humanoid-profile-editor-cyborg-name-label'}" />
                                 <Control HorizontalExpand="True"/>
                                 <LineEdit Name="CyborgNameEdit" MinSize="270 0" HorizontalAlignment="Right" />

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -86,6 +86,10 @@ namespace Content.Client.Lobby.UI
         private Direction _previewRotation = Direction.North;
         private ColorSelectorSliders _rgbSkinColorSelector;
 
+        private bool _customizePronouns;
+        private bool _customizeStationAiName;
+        private bool _customizeBorgName;
+
         public event Action<HumanoidCharacterProfile, int>? OnProfileChanged;
 
         [ValidatePrototypeId<GuideEntryPrototype>]
@@ -186,8 +190,6 @@ namespace Content.Client.Lobby.UI
 
             PronounsButton.OnItemSelected += args =>
             {
-                var label = GetFormattedPronounsFromGender();
-
                 PronounsButton.SelectId(args.Id);
                 SetGender((Gender) args.Id);
 
@@ -197,16 +199,34 @@ namespace Content.Client.Lobby.UI
 
             #endregion Gender
 
-            #region Display Pronouns
+            #region Cosmetic Pronouns
 
-            DisplayPronounsNameEdit.OnTextChanged += args => { SetDisplayPronouns(args.Text); };
+            _customizePronouns = _cfgManager.GetCVar(CCVars.AllowCosmeticPronouns);
+            _cfgManager.OnValueChanged(CCVars.AllowCosmeticPronouns, OnCosmeticPronounsValueChanged);
 
-            #endregion Display Pronouns
+            CosmeticPronounsNameEdit.OnTextChanged += args => { SetDisplayPronouns(args.Text); };
+
+            if (CosmeticPronousContainer.Visible != _customizePronouns)
+                CosmeticPronousContainer.Visible = _customizePronouns;
+
+            #endregion Cosmetic Pronouns
 
             #region Custom Names
 
+            _customizeStationAiName = _cfgManager.GetCVar(CCVars.AllowCustomStationAiName);
+            _customizeBorgName = _cfgManager.GetCVar(CCVars.AllowCustomCyborgName);
+
+            _cfgManager.OnValueChanged(CCVars.AllowCustomStationAiName, OnChangedStationAiNameCustomizationValue);
+            _cfgManager.OnValueChanged(CCVars.AllowCustomCyborgName, OnChangedCyborgNameCustomizationValue);
+
             StationAINameEdit.OnTextChanged += args => { SetStationAiName(args.Text); };
             CyborgNameEdit.OnTextChanged += args => { SetCyborgName(args.Text); };
+
+            if (StationAiNameContainer.Visible != _customizeStationAiName)
+                StationAiNameContainer.Visible = _customizeStationAiName;
+
+            if (CyborgNameContainer.Visible != _customizeBorgName)
+                CyborgNameContainer.Visible = _customizeBorgName;
 
             #endregion
 
@@ -541,6 +561,24 @@ namespace Content.Client.Lobby.UI
                 _flavorTextEdit?.Dispose();
                 _flavorTextEdit = null;
             }
+        }
+
+        private void OnCosmeticPronounsValueChanged(bool newValue)
+        {
+            _customizePronouns = newValue;
+            CosmeticPronousContainer.Visible = newValue;
+        }
+
+        private void OnChangedStationAiNameCustomizationValue(bool newValue)
+        {
+            _customizeStationAiName = newValue;
+            StationAiNameContainer.Visible = newValue;
+        }
+
+        private void OnChangedCyborgNameCustomizationValue(bool newValue)
+        {
+            _customizeBorgName = newValue;
+            CyborgNameContainer.Visible = newValue;
         }
 
         /// Refreshes the species selector
@@ -1431,12 +1469,12 @@ namespace Content.Client.Lobby.UI
                 return;
 
             var label = GetFormattedPronounsFromGender();
-            DisplayPronounsNameEdit.PlaceHolder = label;
+            CosmeticPronounsNameEdit.PlaceHolder = label;
 
             if (Profile.DisplayPronouns == null)
-                DisplayPronounsNameEdit.Text = string.Empty;
+                CosmeticPronounsNameEdit.Text = string.Empty;
             else
-                DisplayPronounsNameEdit.Text = Profile.DisplayPronouns;
+                CosmeticPronounsNameEdit.Text = Profile.DisplayPronouns;
         }
 
         private void UpdateStationAiControls()
@@ -1444,11 +1482,7 @@ namespace Content.Client.Lobby.UI
             if (Profile == null)
                 return;
 
-            if (Profile?.StationAiName != null)
-            {
-                StationAINameEdit.Text = Profile.StationAiName;
-                return;
-            }
+            StationAINameEdit.Text = Profile.StationAiName ?? string.Empty;
 
             if (StationAINameEdit.Text != string.Empty)
                 return;
@@ -1463,11 +1497,7 @@ namespace Content.Client.Lobby.UI
             if (Profile == null)
                 return;
 
-            if (Profile?.CyborgName != null)
-            {
-                CyborgNameEdit.Text = Profile.CyborgName;
-                return;
-            }
+            CyborgNameEdit.Text = Profile.CyborgName ?? string.Empty;
 
             if (CyborgNameEdit.Text != string.Empty)
                 return;

--- a/Content.Shared/CCVar/CCVars.Customize.cs
+++ b/Content.Shared/CCVar/CCVars.Customize.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    ///     Allow players to add extra pronouns to their examine window.
+    ///     It looks something like "She also goes by they/them pronouns."
+    /// </summary>
+    public static readonly CVarDef<bool> AllowCosmeticPronouns =
+        CVarDef.Create("customize.allow_cosmetic_pronouns", false, CVar.REPLICATED);
+
+    /// <summary>
+    ///     Allow players to set their own Station AI names.
+    /// </summary>
+    public static readonly CVarDef<bool> AllowCustomStationAiName =
+        CVarDef.Create("customize.allow_custom_station_ai_name", false, CVar.REPLICATED);
+
+    /// <summary>
+    ///     Allow players to set their own cyborg names. (borgs, mediborgs, etc)
+    /// </summary>
+    public static readonly CVarDef<bool> AllowCustomCyborgName =
+        CVarDef.Create("customize.allow_custom_cyborg_name", false, CVar.REPLICATED);
+}

--- a/Resources/Locale/en-US/character-appearance/components/humanoid-appearance-component.ftl
+++ b/Resources/Locale/en-US/character-appearance/components/humanoid-appearance-component.ftl
@@ -1,3 +1,3 @@
 humanoid-appearance-component-unknown-species = Person
 humanoid-appearance-component-examine = { CAPITALIZE(SUBJECT($user)) } { CONJUGATE-BE($user) } { INDEFINITE($age) } { $age } { $species }.
-humanoid-appearance-component-examine-pronouns = { CAPITALIZE(SUBJECT($user)) } also goes by {$pronouns} pronouns.
+humanoid-appearance-component-examine-pronouns = { CAPITALIZE(SUBJECT($user)) } also accepts {$pronouns} as pronouns.


### PR DESCRIPTION
# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed name customization not changing with different characters.
- fix: Fixed the save button being always clickable.
