### PR TITLE
Nicotine Addiction Tweak

### DIFF
--- a/Resources/Locale/en-US/mood/mood.ftl
+++ b/Resources/Locale/en-US/mood/mood.ftl
@@ -70,6 +70,10 @@ mood-effect-NicotineBenefit =
     I feel as if I have been standing my entire life and I just sat down.
 mood-effect-NicotineWithdrawal =
     I could really go for a smoke right now.
+mood-effect-NicotineWithdrawal2 =
+    I should... get another smoke shouldn't I?
+mood-effect-NicotineWithdrawal3 =
+    I can handle not getting another smoke, even through the itch... right?
 
 # Surgery
 mood-effect-SurgeryPain = The surgery hurts.

--- a/Resources/Prototypes/Mood/drugs.yml
+++ b/Resources/Prototypes/Mood/drugs.yml
@@ -24,7 +24,21 @@
 
 - type: moodEffect
   id: NicotineWithdrawal
-  moodChange: -7 #No timeout
+  moodChange: -7
+  timeout: 1020 #17 minutes
+  moodletOnEnd: NicotineWithdrawal2
+  category: "NicotineAddiction"
+
+- type: moodEffect
+  id: NicotineWithdrawal2
+  moodChange: -5
+  timeout: 1020 #17 minutes
+  moodletOnEnd: NicotineWithdrawal3
+  category: "NicotineAddiction"
+
+- type: moodEffect
+  id: NicotineWithdrawal3
+  moodChange: -3 #No timeout
   category: "NicotineAddiction"
 
 # Non-Addictive Drugs


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

A small tweak to the nicotine addiction to be slightly less punishing (especially with how easy it is to get), serves as a bandaid fix until someone on upstream improves on the addiction system. Not smoking for some time causes the initial mood debuff to degrade into a weaker mood debuff, although still permanent for balance.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked nicotine addictions to degrade into a weaker mood debuff with time spent not smoking. May your recovery be full of progress.