### PR TITLE
Hypopen Changes + Chloral Hydrate Sleepiness

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -524,7 +524,7 @@
   - type: Hypospray
     onlyAffectsMobs: false
   - type: UseDelay
-    delay: 0.5
+    delay: 1
   - type: StaticPrice # A new shitcurity meta
     price: 75
 

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -69,14 +69,15 @@
         time: 4
         type: Add
         refresh: false
-      - !type:HealthChange
+      - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
           reagent: ChloralHydrate
-          min: 20
-        damage:
-          types:
-            Poison: 1.5
+          min: 25
+        key: ForcedSleep
+        component: ForcedSleeping
+        refresh: false
+        type: Add
 
 - type: reagent
   id: GastroToxin

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -55,6 +55,7 @@
   physicalDesc: reagent-physical-desc-nondescript
   metabolisms:
     Poison:
+      metabolismRate: 0.25 # DeltaV: chloral hydrate should last longer for surgery
       effects:
       - !type:Emote
         emote: Yawn

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -348,7 +348,7 @@
     Water:
       amount: 1
   products:
-    ChloralHydrate: 1
+    ChloralHydrate: 3 # DeltaV: make chloral hydrate less outrageously expensive
 
 - type: reaction
   id: Pax


### PR DESCRIPTION
:cl:
- tweak: Chloral hydrate now sleeps people beyond 25u.
- tweak: Made chloral hydrate last much longer to function as an alternate nitrous oxide.
- tweak: Made the recipe for chloral hydrate produce 3 instead of 1, making it a lot more viable for surgery.
- tweak: Hypopen's use delay was changed from 0.5s to 1s to encourage more RP meaningful methods of completing objectives.
