### PR TITLE
MindSwap Consent

### DIFF
--- a/Resources/Locale/en-US/Blep/consent.ftl
+++ b/Resources/Locale/en-US/Blep/consent.ftl
@@ -26,3 +26,7 @@ consent-Hypno-desc = Allow yourself to be hypnotized.
 
 consent-NoClone-name = Disallow Paradox Anomaly
 consent-NoClone-desc = Disallow yourself to be the target of a paradox anomaly clone.
+
+consent-MindSwap-name = Mind Swap
+consent-MindSwap-desc = Should mind swap effect you?
+consent-MindSwap-no-consent = { CAPITALIZE(POSS-ADJ($target)) } mind rejects your advances.

--- a/Resources/Prototypes/consent.yml
+++ b/Resources/Prototypes/consent.yml
@@ -3,3 +3,6 @@
 
 - type: consentToggle
   id: NoClone
+
+- type: consentToggle
+  id: MindSwap


### PR DESCRIPTION
:cl:
- add: Consent toggle added for Mind Swap. While this does mean you can no longer use it for antag purposes, no one did that anyway and it's a trait now.