### PR TITLE
Shoko Repair 2: Case of the missing silo

### DIFF
--- a/Resources/Maps/TheDen/shoukou.yml
+++ b/Resources/Maps/TheDen/shoukou.yml
@@ -123,7 +123,7 @@ entities:
           version: 6
         -3,0:
           ind: -3,0
-          tiles: fwAAAAAAfwAAAAAAewAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAewAAAAAAewAAAAACewAAAAADfQAAAAADfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAJQAAAAACIAAAAAABIAAAAAADIQAAAAABIQAAAAABfwAAAAAAewAAAAACfwAAAAAAewAAAAAAewAAAAAAewAAAAABfQAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAJQAAAAABIAAAAAACIAAAAAACIQAAAAABIQAAAAADfwAAAAAAewAAAAACfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAIAAAAAADIAAAAAADIAAAAAADIAAAAAADQwAAAAAAfwAAAAAAewAAAAABfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAIAAAAAACIAAAAAADQwAAAAAAQwAAAAAAQwAAAAAAfwAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAQwAAAAAAJQAAAAABQwAAAAAAQwAAAAAAQwAAAAAAfwAAAAAAfgAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAZQAAAAAAbgAAAAAAbgAAAAAAbwAAAAAAbwAAAAADfwAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAXgAAAAABbgAAAAAAbgAAAAAAbwAAAAACbwAAAAAAfwAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAZQAAAAAAbgAAAAAAbgAAAAAAbwAAAAABbwAAAAABfwAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAXgAAAAACbgAAAAAAbgAAAAAAbwAAAAADbwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAA
+          tiles: fwAAAAAAfwAAAAAAewAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAewAAAAAAewAAAAACewAAAAADfQAAAAADfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAJQAAAAACIAAAAAABIAAAAAADIQAAAAABIQAAAAABfwAAAAAAewAAAAACfwAAAAAAewAAAAAAewAAAAAAewAAAAABfQAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAJQAAAAABIAAAAAACIAAAAAACIQAAAAABIQAAAAADfwAAAAAAewAAAAACfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAIAAAAAADIAAAAAADIAAAAAADIAAAAAADQwAAAAAAfwAAAAAAewAAAAABfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAIAAAAAACIAAAAAADQwAAAAAAQwAAAAAAQwAAAAAAfwAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAQwAAAAAAJQAAAAABQwAAAAAAQwAAAAAAQwAAAAAAfwAAAAAAfgAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAZQAAAAAAbgAAAAAAbgAAAAAAbwAAAAAAbwAAAAADfwAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAXgAAAAABbgAAAAAAbgAAAAAAbwAAAAACbwAAAAAAfwAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAZQAAAAAAbgAAAAAAbgAAAAAAbwAAAAABbwAAAAABfwAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAXgAAAAACbgAAAAAAbgAAAAAAbwAAAAADbwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -3,-1:
           ind: -3,-1
@@ -167,7 +167,7 @@ entities:
           version: 6
         -4,0:
           ind: -4,0
-          tiles: fgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAACfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAABewAAAAABewAAAAACewAAAAADfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAewAAAAADfQAAAAADfQAAAAADewAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAewAAAAACewAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAewAAAAACOgAAAAAAOgAAAAABOgAAAAAAOgAAAAABOgAAAAACewAAAAADfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAewAAAAAAOgAAAAACOgAAAAADOgAAAAADOgAAAAACOgAAAAACewAAAAABewAAAAADewAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAewAAAAAAOgAAAAAAOgAAAAADOgAAAAACOgAAAAABOgAAAAADfwAAAAAAewAAAAABewAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAACewAAAAABewAAAAACewAAAAADewAAAAACfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAABLAAAAAAALAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAADLAAAAAAALAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAADLAAAAAAALAAAAAAAewAAAAACewAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAewAAAAADewAAAAAAewAAAAADewAAAAABfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: fgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAACfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAABewAAAAABewAAAAACewAAAAADfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAewAAAAADfQAAAAADfQAAAAADewAAAAADfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAewAAAAACewAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAewAAAAACOgAAAAAAOgAAAAABOgAAAAAAOgAAAAABOgAAAAACewAAAAADfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAewAAAAAAOgAAAAACOgAAAAADOgAAAAADOgAAAAACOgAAAAACewAAAAABewAAAAADewAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAewAAAAAAOgAAAAAAOgAAAAADOgAAAAACOgAAAAABOgAAAAADfwAAAAAAewAAAAABewAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAACewAAAAABewAAAAACewAAAAADewAAAAACfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAABLAAAAAAALAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAADLAAAAAAALAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAADLAAAAAAALAAAAAAAewAAAAACewAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAewAAAAADewAAAAAAewAAAAADewAAAAABfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -4,-2:
           ind: -4,-2
@@ -3635,9 +3635,6 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 5932
-      - 5931
-      - 5936
       - 8329
       - 8466
       - 300
@@ -4924,14 +4921,22 @@ entities:
       linkedPorts:
         139:
         - DoorStatus: DoorBolt
-- proto: AirlockExternalGlassShuttleEmergencyLocked
+- proto: AirlockExternalGlassShuttleArrivals
   entities:
   - uid: 141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
+      pos: 6.5,20.5
+      parent: 2
+  - uid: 151
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
       pos: 12.5,20.5
       parent: 2
+- proto: AirlockExternalGlassShuttleEmergencyLocked
+  entities:
   - uid: 142
     components:
     - type: Transform
@@ -4982,12 +4987,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,-43.5
-      parent: 2
-  - uid: 151
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,20.5
       parent: 2
 - proto: AirlockFreezerKitchenHydroLocked
   entities:
@@ -5788,6 +5787,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 44.5,-14.5
       parent: 2
+  - uid: 286
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-13.5
+      parent: 2
 - proto: AirlockSecurityGlassLocked
   entities:
   - uid: 274
@@ -5880,22 +5885,6 @@ entities:
     - type: Transform
       pos: 34.5,-20.5
       parent: 2
-  - uid: 286
-    components:
-    - type: MetaData
-      name: Security Lobby
-    - type: Transform
-      pos: 15.5,-13.5
-      parent: 2
-    - type: DeviceLinkSink
-      invokeCounter: 1
-      links:
-      - 10957
-      - 288
-    - type: DeviceLinkSource
-      linkedPorts:
-        288:
-        - DoorStatus: DoorBolt
   - uid: 287
     components:
     - type: MetaData
@@ -5912,11 +5901,9 @@ entities:
       parent: 2
     - type: DeviceLinkSink
       invokeCounter: 1
-      links:
-      - 286
     - type: DeviceLinkSource
       linkedPorts:
-        286:
+        invalid:
         - DoorStatus: DoorBolt
 - proto: AirlockSecurityLawyerLocked
   entities:
@@ -6705,11 +6692,21 @@ entities:
     - type: Transform
       pos: -13.5,4.5
       parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 9004
+    - type: MaterialSiloUtilizer
+      silo: 9004
   - uid: 406
     components:
     - type: Transform
       pos: -17.5,-40.5
       parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 9004
+    - type: MaterialSiloUtilizer
+      silo: 9004
 - proto: BackgammonBoard
   entities:
   - uid: 407
@@ -15403,36 +15400,6 @@ entities:
     - type: Transform
       pos: 35.5,-29.5
       parent: 2
-  - uid: 2096
-    components:
-    - type: Transform
-      pos: 35.5,-30.5
-      parent: 2
-  - uid: 2097
-    components:
-    - type: Transform
-      pos: 35.5,-31.5
-      parent: 2
-  - uid: 2098
-    components:
-    - type: Transform
-      pos: 35.5,-32.5
-      parent: 2
-  - uid: 2099
-    components:
-    - type: Transform
-      pos: 35.5,-33.5
-      parent: 2
-  - uid: 2100
-    components:
-    - type: Transform
-      pos: 35.5,-34.5
-      parent: 2
-  - uid: 2101
-    components:
-    - type: Transform
-      pos: 35.5,-35.5
-      parent: 2
   - uid: 2102
     components:
     - type: Transform
@@ -15442,11 +15409,6 @@ entities:
     components:
     - type: Transform
       pos: -2.5,14.5
-      parent: 2
-  - uid: 2104
-    components:
-    - type: Transform
-      pos: 35.5,-36.5
       parent: 2
   - uid: 2105
     components:
@@ -29100,6 +29062,11 @@ entities:
     - type: Transform
       pos: -33.5,-19.5
       parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 9004
+    - type: MaterialSiloUtilizer
+      silo: 9004
 - proto: CleanerDispenser
   entities:
   - uid: 4744
@@ -29346,11 +29313,6 @@ entities:
     components:
     - type: Transform
       pos: -28.5,-27.5
-      parent: 2
-  - uid: 4792
-    components:
-    - type: Transform
-      pos: -29.5,-27.5
       parent: 2
   - uid: 4793
     components:
@@ -29755,16 +29717,6 @@ entities:
     components:
     - type: Transform
       pos: -23.539022,-27.306688
-      parent: 2
-  - uid: 4852
-    components:
-    - type: Transform
-      pos: 35.55076,-35.157898
-      parent: 2
-  - uid: 4853
-    components:
-    - type: Transform
-      pos: 35.45701,-33.970398
       parent: 2
 - proto: ClothingHeadHatGreensoftFlipped
   entities:
@@ -31619,11 +31571,6 @@ entities:
     components:
     - type: Transform
       pos: -52.397526,-17.118998
-      parent: 2
-  - uid: 5055
-    components:
-    - type: Transform
-      pos: 35.428898,-33.767273
       parent: 2
 - proto: CrowbarRed
   entities:
@@ -35201,13 +35148,6 @@ entities:
     - type: Transform
       pos: 13.863688,-40.13169
       parent: 2
-- proto: DrinkSakeBottleFull
-  entities:
-  - uid: 5614
-    components:
-    - type: Transform
-      pos: 2.7853847,-3.2562366
-      parent: 2
 - proto: DrinkSakeCup
   entities:
   - uid: 5615
@@ -35253,25 +35193,6 @@ entities:
     components:
     - type: Transform
       pos: 41.310482,5.6547894
-      parent: 2
-- proto: DrinkShotGlass
-  entities:
-  - uid: 5623
-    components:
-    - type: Transform
-      pos: 2.502306,-3.3255205
-      parent: 2
-  - uid: 5624
-    components:
-    - type: Transform
-      pos: 2.346056,-3.492303
-      parent: 2
-- proto: DrinkSojuBottleFull
-  entities:
-  - uid: 5625
-    components:
-    - type: Transform
-      pos: 3.0978847,-3.2770853
       parent: 2
 - proto: DrinkSoyLatte
   entities:
@@ -36193,6 +36114,18 @@ entities:
       parent: 5762
     - type: Physics
       canCollide: False
+- proto: EngineeringTechFab
+  entities:
+  - uid: 2101
+    components:
+    - type: Transform
+      pos: -29.5,-27.5
+      parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 9004
+    - type: MaterialSiloUtilizer
+      silo: 9004
 - proto: ExosuitFabricator
   entities:
   - uid: 5764
@@ -37181,7 +37114,7 @@ entities:
       pos: -36.5,-22.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -78647.28
+      secondsUntilStateChange: -80274.39
       state: Closing
   - uid: 5912
     components:
@@ -37320,24 +37253,6 @@ entities:
       - 5815
       - 9
       - 23
-  - uid: 5931
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 33.5,-32.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 16
-  - uid: 5932
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 34.5,-32.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 16
   - uid: 5933
     components:
     - type: Transform
@@ -37353,15 +37268,6 @@ entities:
     - type: Transform
       pos: 20.5,-24.5
       parent: 2
-  - uid: 5936
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 35.5,-32.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 16
   - uid: 5937
     components:
     - type: Transform
@@ -38023,6 +37929,14 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+  - uid: 2100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-28.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 6031
     components:
     - type: Transform
@@ -38496,7 +38410,7 @@ entities:
     - type: GasFilter
       transferRate: 100
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF74D4FF'
   - uid: 6111
     components:
     - type: MetaData
@@ -38508,7 +38422,7 @@ entities:
     - type: GasFilter
       transferRate: 100
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#FF74D4FF'
 - proto: GasMinerCarbonDioxide
   entities:
   - uid: 6112
@@ -38790,6 +38704,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 0.5,-43.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FF74D4FF'
   - uid: 6175
     components:
     - type: Transform
@@ -39151,6 +39067,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -0.5,-43.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FF74D4FF'
   - uid: 6226
     components:
     - type: Transform
@@ -40438,6 +40356,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -0.5,-41.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FF74D4FF'
   - uid: 6454
     components:
     - type: Transform
@@ -44930,6 +44850,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -0.5,-42.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FF74D4FF'
   - uid: 7033
     components:
     - type: Transform
@@ -52191,6 +52113,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 0.5,-40.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FF74D4FF'
   - uid: 8001
     components:
     - type: Transform
@@ -52430,11 +52354,15 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -1.5,-40.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FF74D4FF'
   - uid: 8033
     components:
     - type: Transform
       pos: -0.5,-40.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FF74D4FF'
   - uid: 8034
     components:
     - type: Transform
@@ -54305,6 +54233,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: -1.5,-41.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FF74D4FF'
 - proto: GasRecycler
   entities:
   - uid: 6397
@@ -54336,6 +54266,8 @@ entities:
     - type: Transform
       pos: -1.5,-39.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#FF74D4FF'
 - proto: GasThermoMachineHeater
   entities:
   - uid: 6357
@@ -58987,61 +58919,6 @@ entities:
     - type: Transform
       pos: -40.5,16.5
       parent: 2
-  - uid: 8999
-    components:
-    - type: Transform
-      pos: -63.5,9.5
-      parent: 2
-  - uid: 9000
-    components:
-    - type: Transform
-      pos: -62.5,9.5
-      parent: 2
-  - uid: 9001
-    components:
-    - type: Transform
-      pos: -62.5,10.5
-      parent: 2
-  - uid: 9002
-    components:
-    - type: Transform
-      pos: -61.5,10.5
-      parent: 2
-  - uid: 9003
-    components:
-    - type: Transform
-      pos: -61.5,11.5
-      parent: 2
-  - uid: 9004
-    components:
-    - type: Transform
-      pos: -60.5,11.5
-      parent: 2
-  - uid: 9005
-    components:
-    - type: Transform
-      pos: -60.5,12.5
-      parent: 2
-  - uid: 9006
-    components:
-    - type: Transform
-      pos: -59.5,12.5
-      parent: 2
-  - uid: 9007
-    components:
-    - type: Transform
-      pos: -59.5,13.5
-      parent: 2
-  - uid: 9008
-    components:
-    - type: Transform
-      pos: -58.5,13.5
-      parent: 2
-  - uid: 9009
-    components:
-    - type: Transform
-      pos: -58.5,14.5
-      parent: 2
   - uid: 9010
     components:
     - type: Transform
@@ -60715,6 +60592,78 @@ entities:
       parent: 2
 - proto: GrilleDiagonal
   entities:
+  - uid: 5623
+    components:
+    - type: Transform
+      pos: -58.5,14.5
+      parent: 2
+  - uid: 5624
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -58.5,13.5
+      parent: 2
+  - uid: 5625
+    components:
+    - type: Transform
+      pos: -59.5,13.5
+      parent: 2
+  - uid: 5931
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -59.5,12.5
+      parent: 2
+  - uid: 5932
+    components:
+    - type: Transform
+      pos: -60.5,12.5
+      parent: 2
+  - uid: 5936
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -60.5,11.5
+      parent: 2
+  - uid: 8999
+    components:
+    - type: Transform
+      pos: -61.5,11.5
+      parent: 2
+  - uid: 9000
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -61.5,10.5
+      parent: 2
+  - uid: 9001
+    components:
+    - type: Transform
+      pos: -62.5,10.5
+      parent: 2
+  - uid: 9002
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -62.5,9.5
+      parent: 2
+  - uid: 9003
+    components:
+    - type: Transform
+      pos: -63.5,9.5
+      parent: 2
+  - uid: 9005
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -56.5,14.5
+      parent: 2
+  - uid: 9009
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -63.5,7.5
+      parent: 2
   - uid: 11708
     components:
     - type: Transform
@@ -61298,12 +61247,6 @@ entities:
     components:
     - type: Transform
       pos: 17.5,-11.5
-      parent: 2
-  - uid: 9416
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.5,4.5
       parent: 2
   - uid: 9417
     components:
@@ -62438,6 +62381,29 @@ entities:
     - type: Transform
       pos: 6.5,-19.5
       parent: 2
+- proto: MaterialSilo
+  entities:
+  - uid: 9004
+    components:
+    - type: Transform
+      pos: 40.5,-35.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        10870:
+        - MaterialSilo: MaterialSiloUtilizer
+        9605:
+        - MaterialSilo: MaterialSiloUtilizer
+        406:
+        - MaterialSilo: MaterialSiloUtilizer
+        2101:
+        - MaterialSilo: MaterialSiloUtilizer
+        4743:
+        - MaterialSilo: MaterialSiloUtilizer
+        10152:
+        - MaterialSilo: MaterialSiloUtilizer
+        405:
+        - MaterialSilo: MaterialSiloUtilizer
 - proto: MaterialWoodPlank1
   entities:
   - uid: 9595
@@ -62505,6 +62471,11 @@ entities:
     - type: Transform
       pos: 11.5,-38.5
       parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 9004
+    - type: MaterialSiloUtilizer
+      silo: 9004
 - proto: MedkitAdvancedFilled
   entities:
   - uid: 9606
@@ -63956,16 +63927,6 @@ entities:
     - type: Transform
       pos: 5.5,1.5
       parent: 2
-  - uid: 9823
-    components:
-    - type: Transform
-      pos: 49.5,-31.5
-      parent: 2
-  - uid: 9824
-    components:
-    - type: Transform
-      pos: 55.5,-31.5
-      parent: 2
   - uid: 9825
     components:
     - type: Transform
@@ -65122,12 +65083,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 35.5,-28.5
       parent: 2
-  - uid: 10014
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 35.5,-35.5
-      parent: 2
   - uid: 10015
     components:
     - type: Transform
@@ -66039,6 +65994,11 @@ entities:
     - type: Transform
       pos: -35.5,-17.5
       parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 9004
+    - type: MaterialSiloUtilizer
+      silo: 9004
   - uid: 10153
     components:
     - type: Transform
@@ -67581,6 +67541,34 @@ entities:
     components:
     - type: Transform
       pos: 8.320472,-5.1379967
+      parent: 2
+- proto: ReagentTinPowderedJuiceBanana
+  entities:
+  - uid: 2104
+    components:
+    - type: Transform
+      pos: 2.67125,-3.3434942
+      parent: 2
+- proto: ReagentTinPowderedJuiceBerry
+  entities:
+  - uid: 4853
+    components:
+    - type: Transform
+      pos: 2.6608093,-3.1030645
+      parent: 2
+- proto: ReagentTinPowderedJuicePineapple
+  entities:
+  - uid: 4792
+    components:
+    - type: Transform
+      pos: 3.0888708,-3.1553316
+      parent: 2
+- proto: ReagentTinPowderedJuiceWatermelon
+  entities:
+  - uid: 4852
+    components:
+    - type: Transform
+      pos: 3.0888708,-3.3121338
       parent: 2
 - proto: Recycler
   entities:
@@ -69865,6 +69853,11 @@ entities:
     - type: Transform
       pos: 33.5,-6.5
       parent: 2
+    - type: DeviceLinkSink
+      links:
+      - 9004
+    - type: MaterialSiloUtilizer
+      silo: 9004
 - proto: SeedExtractor
   entities:
   - uid: 10871
@@ -70557,7 +70550,7 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        286:
+        invalid:
         - Pressed: Open
         - Pressed: Close
 - proto: SignalSwitch
@@ -72148,11 +72141,11 @@ entities:
       parent: 2
 - proto: SpareIdCabinetFilled
   entities:
-  - uid: 11185
+  - uid: 9007
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 40.5,-36.5
+      rot: 1.5707963267948966 rad
+      pos: 48.5,-31.5
       parent: 2
 - proto: SpawnMobAlexander
   entities:
@@ -74646,6 +74639,14 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.61118,-1.4217451
+      parent: 2
+- proto: SyringeTranexamicAcid
+  entities:
+  - uid: 2099
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5032825,-34.82811
       parent: 2
 - proto: Table
   entities:
@@ -77432,6 +77433,11 @@ entities:
       parent: 2
 - proto: VendingMachineYouTool
   entities:
+  - uid: 9008
+    components:
+    - type: Transform
+      pos: -35.5,-25.5
+      parent: 2
   - uid: 11996
     components:
     - type: Transform
@@ -77570,6 +77576,16 @@ entities:
     - type: Transform
       pos: 34.5,3.5
       parent: 2
+  - uid: 2096
+    components:
+    - type: Transform
+      pos: 35.5,-34.5
+      parent: 2
+  - uid: 2097
+    components:
+    - type: Transform
+      pos: 35.5,-35.5
+      parent: 2
   - uid: 3907
     components:
     - type: Transform
@@ -77591,6 +77607,11 @@ entities:
     components:
     - type: Transform
       pos: 37.5,0.5
+      parent: 2
+  - uid: 5614
+    components:
+    - type: Transform
+      pos: 35.5,-33.5
       parent: 2
   - uid: 5651
     components:
@@ -83159,6 +83180,19 @@ entities:
     - type: Transform
       pos: 60.5,-25.5
       parent: 2
+- proto: WallReinforcedDiagonal
+  entities:
+  - uid: 5055
+    components:
+    - type: Transform
+      pos: 35.5,-32.5
+      parent: 2
+  - uid: 9006
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 35.5,-36.5
+      parent: 2
 - proto: WallReinforcedRust
   entities:
   - uid: 13115
@@ -85764,6 +85798,11 @@ entities:
       parent: 2
 - proto: WeldingFuelTankFull
   entities:
+  - uid: 2098
+    components:
+    - type: Transform
+      pos: -32.5,-33.5
+      parent: 2
   - uid: 13572
     components:
     - type: Transform
@@ -85785,11 +85824,6 @@ entities:
       desc: Fred insists it's alright to put the fuel tank here. Take it up with him if you have a problem with it.
     - type: Transform
       pos: -54.5,10.5
-      parent: 2
-  - uid: 13576
-    components:
-    - type: Transform
-      pos: -35.5,-25.5
       parent: 2
   - uid: 13577
     components:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

Adds the silo to shoko BECAUSE IM A SILLY FOX WHO FORGOT
https://www.youtube.com/watch?v=SYCP71qcYZw

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Fox
- tweak: Silly girl forgot shoko's Mat Silo, its there now
- tweak: Shoko's arrivals shuttle should now dock properly
