### PR TITLE
Quickfixes

### DIFF
--- a/Resources/Maps/Floof/arena.yml
+++ b/Resources/Maps/Floof/arena.yml
@@ -129215,23 +129215,6 @@ entities:
             Quantity: 10
     - type: Physics
       canCollide: False
-  - uid: 1247
-    components:
-    - type: Transform
-      parent: 1242
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 25
-          name: null
-          reagents:
-          - data: null
-            ReagentId: Codeine
-            Quantity: 15
-    - type: Physics
-      canCollide: False
 - proto: PillCanister
   entities:
   - uid: 1242

--- a/Resources/Maps/TheDen/arena.yml
+++ b/Resources/Maps/TheDen/arena.yml
@@ -129136,23 +129136,6 @@ entities:
             Quantity: 10
     - type: Physics
       canCollide: False
-  - uid: 17316
-    components:
-    - type: Transform
-      parent: 17308
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 25
-          name: null
-          reagents:
-          - data: null
-            ReagentId: Codeine
-            Quantity: 15
-    - type: Physics
-      canCollide: False
 - proto: PillCanister
   entities:
   - uid: 17308

--- a/Resources/Maps/arena.yml
+++ b/Resources/Maps/arena.yml
@@ -129136,23 +129136,6 @@ entities:
             Quantity: 10
     - type: Physics
       canCollide: False
-  - uid: 17316
-    components:
-    - type: Transform
-      parent: 17308
-    - type: SolutionContainerManager
-      solutions:
-        food:
-          temperature: 293.15
-          canReact: True
-          maxVol: 25
-          name: null
-          reagents:
-          - data: null
-            ReagentId: Codeine
-            Quantity: 15
-    - type: Physics
-      canCollide: False
 - proto: PillCanister
   entities:
   - uid: 17308

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -536,7 +536,7 @@
   name: slim cardigan
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterStorageBase
   id: ClothingOuterCowboyDuster
   name: cowboy duster
   description: A duster commonly seen on cowboys from Earth's late 1800's.

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -408,7 +408,7 @@
   displayName: seeds-sugarcane-display-name
   plantRsi: Objects/Specific/Hydroponics/sugarcane.rsi
   packetPrototype: SugarcaneSeeds
-  productPrototypes: 
+  productPrototypes:
     - Sugarcane
   mutationPrototypes:
     - papercane
@@ -1193,7 +1193,7 @@
   growthStages: 3
   waterConsumption: 0.60
   chemicals:
-    Ultravasculine:
+    PenteticAcid:
       Min: 1
       Max: 20
       PotencyDivisor: 5

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -919,8 +919,6 @@
     - !type:CharacterSpeciesRequirement
       species:
         - IPC
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMind
   functions:
     - !type:TraitAddComponent
       components:

--- a/Resources/Prototypes/_Nuclear14/Stacks/material_stacks.yml
+++ b/Resources/Prototypes/_Nuclear14/Stacks/material_stacks.yml
@@ -10,7 +10,7 @@
   name: bauxite
   icon: { sprite: "/Textures/_Nuclear14/Objects/Misc/materials.rsi", state: lead }
   spawn: N14AluminiumOre1
-  maxCount: 10
+  maxCount: 30
   itemSize: 1
 
 - type: stack
@@ -18,7 +18,7 @@
   name: lead ore
   icon: { sprite: "/Textures/_Nuclear14/Objects/Misc/materials.rsi", state: lead }
   spawn: N14LeadOre1
-  maxCount: 10
+  maxCount: 30
   itemSize: 1
 
 - type: stack
@@ -34,7 +34,7 @@
   name: sulfur ore
   icon: { sprite: "/Textures/_Nuclear14/Objects/Misc/materials.rsi", state: sulfur }
   spawn: SulfurOre1
-  maxCount: 10
+  maxCount: 30
   itemSize: 1
 
 # Metals


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Removed big opium from Arena item spawns, gave lingzhis the proper chem contents, removed mind or machine requirement that was missed on a previous fix.

---

