### PR TITLE
Epistemics Point Generation Buffs

### DIFF
--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
@@ -58,7 +58,7 @@ public sealed partial class ArtifactComponent : Component
     /// to determine the monetary value of the artifact
     /// </summary>
     [DataField("priceMultiplier"), ViewVariables(VVAccess.ReadWrite)]
-    public float PriceMultiplier = 0.05f;
+    public float PriceMultiplier = 0.1f;
 
     /// <summary>
     /// The base amount of research points for each artifact node.

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
@@ -58,7 +58,7 @@ public sealed partial class ArtifactComponent : Component
     /// to determine the monetary value of the artifact
     /// </summary>
     [DataField("priceMultiplier"), ViewVariables(VVAccess.ReadWrite)]
-    public float PriceMultiplier = 0.1f;
+    public float PriceMultiplier = 0.07f;
 
     /// <summary>
     /// The base amount of research points for each artifact node.

--- a/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
+++ b/Content.Server/Xenoarchaeology/XenoArtifacts/ArtifactComponent.cs
@@ -58,13 +58,13 @@ public sealed partial class ArtifactComponent : Component
     /// to determine the monetary value of the artifact
     /// </summary>
     [DataField("priceMultiplier"), ViewVariables(VVAccess.ReadWrite)]
-    public float PriceMultiplier = 0.07f;
+    public float PriceMultiplier = 0.1f;
 
     /// <summary>
     /// The base amount of research points for each artifact node.
     /// </summary>
     [DataField("pointsPerNode"), ViewVariables(VVAccess.ReadWrite)]
-    public int PointsPerNode = 6500;
+    public int PointsPerNode = 7500;
 
     /// <summary>
     /// Research points which have been "consumed" from the theoretical max value of the artifact.

--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -185,21 +185,21 @@ public sealed partial class AnomalyComponent : Component
     /// The minimum amount of research points generated per second
     /// </summary>
     [DataField("minPointsPerSecond")]
-    public int MinPointsPerSecond = 10;
+    public int MinPointsPerSecond = 40;
 
     /// <summary>
     /// The maximum amount of research points generated per second
     /// This doesn't include the point bonus for being unstable.
     /// </summary>
     [DataField("maxPointsPerSecond")]
-    public int MaxPointsPerSecond = 70;
+    public int MaxPointsPerSecond = 150;
 
     /// <summary>
     /// The multiplier applied to the point value for the
     /// anomaly being above the <see cref="GrowthThreshold"/>
     /// </summary>
     [DataField("growingPointMultiplier")]
-    public float GrowingPointMultiplier = 1.5f;
+    public float GrowingPointMultiplier = 2.0f;
     #endregion
 
     /// <summary>

--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -1,6 +1,6 @@
 ﻿- type: cargoBounty
   id: BountyArtifact
-  reward: 2500
+  reward: 5500
   description: bounty-description-artifact
   entries:
   - name: bounty-item-artifact


### PR DESCRIPTION
:cl:
- tweak: Artifacts price multiplier has been upped from 0.05 to 0.1, generating at minimum an extra 450 spesos, hopefully increasing the Epistemics-Logistics teamwork a little more.
- tweak: The artifact bounty sell price has jumped from 2500 to 5500, in an attempt to make epistemics more willing to cooperate with logistics on this bounty.
- tweak: Artifacts now provide an extra 1000 research points, from 6500 points per node to 7500.
- tweak: Anomalies now generate at minimum 40 points per second, instead of 10
- tweak: Anomalies also generate at maximum 150 points per second instead of 70.
