### PR TITLE
Bandana Eat Hotfix

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/bandanas.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/bandanas.yml
@@ -13,7 +13,9 @@
     - MASK
   - type: Mask
   - type: IngestionBlocker
+    enabled: true
   - type: IdentityBlocker
+    enabled: true
     coverage: MOUTH
   - type: Sprite
     layers:


### PR DESCRIPTION
# Description

Bandanas were bugged to the point where you could not eat while they were on your head. Flipped a couple of values to "true." goddamn it.

- [x] Completed Task

:cl:
- fix: Fixed bandanas on the head preventing the character from eating.
- fix: Bandanas on face should now obscure the wearer.