### PR TITLE
Gun Tweaks

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -58,12 +58,12 @@
   category: cargoproduct-category-name-armory
   group: market
 
-- type: cargoProduct
-  id: ArmoryBRDIR25
-  icon:
-    sprite: _EE/Objects/Weapons/Guns/SMGs/BRDI_R25.rsi
-    state: icon
-  product: CrateArmoryBRDIR25
-  cost: 52000
-  category: cargoproduct-category-name-armory
-  group: market
+# - type: cargoProduct
+#   id: ArmoryBRDIR25
+#   icon:
+#     sprite: _EE/Objects/Weapons/Guns/SMGs/BRDI_R25.rsi
+#     state: icon
+#   product: CrateArmoryBRDIR25
+#   cost: 52000
+#   category: cargoproduct-category-name-armory
+#   group: market

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -10,7 +10,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 28
+        Piercing: 35
 
 - type: entity
   id: PelletShotgunBeanbag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -357,9 +357,9 @@
   - type: Gun
     minAngle: 1
     maxAngle: 20
-    angleIncrease: 8
+    angleIncrease: 10
     angleDecay: 9
-    fireRate: 4
+    fireRate: 3
     availableModes:
     - SemiAuto
     soundGunshot:

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1122,13 +1122,16 @@
       - WeaponMechCombatFlashbangLauncher
       - WeaponMechCombatMissileRack8
       - EnergySword
-      - EnergySwordDouble
       - EnergyCutlass
       - WeaponSubMachineGunFPA90
       - WeaponSubMachineGunBRDIR25
       - WeaponPistolMk58
       - WeaponPistolN1984
       - WeaponPistolViper
+      - WeaponPistolCobra
+  - type: EmagLatheRecipes
+    emagDynamicRecipes:
+      - EnergySwordDouble
       - WeaponPistolCobra
   - type: MaterialStorage
     whitelist:

--- a/Resources/Prototypes/Loadouts/Jobs/Security/headOfSecurity.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/headOfSecurity.yml
@@ -121,7 +121,7 @@
 - type: loadout
   id: LoadoutCommandHoSBRDIR25
   category: JobsSecurityHeadOfSecurity
-  cost: 0
+  cost: 7 # Cracked
   canBeHeirloom: true
   requirements:
     - !type:CharacterItemGroupRequirement

--- a/Resources/Prototypes/Loadouts/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/uncategorized.yml
@@ -657,7 +657,7 @@
 - type: loadout
   id: LoadoutSecurityPistolN1984
   category: JobsSecurityAUncategorized
-  cost: 5
+  cost: 6
   canBeHeirloom: true
   guideEntry: SecurityWeapons
   requirements:

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -139,10 +139,9 @@
   - WeaponGunLaserCarbineAutomatic
   - WeaponLaserCannon
   - WeaponMechCombatSolarisLaser # Goobstation
-  - WeaponSubMachineGunFPA90
   - WeaponPistolN1984
   - WeaponPistolViper
-  - WeaponPistolCobra
+#  - WeaponPistolCobra
   technologyPrerequisites:
   - BasicWeapons
 
@@ -183,7 +182,8 @@
   - ShuttleGunDusterCircuitboard
   - WeaponMechCombatImmolationGun # Goobstation
   - EnergySword # TODO: Add a bunch of stupidly exotic energy weapons to act as a reaaaaaally nice incentive for research to consider this.
-  - EnergySwordDouble
+#  - EnergySwordDouble
   - EnergyCutlass
+  - WeaponSubMachineGunFPA90
   - WeaponSubMachineGunBRDIR25
   softCapContribution: 1.5


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adjustments:
- BRDI Crate removed from cargo catalog.
- HoS' BRDI Costs 7 Points
- N1984 spread while firing slightly increased, loadout cost increased to 6 from 5.
- Cobra and Double Esword moved to security techfab's emagged inventory.
- FPA90 moved to T3 Security Research from T2.
- Shotgun slugs damage increased to 35 Pierce from 28.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Some gun tweaks, view PR for complete details.
