### PR TITLE
Wisps and Fixes

### DIFF
--- a/Resources/Locale/en-US/psionics/psionic-powers.ftl
+++ b/Resources/Locale/en-US/psionics/psionic-powers.ftl
@@ -201,6 +201,7 @@ oracle-feedback = WHY DO YOU BOTHER ME SEEKER? HAVE I NOT MADE MY DESIRES CLEAR?
 orecrab-feedback = Heralds of the Lord of Earth, summoned to this realm from Grome's kingdom
 reagent-slime-feedback = Heralds of the Lord of Water, summoned to this realm from Straasha's kingdom.
 flesh-golem-feedback = Abominations pulled from dead realms, twisted amalgamations of those fallen to the influence of primordial Chaos
+living-light-feedback = Luminous creatures formed deceitfully beautiful and bright, bringing their music to lure and consume.
 glimmer-mite-feedback = A semi-corporeal parasite native to the dreamlight, its presence here brings forth the screams of dead stars.
 anomaly-pyroclastic-feedback = A small mirror to the plane of Gehenna, truth lies within the Secret of Fire
 anomaly-gravity-feedback = Violet and crimson, blue of blue, impossibly dark yet greater than the whitest of white, a black star shines weakly at the end of it all

--- a/Resources/Locale/en-US/station-events/events/vent-critters.ftl
+++ b/Resources/Locale/en-US/station-events/events/vent-critters.ftl
@@ -15,3 +15,5 @@ station-event-space-vents-announcement = Confirmed sightings of hostile wildlife
 # Weak
 station-event-slimes-spawn-weak-announcement = Attention. A moderate influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
 station-event-spider-spawn-weak-announcement = Attention. A moderate influx of unknown life forms have been detected residing within the station's ventilation systems. Please be rid of these creatures before it begins to affect productivity.
+station-event-argocyte-vents-weak-announcement = Suspected signatures of hostile alien wildlife detected on the station. Personnel are advised to arm themselves, barricade doors, and defend themselves if necessary. Security is advised to eradicate the threat as soon as possible.
+station-event-carp-vents-weak-announcement = Suspected signatures of hostile alien wildlife detected on the station. Personnel are advised to arm themselves, barricade doors, and defend themselves if necessary. Security is advised to eradicate the threat as soon as possible.

--- a/Resources/Migrations/floofmigration.yml
+++ b/Resources/Migrations/floofmigration.yml
@@ -1,6 +1,6 @@
 # 2024-08-16 Floof Only Please message @FracturedSwords on discord if there are any merge conflicts upcoming
-SpawnMobArcticFoxSiobhan: SpawnMobArcticFoxSeb
-MobArcticFoxSiobhan: MobArcticFoxSeb
+# SpawnMobArcticFoxSiobhan: SpawnMobArcticFoxSeb
+# MobArcticFoxSiobhan: MobArcticFoxSeb
 
 # 2024-12-15: Leash now supports changing the length intrinsically
 ShortLeash: LeashBasic

--- a/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
@@ -91,6 +91,7 @@
     roller: false
     assayFeedback:
       - living-light-feedback
+  - type: Dispellable
   - type: Destructible
     thresholds:
       - trigger:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/living_light.yml
@@ -86,6 +86,11 @@
   - type: Tag
     tags:
       - FootstepSound
+  - type: Psionic
+    removable: false
+    roller: false
+    assayFeedback:
+      - living-light-feedback
   - type: Destructible
     thresholds:
       - trigger:

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -557,6 +557,9 @@
   - type: Sprite
     sprite: Objects/Decoration/Flora/flora_treeslight.rsi
     state: tree01
+  - type: Psionic
+    removable: false
+    roller: false
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -1305,7 +1305,7 @@
     - type: Icon
       sprite: Structures/Magic/forcewall.rsi
       state: forcewall
-#    - type: Dispellable
+    - type: Dispellable
     - type: Clickable #Nyano
 
 - type: entity

--- a/Resources/Prototypes/Floof/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Floof/Entities/Mobs/NPCs/slimes.yml
@@ -9,7 +9,7 @@
     color: "#FFFDFB"
   - type: Sprite
     drawdepth: Mobs
-    sprite: Floof/Mobs/Animals/elemental.rsi
+    sprite: Mobs/Aliens/elemental.rsi
     layers:
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
@@ -26,7 +26,7 @@
     color: "#45072f"
   - type: Sprite
     drawdepth: Mobs
-    sprite: Floof/Mobs/Animals/elemental.rsi
+    sprite: Mobs/Aliens/elemental.rsi
     layers:
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
@@ -43,7 +43,7 @@
     color: "#ae0072"
   - type: Sprite
     drawdepth: Mobs
-    sprite: Floof/Mobs/Animals/elemental.rsi
+    sprite: Mobs/Aliens/elemental.rsi
     layers:
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive
@@ -60,7 +60,7 @@
     color: "#c90084"
   - type: Sprite
     drawdepth: Mobs
-    sprite: Floof/Mobs/Animals/elemental.rsi
+    sprite: Mobs/Aliens/elemental.rsi
     layers:
       - map: [ "enum.DamageStateVisualLayers.Base" ]
         state: alive

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -123,13 +123,16 @@
     maximumGlimmer: 1000
     report: glimmer-event-report-signatures
 
-#- type: entity
-#  id: GlimmerWispSpawn
-#  parent: BaseGlimmerSignaturesEvent
-#  categories: [ HideSpawnMenu ]
-#  components:
-#  - type: GlimmerMobRule
-#    mobPrototype: MobGlimmerWisp
+- type: entity
+  id: GlimmerWispSpawn
+  parent: BaseGlimmerSignaturesEvent
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: GlimmerEvent
+    minimumGlimmer: 700
+    maximumGlimmer: 1000
+  - type: GlimmerMobRule
+    mobPrototype: MobGlimmerWisp
 
 - type: entity
   parent: BaseGlimmerSignaturesEvent
@@ -176,7 +179,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: GlimmerEvent
-    minimumGlimmer: 700
+    minimumGlimmer: 620
     maximumGlimmer: 900
     glimmerBurnLower: 50
     glimmerBurnUpper: 250


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Glimmer Wisps returning, Mites now have a lower minimum glimmer requirement to spawn (From 700 to 620),Localization fixes for the vent events, Luminous creatures spawned by the flora anomaly are now psionic to fall in line with the rest of the anomaly based creatures, Reagent Slime Bottom Surgery.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Glimmer Wisps have returned.
- tweak: Luminous Entities now count as a psionic creature, to match with the rest of the anomalous entities.
- tweak: Gave certain reagent slimes bottom surgery, good for them.
