### PR TITLE
Quickfixes and Tweaks

### DIFF
--- a/Content.Server/WhiteDream/BloodCult/Runes/Apocalypse/CultRuneApocalypseComponent.cs
+++ b/Content.Server/WhiteDream/BloodCult/Runes/Apocalypse/CultRuneApocalypseComponent.cs
@@ -50,7 +50,6 @@ public sealed partial class CultRuneApocalypseComponent : Component
     [DataField]
     public Dictionary<EntProtoId, int> PossibleEvents = new()
     {
-        ["ImmovableRodSpawn"] = 3,
         ["MimicVendorRule"] = 2,
         ["RatKingSpawn"] = 2,
         ["MeteorSwarm"] = 2,

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -32,7 +32,7 @@
   # TODO: salvage 5g, 3 implants and a locator for 600
   # TODO: wormhole jaunter for 750
   - id: WeaponCrusher
-    cost: 750
+    cost: 1750
   - id: WeaponProtoKineticAccelerator
     cost: 750
   # TODO: resonator for 800

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -592,18 +592,18 @@
     sounds:
       collection: Paracusia
 
-- type: entity
-  id: ImmovableRodSpawn
-  parent: BaseGameRule
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: StationEvent
-    startAnnouncement: false
-    weight: 2
-    duration: 1
-    earliestStart: 45
-    minimumPlayers: 20
-  - type: ImmovableRodRule
+# - type: entity
+#   id: ImmovableRodSpawn
+#   parent: BaseGameRule
+#   categories: [ HideSpawnMenu ]
+#   components:
+#   - type: StationEvent
+#     startAnnouncement: false
+#     weight: 2
+#     duration: 1
+#     earliestStart: 45
+#     minimumPlayers: 20
+#   - type: ImmovableRodRule
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -21,10 +21,6 @@
         - !type:CharacterTraitRequirement
           traits:
             - ShadowkinBlackeye
-  special:
-  - !type:AddComponentSpecial
-    components:
-      - type: Pacified
   afterLoadoutSpecial:
   - !type:ModifyEnvirosuitSpecial
     charges: 3 # Poor prisoners with not a lot of self-extinguishes.


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Immovable rods removal, Prisoner pacifism turned off, Crusher axes price hike.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Crusher price in the mining points shop increased following its buff.
- tweak: Prisoners' pacifism implants have been turned off, please do behave.
- remove: Immovable Rods redirected from sector.
