### PR TITLE
Edge Evac Shuttle Change

### DIFF
--- a/Resources/Prototypes/Maps/edge.yml
+++ b/Resources/Prototypes/Maps/edge.yml
@@ -9,7 +9,7 @@
       stationProto: StandardNanotrasenStation
       components:
         - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/emergency.yml
+          emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Right
         - type: StationNameSetup
           mapNameTemplate: '{0} Edge Station {1}'
           nameGenerator:

--- a/Resources/Prototypes/Maps/edge.yml
+++ b/Resources/Prototypes/Maps/edge.yml
@@ -9,7 +9,7 @@
       stationProto: StandardNanotrasenStation
       components:
         - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Right
+          emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Right.yml
         - type: StationNameSetup
           mapNameTemplate: '{0} Edge Station {1}'
           nameGenerator:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Temporary change until the NTES Vertex can be ported.
Beats the default, and the Right is unused.

---


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Fox
- tweak: Edge has a bigger evac shuttle, thank god
