### PR TITLE
Shoukou Hotfix

### DIFF
--- a/Resources/Maps/TheDen/shoukou.yml
+++ b/Resources/Maps/TheDen/shoukou.yml
@@ -163,7 +163,7 @@ entities:
           version: 6
         -3,-4:
           ind: -3,-4
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbgAAAAAAbgAAAAAAbgAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAACIAAAAAAAIAAAAAACUAAAAAAAIAAAAAADIAAAAAADIAAAAAADfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAADTwAAAAADIAAAAAAAbQAAAAAAIAAAAAACfwAAAAAAIAAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAADUAAAAAAAIAAAAAABfwAAAAAAIAAAAAAB
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbgAAAAAAbgAAAAAAbgAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAACIAAAAAAAIAAAAAACUAAAAAAAIAAAAAADIAAAAAADIAAAAAADfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAADTwAAAAADIAAAAAAAbQAAAAAAIAAAAAACfwAAAAAAIAAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAADUAAAAAAAIAAAAAABfwAAAAAAIAAAAAAB
           version: 6
         -4,-4:
           ind: -4,-4
@@ -239,7 +239,7 @@ entities:
           version: 6
         0,1:
           ind: 0,1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAXgAAAAABIQAAAAAAIQAAAAAAIQAAAAACIQAAAAACIQAAAAADIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAABXgAAAAADbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAXgAAAAAAIQAAAAACIQAAAAABIQAAAAABIQAAAAADIQAAAAADIQAAAAADIQAAAAABIQAAAAAAIQAAAAADXgAAAAABfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAXgAAAAADXgAAAAAAXgAAAAABXgAAAAABXgAAAAACXgAAAAADXgAAAAAAXgAAAAAAXgAAAAACXgAAAAACXgAAAAADfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAATgAAAAADXgAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAXgAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAUAAAAAAAbQAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAXgAAAAABIQAAAAAAIQAAAAAAIQAAAAACIQAAAAACIQAAAAADIQAAAAAAIQAAAAAAIQAAAAAAIQAAAAABXgAAAAADbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAXgAAAAAAIQAAAAACIQAAAAABIQAAAAABIQAAAAADIQAAAAADIQAAAAADIQAAAAABIQAAAAAAIQAAAAADXgAAAAABfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAXgAAAAADXgAAAAAAXgAAAAABXgAAAAABXgAAAAACXgAAAAADXgAAAAAAXgAAAAAAXgAAAAACXgAAAAACXgAAAAADfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAABQAAAAAABQAAAAAABQAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         1,-4:
           ind: 1,-4
@@ -287,7 +287,7 @@ entities:
           version: 6
         -3,-5:
           ind: -3,-5
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAABwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAABwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAABwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAABwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAA
           version: 6
         -2,-5:
           ind: -2,-5
@@ -1671,6 +1671,11 @@ entities:
             185: 11,1
         - node:
             color: '#FFFFFFFF'
+            id: FlowersBRThree
+          decals:
+            1316: 9.916114,19.891033
+        - node:
+            color: '#FFFFFFFF'
             id: Flowersbr1
           decals:
             252: 0.46875298,-52.976757
@@ -1700,6 +1705,7 @@ entities:
             id: Flowerspv2
           decals:
             466: 39,-26
+            1314: 8.028092,19.939861
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -1725,6 +1731,7 @@ entities:
             id: Flowersy2
           decals:
             464: 45,-22
+            1315: 8.939551,19.939861
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -1797,9 +1804,27 @@ entities:
             1148: -38,-48
         - node:
             color: '#FFFFFFFF'
+            id: Grassd1
+          decals:
+            1308: 8.060645,19.972412
+            1313: 9.151139,20.004965
+        - node:
+            color: '#FFFFFFFF'
             id: Grassd2
           decals:
             258: 1.0208364,-52.95591
+            1309: 8.53265,19.923584
+            1312: 8.044369,19.956137
+        - node:
+            color: '#FFFFFFFF'
+            id: Grassd3
+          decals:
+            1310: 9.265072,20.02124
+        - node:
+            color: '#FFFFFFFF'
+            id: Grasse1
+          decals:
+            1311: 9.964942,19.972412
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -3047,7 +3072,7 @@ entities:
           1,-1:
             0: 47879
           1,4:
-            0: 28671
+            0: 12287
           2,0:
             0: 65535
           2,1:
@@ -3071,7 +3096,7 @@ entities:
           3,-1:
             0: 63271
           3,4:
-            0: 26495
+            0: 10111
           4,0:
             0: 61695
           4,1:
@@ -3523,13 +3548,13 @@ entities:
             2: 3
           -10,-10:
             0: 63232
-            4: 14
+            6: 14
           -10,-12:
             0: 14
             3: 3584
           -10,-11:
-            5: 14
-            6: 3584
+            4: 14
+            5: 3584
           -10,-13:
             0: 61166
           -9,-13:
@@ -3578,7 +3603,7 @@ entities:
           -13,-13:
             2: 3874
           -11,-15:
-            2: 61440
+            2: 65516
           -11,-14:
             2: 16383
             0: 32768
@@ -3587,7 +3612,10 @@ entities:
           -10,-14:
             2: 3935
           -10,-16:
-            2: 25804
+            2: 30719
+          -10,-17:
+            2: 65294
+            0: 225
           -9,-16:
             2: 60159
           -9,-15:
@@ -3595,8 +3623,8 @@ entities:
           -9,-14:
             2: 61359
           -9,-17:
-            2: 65471
-            0: 64
+            2: 65423
+            0: 112
           -8,-16:
             2: 30583
           -8,-15:
@@ -4092,11 +4120,12 @@ entities:
           13,1:
             2: 4982
           1,5:
-            0: 4
+            0: 22391
           2,5:
-            2: 15
+            0: 7
+            2: 1792
           3,5:
-            0: 2
+            0: 22391
           4,-15:
             2: 32768
           4,-14:
@@ -4257,12 +4286,22 @@ entities:
           19,-6:
             0: 4
             2: 35016
-          -10,-17:
-            2: 3822
+          -12,-19:
+            2: 32768
+          -12,-18:
+            2: 136
+          -11,-18:
+            2: 61299
+            0: 128
+          -11,-17:
+            2: 52428
+          -10,-18:
+            0: 4400
+            2: 61128
           -9,-18:
-            2: 52974
+            2: 65535
           -9,-19:
-            2: 49152
+            2: 57344
           -8,-19:
             2: 28672
           -8,-18:
@@ -4332,21 +4371,6 @@ entities:
           temperature: 293.15
           moles:
           - 0
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 0
           - 0
           - 0
           - 6666.982
@@ -4363,6 +4387,21 @@ entities:
           moles:
           - 6666.982
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 6666.982
           - 0
           - 0
           - 0
@@ -5899,6 +5938,18 @@ entities:
     - type: Transform
       pos: 5.5,-51.5
       parent: 2
+  - uid: 13553
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,19.5
+      parent: 2
+  - uid: 13826
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,19.5
+      parent: 2
 - proto: AirlockExternalGlassAtmosphericsLocked
   entities:
   - uid: 141
@@ -6165,19 +6216,41 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 18.5,-48.5
       parent: 2
+  - uid: 16180
+    components:
+    - type: Transform
+      pos: 60.5,-50.5
+      parent: 2
+  - uid: 16181
+    components:
+    - type: Transform
+      pos: 58.5,-50.5
+      parent: 2
 - proto: AirlockExternalGlassShuttleArrivals
   entities:
-  - uid: 168
+  - uid: 16197
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,20.5
+      pos: 6.5,23.5
       parent: 2
-  - uid: 6483
+  - uid: 16198
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 14.5,20.5
+      pos: 4.5,23.5
+      parent: 2
+  - uid: 16199
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,23.5
+      parent: 2
+  - uid: 16200
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,23.5
       parent: 2
 - proto: AirlockExternalGlassShuttleEmergencyLocked
   entities:
@@ -6251,30 +6324,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,-43.5
-      parent: 2
-  - uid: 2039
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -38.5,-65.5
-      parent: 2
-  - uid: 9440
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -38.5,-67.5
-      parent: 2
-- proto: AirlockExternalGlassShuttleShipyard
-  entities:
-  - uid: 173
-    components:
-    - type: Transform
-      pos: 60.5,-50.5
-      parent: 2
-  - uid: 196
-    components:
-    - type: Transform
-      pos: 58.5,-50.5
       parent: 2
 - proto: AirlockFreezerHydroponicsLocked
   entities:
@@ -6388,7 +6437,7 @@ entities:
       pos: 24.5,16.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -5746.3276
+      secondsUntilStateChange: -11383.509
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -6808,7 +6857,7 @@ entities:
       pos: 15.5,8.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -19404.943
+      secondsUntilStateChange: -25042.125
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -7280,7 +7329,7 @@ entities:
       pos: 18.5,-7.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -246119.12
+      secondsUntilStateChange: -251756.31
       state: Opening
     - type: DeviceLinkSink
       links:
@@ -7389,6 +7438,23 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 22.5,1.5
+      parent: 2
+- proto: AirlockShuttle
+  entities:
+  - uid: 9828
+    components:
+    - type: Transform
+      pos: -40.5,-70.5
+      parent: 2
+  - uid: 9857
+    components:
+    - type: Transform
+      pos: -39.5,-70.5
+      parent: 2
+  - uid: 10293
+    components:
+    - type: Transform
+      pos: -38.5,-70.5
       parent: 2
 - proto: AirlockTheatreLocked
   entities:
@@ -8234,12 +8300,6 @@ entities:
     - type: Transform
       pos: 6.5,-55.5
       parent: 2
-  - uid: 416
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,20.5
-      parent: 2
   - uid: 417
     components:
     - type: Transform
@@ -8284,18 +8344,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -13.5,-2.5
       parent: 2
-  - uid: 15564
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -38.5,-65.5
-      parent: 2
-  - uid: 15661
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -38.5,-67.5
-      parent: 2
   - uid: 15802
     components:
     - type: Transform
@@ -8307,6 +8355,45 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -61.5,3.5
+      parent: 2
+  - uid: 16177
+    components:
+    - type: Transform
+      pos: -40.5,-70.5
+      parent: 2
+  - uid: 16178
+    components:
+    - type: Transform
+      pos: -39.5,-70.5
+      parent: 2
+  - uid: 16179
+    components:
+    - type: Transform
+      pos: -38.5,-70.5
+      parent: 2
+  - uid: 16225
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,23.5
+      parent: 2
+  - uid: 16226
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,23.5
+      parent: 2
+  - uid: 16227
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,23.5
+      parent: 2
+  - uid: 16228
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,23.5
       parent: 2
 - proto: AtmosFixBlockerMarker
   entities:
@@ -9344,6 +9431,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -59.5,7.5
       parent: 2
+  - uid: 16251
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,18.5
+      parent: 2
 - proto: BenchSteelMiddle
   entities:
   - uid: 593
@@ -9351,17 +9444,18 @@ entities:
     - type: Transform
       pos: 9.5,18.5
       parent: 2
-  - uid: 4895
+- proto: BenchSteelRight
+  entities:
+  - uid: 595
     components:
     - type: Transform
       pos: 10.5,18.5
       parent: 2
-- proto: BenchSteelRight
-  entities:
-  - uid: 534
+  - uid: 9736
     components:
     - type: Transform
-      pos: 11.5,18.5
+      rot: -1.5707963267948966 rad
+      pos: 14.5,17.5
       parent: 2
   - uid: 15898
     components:
@@ -10293,6 +10387,16 @@ entities:
       parent: 2
 - proto: CableApcExtension
   entities:
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -37.5,-66.5
+      parent: 2
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -39.5,-66.5
+      parent: 2
   - uid: 172
     components:
     - type: Transform
@@ -10307,6 +10411,11 @@ entities:
     components:
     - type: Transform
       pos: 20.5,-36.5
+      parent: 2
+  - uid: 260
+    components:
+    - type: Transform
+      pos: -39.5,-67.5
       parent: 2
   - uid: 424
     components:
@@ -14329,11 +14438,6 @@ entities:
     components:
     - type: Transform
       pos: 3.5,14.5
-      parent: 2
-  - uid: 1510
-    components:
-    - type: Transform
-      pos: 6.5,19.5
       parent: 2
   - uid: 1511
     components:
@@ -20600,6 +20704,16 @@ entities:
     - type: Transform
       pos: -33.5,-66.5
       parent: 2
+  - uid: 11916
+    components:
+    - type: Transform
+      pos: -38.5,-66.5
+      parent: 2
+  - uid: 11924
+    components:
+    - type: Transform
+      pos: -36.5,-66.5
+      parent: 2
   - uid: 13920
     components:
     - type: Transform
@@ -21055,31 +21169,6 @@ entities:
     - type: Transform
       pos: -39.5,7.5
       parent: 2
-  - uid: 15556
-    components:
-    - type: Transform
-      pos: -36.5,-66.5
-      parent: 2
-  - uid: 15560
-    components:
-    - type: Transform
-      pos: -35.5,-66.5
-      parent: 2
-  - uid: 15561
-    components:
-    - type: Transform
-      pos: -37.5,-66.5
-      parent: 2
-  - uid: 15562
-    components:
-    - type: Transform
-      pos: -37.5,-65.5
-      parent: 2
-  - uid: 15563
-    components:
-    - type: Transform
-      pos: -37.5,-67.5
-      parent: 2
   - uid: 15636
     components:
     - type: Transform
@@ -21209,6 +21298,106 @@ entities:
     components:
     - type: Transform
       pos: 35.5,-45.5
+      parent: 2
+  - uid: 16171
+    components:
+    - type: Transform
+      pos: -35.5,-66.5
+      parent: 2
+  - uid: 16172
+    components:
+    - type: Transform
+      pos: -39.5,-68.5
+      parent: 2
+  - uid: 16173
+    components:
+    - type: Transform
+      pos: -39.5,-69.5
+      parent: 2
+  - uid: 16174
+    components:
+    - type: Transform
+      pos: -39.5,-70.5
+      parent: 2
+  - uid: 16175
+    components:
+    - type: Transform
+      pos: -38.5,-70.5
+      parent: 2
+  - uid: 16176
+    components:
+    - type: Transform
+      pos: -40.5,-70.5
+      parent: 2
+  - uid: 16211
+    components:
+    - type: Transform
+      pos: 5.5,18.5
+      parent: 2
+  - uid: 16212
+    components:
+    - type: Transform
+      pos: 5.5,19.5
+      parent: 2
+  - uid: 16213
+    components:
+    - type: Transform
+      pos: 5.5,20.5
+      parent: 2
+  - uid: 16214
+    components:
+    - type: Transform
+      pos: 5.5,21.5
+      parent: 2
+  - uid: 16215
+    components:
+    - type: Transform
+      pos: 6.5,21.5
+      parent: 2
+  - uid: 16216
+    components:
+    - type: Transform
+      pos: 6.5,22.5
+      parent: 2
+  - uid: 16217
+    components:
+    - type: Transform
+      pos: 4.5,21.5
+      parent: 2
+  - uid: 16218
+    components:
+    - type: Transform
+      pos: 4.5,22.5
+      parent: 2
+  - uid: 16219
+    components:
+    - type: Transform
+      pos: 13.5,20.5
+      parent: 2
+  - uid: 16220
+    components:
+    - type: Transform
+      pos: 13.5,21.5
+      parent: 2
+  - uid: 16221
+    components:
+    - type: Transform
+      pos: 14.5,21.5
+      parent: 2
+  - uid: 16222
+    components:
+    - type: Transform
+      pos: 14.5,22.5
+      parent: 2
+  - uid: 16223
+    components:
+    - type: Transform
+      pos: 12.5,21.5
+      parent: 2
+  - uid: 16224
+    components:
+    - type: Transform
+      pos: 12.5,22.5
       parent: 2
 - proto: CableApcStack1
   entities:
@@ -30240,15 +30429,20 @@ entities:
       parent: 2
 - proto: Catwalk
   entities:
-  - uid: 188
+  - uid: 1510
     components:
     - type: Transform
-      pos: -34.5,-65.5
+      pos: 6.5,22.5
       parent: 2
   - uid: 3002
     components:
     - type: Transform
       pos: 20.5,-48.5
+      parent: 2
+  - uid: 3383
+    components:
+    - type: Transform
+      pos: -40.5,-66.5
       parent: 2
   - uid: 4220
     components:
@@ -32915,11 +33109,31 @@ entities:
     - type: Transform
       pos: 32.5,9.5
       parent: 2
+  - uid: 4895
+    components:
+    - type: Transform
+      pos: -40.5,-65.5
+      parent: 2
+  - uid: 6483
+    components:
+    - type: Transform
+      pos: -40.5,-68.5
+      parent: 2
   - uid: 6618
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -30.5,-69.5
+      parent: 2
+  - uid: 6835
+    components:
+    - type: Transform
+      pos: -40.5,-69.5
+      parent: 2
+  - uid: 6836
+    components:
+    - type: Transform
+      pos: -40.5,-67.5
       parent: 2
   - uid: 6962
     components:
@@ -32932,10 +33146,45 @@ entities:
     - type: Transform
       pos: -53.5,-26.5
       parent: 2
+  - uid: 8397
+    components:
+    - type: Transform
+      pos: -38.5,-65.5
+      parent: 2
+  - uid: 8961
+    components:
+    - type: Transform
+      pos: -35.5,-65.5
+      parent: 2
   - uid: 9438
     components:
     - type: Transform
       pos: -33.5,-65.5
+      parent: 2
+  - uid: 9440
+    components:
+    - type: Transform
+      pos: -36.5,-65.5
+      parent: 2
+  - uid: 9588
+    components:
+    - type: Transform
+      pos: -37.5,-65.5
+      parent: 2
+  - uid: 9705
+    components:
+    - type: Transform
+      pos: -34.5,-65.5
+      parent: 2
+  - uid: 9707
+    components:
+    - type: Transform
+      pos: -39.5,-65.5
+      parent: 2
+  - uid: 9747
+    components:
+    - type: Transform
+      pos: -36.5,-67.5
       parent: 2
   - uid: 9796
     components:
@@ -32951,6 +33200,11 @@ entities:
     components:
     - type: Transform
       pos: 37.5,-50.5
+      parent: 2
+  - uid: 10276
+    components:
+    - type: Transform
+      pos: -35.5,-67.5
       parent: 2
   - uid: 10376
     components:
@@ -32973,6 +33227,11 @@ entities:
     - type: Transform
       pos: 37.5,-53.5
       parent: 2
+  - uid: 10453
+    components:
+    - type: Transform
+      pos: -34.5,-67.5
+      parent: 2
   - uid: 11125
     components:
     - type: Transform
@@ -32983,51 +33242,26 @@ entities:
     - type: Transform
       pos: 21.5,-53.5
       parent: 2
+  - uid: 11416
+    components:
+    - type: Transform
+      pos: 4.5,22.5
+      parent: 2
   - uid: 11472
     components:
     - type: Transform
-      pos: -35.5,-65.5
-      parent: 2
-  - uid: 11505
-    components:
-    - type: Transform
-      pos: -36.5,-65.5
-      parent: 2
-  - uid: 11506
-    components:
-    - type: Transform
-      pos: -37.5,-65.5
+      pos: -37.5,-67.5
       parent: 2
   - uid: 11894
     components:
     - type: Transform
       pos: 21.5,-54.5
       parent: 2
-  - uid: 11916
-    components:
-    - type: Transform
-      pos: -37.5,-67.5
-      parent: 2
-  - uid: 11923
-    components:
-    - type: Transform
-      pos: -36.5,-67.5
-      parent: 2
-  - uid: 11924
-    components:
-    - type: Transform
-      pos: -35.5,-67.5
-      parent: 2
   - uid: 13014
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -34.5,-30.5
-      parent: 2
-  - uid: 13553
-    components:
-    - type: Transform
-      pos: -34.5,-67.5
       parent: 2
   - uid: 13554
     components:
@@ -33044,6 +33278,16 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 50.5,-28.5
+      parent: 2
+  - uid: 15561
+    components:
+    - type: Transform
+      pos: -38.5,-68.5
+      parent: 2
+  - uid: 15562
+    components:
+    - type: Transform
+      pos: -38.5,-69.5
       parent: 2
   - uid: 15635
     components:
@@ -33107,14 +33351,63 @@ entities:
       rot: 3.141592653589793 rad
       pos: -33.5,-46.5
       parent: 2
-- proto: Chair
-  entities:
-  - uid: 592
+  - uid: 16165
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,17.5
+      pos: -38.5,-67.5
       parent: 2
+  - uid: 16183
+    components:
+    - type: Transform
+      pos: 5.5,20.5
+      parent: 2
+  - uid: 16184
+    components:
+    - type: Transform
+      pos: 5.5,21.5
+      parent: 2
+  - uid: 16185
+    components:
+    - type: Transform
+      pos: 6.5,21.5
+      parent: 2
+  - uid: 16186
+    components:
+    - type: Transform
+      pos: 4.5,21.5
+      parent: 2
+  - uid: 16187
+    components:
+    - type: Transform
+      pos: 13.5,20.5
+      parent: 2
+  - uid: 16188
+    components:
+    - type: Transform
+      pos: 13.5,21.5
+      parent: 2
+  - uid: 16189
+    components:
+    - type: Transform
+      pos: 12.5,21.5
+      parent: 2
+  - uid: 16190
+    components:
+    - type: Transform
+      pos: 14.5,21.5
+      parent: 2
+  - uid: 16191
+    components:
+    - type: Transform
+      pos: 12.5,22.5
+      parent: 2
+  - uid: 16192
+    components:
+    - type: Transform
+      pos: 14.5,22.5
+      parent: 2
+- proto: Chair
+  entities:
   - uid: 4758
     components:
     - type: Transform
@@ -34978,15 +35271,15 @@ entities:
     - type: Transform
       pos: -47.5,-22.5
       parent: 2
-  - uid: 6836
-    components:
-    - type: Transform
-      pos: 12.5,18.5
-      parent: 2
   - uid: 6869
     components:
     - type: Transform
       pos: 31.5,13.5
+      parent: 2
+  - uid: 9745
+    components:
+    - type: Transform
+      pos: 11.5,18.5
       parent: 2
   - uid: 15787
     components:
@@ -45838,7 +46131,7 @@ entities:
       pos: 24.5,16.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -5752.6274
+      secondsUntilStateChange: -11389.809
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -46282,12 +46575,24 @@ entities:
     - type: Transform
       pos: 1.4223047,-54.51645
       parent: 2
-- proto: FoodMealGrilledCheese
-  entities:
-  - uid: 595
+  - uid: 16241
     components:
     - type: Transform
-      pos: -38.811848,-70.25767
+      pos: 9.462598,22.509672
+      parent: 2
+- proto: FoodMealBearsteak
+  entities:
+  - uid: 16242
+    components:
+    - type: Transform
+      pos: 9.498422,20.324041
+      parent: 2
+- proto: FoodMealGrilledCheese
+  entities:
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -35.554573,-70.48586
       parent: 2
 - proto: FoodMealNachos
   entities:
@@ -46334,13 +46639,6 @@ entities:
     components:
     - type: Transform
       pos: -1.0944183,-17.486998
-      parent: 2
-- proto: FoodPoppy
-  entities:
-  - uid: 16065
-    components:
-    - type: Transform
-      pos: 9.897989,20.322937
       parent: 2
 - proto: FoodPotato
   entities:
@@ -67071,29 +67369,22 @@ entities:
       parent: 2
 - proto: Grille
   entities:
-  - uid: 158
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -35.5,-68.5
-      parent: 2
   - uid: 231
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 13.5,-49.5
       parent: 2
-  - uid: 260
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.5,20.5
-      parent: 2
   - uid: 2035
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,-49.5
+      parent: 2
+  - uid: 2039
+    components:
+    - type: Transform
+      pos: 6.5,19.5
       parent: 2
   - uid: 2563
     components:
@@ -69180,6 +69471,12 @@ entities:
     - type: Transform
       pos: -63.5,-26.5
       parent: 2
+  - uid: 9589
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -43.5,-71.5
+      parent: 2
   - uid: 9597
     components:
     - type: Transform
@@ -69677,11 +69974,6 @@ entities:
     - type: Transform
       pos: -57.5,-36.5
       parent: 2
-  - uid: 9696
-    components:
-    - type: Transform
-      pos: 5.5,20.5
-      parent: 2
   - uid: 9697
     components:
     - type: Transform
@@ -69721,11 +70013,6 @@ entities:
     components:
     - type: Transform
       pos: -63.5,-7.5
-      parent: 2
-  - uid: 9705
-    components:
-    - type: Transform
-      pos: -39.5,-59.5
       parent: 2
   - uid: 9708
     components:
@@ -69863,11 +70150,6 @@ entities:
     - type: Transform
       pos: 40.5,-4.5
       parent: 2
-  - uid: 9736
-    components:
-    - type: Transform
-      pos: -34.5,-64.5
-      parent: 2
   - uid: 9737
     components:
     - type: Transform
@@ -69908,20 +70190,10 @@ entities:
     - type: Transform
       pos: -65.5,-25.5
       parent: 2
-  - uid: 9745
-    components:
-    - type: Transform
-      pos: -35.5,-64.5
-      parent: 2
   - uid: 9746
     components:
     - type: Transform
       pos: -65.5,-26.5
-      parent: 2
-  - uid: 9747
-    components:
-    - type: Transform
-      pos: -36.5,-63.5
       parent: 2
   - uid: 9748
     components:
@@ -69932,11 +70204,6 @@ entities:
     components:
     - type: Transform
       pos: -55.5,-36.5
-      parent: 2
-  - uid: 9750
-    components:
-    - type: Transform
-      pos: -37.5,-62.5
       parent: 2
   - uid: 9751
     components:
@@ -70014,16 +70281,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -53.5,-46.5
-      parent: 2
-  - uid: 9766
-    components:
-    - type: Transform
-      pos: -38.5,-60.5
-      parent: 2
-  - uid: 9767
-    components:
-    - type: Transform
-      pos: -37.5,-61.5
       parent: 2
   - uid: 9768
     components:
@@ -70400,11 +70657,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -61.5,5.5
       parent: 2
-  - uid: 10254
-    components:
-    - type: Transform
-      pos: 11.5,19.5
-      parent: 2
   - uid: 10281
     components:
     - type: Transform
@@ -70494,6 +70746,17 @@ entities:
     components:
     - type: Transform
       pos: 37.5,-5.5
+      parent: 2
+  - uid: 11923
+    components:
+    - type: Transform
+      pos: 4.5,19.5
+      parent: 2
+  - uid: 13841
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,23.5
       parent: 2
   - uid: 14486
     components:
@@ -70811,6 +71074,11 @@ entities:
     - type: Transform
       pos: -61.5,-41.5
       parent: 2
+  - uid: 15560
+    components:
+    - type: Transform
+      pos: 12.5,19.5
+      parent: 2
   - uid: 15662
     components:
     - type: Transform
@@ -71005,18 +71273,42 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -42.5,-58.5
       parent: 2
-- proto: GrilleBroken
-  entities:
-  - uid: 8397
+  - uid: 16182
+    components:
+    - type: Transform
+      pos: 14.5,19.5
+      parent: 2
+  - uid: 16201
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -36.5,-70.5
+      pos: 13.5,23.5
       parent: 2
-  - uid: 8961
+  - uid: 16229
     components:
     - type: Transform
-      pos: -36.5,-70.5
+      rot: 3.141592653589793 rad
+      pos: 8.5,21.5
+      parent: 2
+  - uid: 16230
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,21.5
+      parent: 2
+  - uid: 16231
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,21.5
+      parent: 2
+- proto: GrilleBroken
+  entities:
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -44.5,-71.5
       parent: 2
   - uid: 9565
     components:
@@ -71141,12 +71433,6 @@ entities:
     components:
     - type: Transform
       pos: 19.5,-52.5
-      parent: 2
-  - uid: 16165
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -34.5,-68.5
       parent: 2
   - uid: 16168
     components:
@@ -71860,6 +72146,13 @@ entities:
     components:
     - type: Transform
       pos: 27.5,13.5
+      parent: 2
+- proto: HolopadGeneralShipyardDock
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 59.5,-45.5
       parent: 2
 - proto: HolopadGeneralTools
   entities:
@@ -74099,6 +74392,16 @@ entities:
     - type: Transform
       pos: 19.455956,1.5228162
       parent: 2
+- proto: Memorial
+  entities:
+  - uid: 16237
+    components:
+    - type: MetaData
+      desc: You can burn so bright you save this land, but there's no telling what fate lies for you afterwards. All you have to do is keep going.
+      name: In Honor Of The Burnt Bird Protection Program
+    - type: Transform
+      pos: 9.5,21.5
+      parent: 2
 - proto: MetempsychoticMachine
   entities:
   - uid: 10189
@@ -74995,28 +75298,25 @@ entities:
     - type: Transform
       pos: 37.943455,-31.413465
       parent: 2
-- proto: PaperCargoBountyManifest
+- proto: PaperCargoInvoice
   entities:
-  - uid: 9802
+  - uid: 188
     components:
     - type: Transform
-      pos: -39.293842,-70.52365
+      rot: -1.5707963267948966 rad
+      pos: -35.404346,-70.22163
       parent: 2
     - type: Paper
       stampState: paper_stamp-signature
       stampedBy:
       - stampedColor: '#2F4F4FFF'
-        stampedName: Franky Jimtim
-      content: >-
-        Hey. The arrivals shuttle used to dock here, and that's super annoying.
+        stampedName: Zeyn Moreaux
+      content: >+
+        I FIXED THIS SHITASS CARGO DOCK SO THE PATHFINDER DOCKS TO IT. HAHAHAHAHAHAHAHAHAHAHAHAHAHA!! MARVEL AT MY BEAUTIFUL ARCHITECTURAL PROWESS. NOW, IT IS IMMUNE. IT FITS NOTHING ELSE. 
 
 
-        So, cut this lattice if you wanna park your shuttle here. I built it so that the arrivals shuttle doesn't dock and everyone goes to station like they should.
+        Thank you to my beautiful salv team for helping this happen, and CC for not obliterating it and approving the construction. Love you guys. <3
 
-
-        Signed,
-
-        Frank of the CC Station Design Team
 - proto: PaperCNCSheet
   entities:
   - uid: 10318
@@ -75578,6 +75878,16 @@ entities:
     - type: Transform
       pos: 34.720486,17.9614
       parent: 2
+- proto: PlushieCatBlack
+  entities:
+  - uid: 16244
+    components:
+    - type: MetaData
+      desc: A dark cat plushie that almost blends in with the shadows around it. You feel like it's the monster in your closet.
+      name: dark cat plushie
+    - type: Transform
+      pos: 8.369348,20.812155
+      parent: 2
 - proto: PlushieCatTabby
   entities:
   - uid: 6863
@@ -75594,6 +75904,16 @@ entities:
       name: Goddess
     - type: Transform
       pos: 34.25009,17.956093
+      parent: 2
+- proto: PlushieDeer
+  entities:
+  - uid: 16243
+    components:
+    - type: MetaData
+      desc: A space-themed deer plushie. Reminds you of one of those old space murals you might've seen at the spaceport.
+      name: space deer plushie
+    - type: Transform
+      pos: 8.931848,20.35903
       parent: 2
 - proto: PlushieGhost
   entities:
@@ -75634,6 +75954,16 @@ entities:
       name: captain kenway
     - type: Transform
       pos: -56.338932,10.469566
+      parent: 2
+- proto: PlushieIpc
+  entities:
+  - uid: 16245
+    components:
+    - type: MetaData
+      desc: This looks too real to be a plushie. It is almost worrying.
+      name: hyper-realistic ipc plushie
+    - type: Transform
+      pos: 10.009973,20.343405
       parent: 2
 - proto: PlushieLamp
   entities:
@@ -75716,6 +76046,16 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.653599,10.398014
+      parent: 2
+- proto: PlushieOrangeFox
+  entities:
+  - uid: 10254
+    components:
+    - type: MetaData
+      desc: A plushie of the endangered species, Refarx! Looks chewed on.
+      name: refarx plushie
+    - type: Transform
+      pos: 10.463098,20.60903
       parent: 2
 - proto: PlushiePenguin
   entities:
@@ -76355,11 +76695,6 @@ entities:
       parent: 2
 - proto: PosterMapShoukou
   entities:
-  - uid: 9588
-    components:
-    - type: Transform
-      pos: 12.5,19.5
-      parent: 2
   - uid: 10440
     components:
     - type: Transform
@@ -76370,6 +76705,11 @@ entities:
     - type: Transform
       pos: 30.5,14.5
       parent: 2
+  - uid: 11505
+    components:
+    - type: Transform
+      pos: 11.5,19.5
+      parent: 2
   - uid: 15016
     components:
     - type: Transform
@@ -76377,11 +76717,6 @@ entities:
       parent: 2
 - proto: PottedPlant10
   entities:
-  - uid: 9857
-    components:
-    - type: Transform
-      pos: 13.5,19.5
-      parent: 2
   - uid: 10444
     components:
     - type: Transform
@@ -76426,11 +76761,6 @@ entities:
     components:
     - type: Transform
       pos: -5.5,-2.5
-      parent: 2
-  - uid: 10453
-    components:
-    - type: Transform
-      pos: 5.5,19.5
       parent: 2
   - uid: 10454
     components:
@@ -76486,6 +76816,26 @@ entities:
     components:
     - type: Transform
       pos: 15.5,-47.5
+      parent: 2
+  - uid: 16246
+    components:
+    - type: Transform
+      pos: 6.5,18.5
+      parent: 2
+  - uid: 16247
+    components:
+    - type: Transform
+      pos: 12.5,18.5
+      parent: 2
+  - uid: 16248
+    components:
+    - type: Transform
+      pos: 13.5,22.5
+      parent: 2
+  - uid: 16249
+    components:
+    - type: Transform
+      pos: 5.5,22.5
       parent: 2
 - proto: PottedPlant22
   entities:
@@ -76838,6 +77188,11 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -33.5,-69.5
+      parent: 2
+  - uid: 11461
+    components:
+    - type: Transform
+      pos: -36.5,-66.5
       parent: 2
 - proto: Poweredlight
   entities:
@@ -77919,6 +78274,18 @@ entities:
     components:
     - type: Transform
       pos: 32.5,-42.5
+      parent: 2
+  - uid: 16235
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,21.5
+      parent: 2
+  - uid: 16236
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,21.5
       parent: 2
 - proto: PoweredlightBlue
   entities:
@@ -80501,11 +80868,6 @@ entities:
     - type: Transform
       pos: -43.5,-56.5
       parent: 2
-  - uid: 9707
-    components:
-    - type: Transform
-      pos: -36.5,-69.5
-      parent: 2
   - uid: 9856
     components:
     - type: Transform
@@ -80676,6 +81038,21 @@ entities:
     components:
     - type: Transform
       pos: -61.5,-50.5
+      parent: 2
+  - uid: 11454
+    components:
+    - type: Transform
+      pos: -42.5,-70.5
+      parent: 2
+  - uid: 11459
+    components:
+    - type: Transform
+      pos: -36.5,-70.5
+      parent: 2
+  - uid: 11556
+    components:
+    - type: Transform
+      pos: -42.5,-71.5
       parent: 2
   - uid: 14883
     components:
@@ -81052,22 +81429,10 @@ entities:
     - type: Transform
       pos: -58.5,5.5
       parent: 2
-  - uid: 9878
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.5,20.5
-      parent: 2
   - uid: 10170
     components:
     - type: Transform
       pos: 58.5,-48.5
-      parent: 2
-  - uid: 10293
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,19.5
       parent: 2
   - uid: 10867
     components:
@@ -82104,11 +82469,6 @@ entities:
     - type: Transform
       pos: -34.5,-51.5
       parent: 2
-  - uid: 11416
-    components:
-    - type: Transform
-      pos: 5.5,20.5
-      parent: 2
   - uid: 11417
     components:
     - type: Transform
@@ -82290,11 +82650,6 @@ entities:
     - type: Transform
       pos: 51.5,-2.5
       parent: 2
-  - uid: 11454
-    components:
-    - type: Transform
-      pos: 9.5,19.5
-      parent: 2
   - uid: 11455
     components:
     - type: Transform
@@ -82315,20 +82670,10 @@ entities:
     - type: Transform
       pos: 3.5,17.5
       parent: 2
-  - uid: 11459
-    components:
-    - type: Transform
-      pos: 10.5,19.5
-      parent: 2
   - uid: 11460
     components:
     - type: Transform
       pos: -1.5,15.5
-      parent: 2
-  - uid: 11461
-    components:
-    - type: Transform
-      pos: 8.5,19.5
       parent: 2
   - uid: 11462
     components:
@@ -82641,6 +82986,60 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -61.5,6.5
       parent: 2
+  - uid: 16202
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,19.5
+      parent: 2
+  - uid: 16203
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,19.5
+      parent: 2
+  - uid: 16204
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,23.5
+      parent: 2
+  - uid: 16205
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,19.5
+      parent: 2
+  - uid: 16206
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,19.5
+      parent: 2
+  - uid: 16207
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,23.5
+      parent: 2
+  - uid: 16232
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,21.5
+      parent: 2
+  - uid: 16233
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,21.5
+      parent: 2
+  - uid: 16234
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,21.5
+      parent: 2
 - proto: ResearchAndDevelopmentServer
   entities:
   - uid: 11530
@@ -82775,12 +83174,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -4.5,-50.5
       parent: 2
-  - uid: 11556
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,19.5
-      parent: 2
   - uid: 11557
     components:
     - type: Transform
@@ -82821,6 +83214,11 @@ entities:
     components:
     - type: Transform
       pos: 15.5,19.5
+      parent: 2
+  - uid: 16250
+    components:
+    - type: Transform
+      pos: 3.5,19.5
       parent: 2
 - proto: Screwdriver
   entities:
@@ -86505,11 +86903,6 @@ entities:
       parent: 2
 - proto: SpawnPointLatejoin
   entities:
-  - uid: 9589
-    components:
-    - type: Transform
-      pos: 11.5,18.5
-      parent: 2
   - uid: 12003
     components:
     - type: Transform
@@ -89412,15 +89805,13 @@ entities:
       id: Disposals
 - proto: SurveillanceCameraSupply
   entities:
-  - uid: 11507
+  - uid: 9696
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -37.5,-66.5
+      pos: -38.5,-66.5
       parent: 2
     - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraSupply
       nameSet: True
       id: Salvage Dock
   - uid: 12025
@@ -93192,15 +93583,20 @@ entities:
       parent: 2
 - proto: WallReinforced
   entities:
+  - uid: 416
+    components:
+    - type: Transform
+      pos: 3.5,20.5
+      parent: 2
+  - uid: 534
+    components:
+    - type: Transform
+      pos: -37.5,-70.5
+      parent: 2
   - uid: 2037
     components:
     - type: Transform
       pos: 18.5,-49.5
-      parent: 2
-  - uid: 3383
-    components:
-    - type: Transform
-      pos: -38.5,-66.5
       parent: 2
   - uid: 4153
     components:
@@ -93282,12 +93678,6 @@ entities:
     - type: Transform
       pos: 48.5,-36.5
       parent: 2
-  - uid: 6835
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,19.5
-      parent: 2
   - uid: 6840
     components:
     - type: Transform
@@ -93340,6 +93730,21 @@ entities:
     - type: Transform
       pos: 34.5,-43.5
       parent: 2
+  - uid: 9750
+    components:
+    - type: Transform
+      pos: 11.5,22.5
+      parent: 2
+  - uid: 9766
+    components:
+    - type: Transform
+      pos: -39.5,-66.5
+      parent: 2
+  - uid: 9767
+    components:
+    - type: Transform
+      pos: 11.5,21.5
+      parent: 2
   - uid: 9784
     components:
     - type: Transform
@@ -93370,6 +93775,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 61.5,-41.5
       parent: 2
+  - uid: 9802
+    components:
+    - type: Transform
+      pos: 3.5,22.5
+      parent: 2
   - uid: 9871
     components:
     - type: Transform
@@ -93381,6 +93791,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 73.5,-29.5
+      parent: 2
+  - uid: 9878
+    components:
+    - type: Transform
+      pos: -41.5,-70.5
       parent: 2
   - uid: 9884
     components:
@@ -93420,12 +93835,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -18.5,-36.5
-      parent: 2
-  - uid: 10276
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,20.5
       parent: 2
   - uid: 10328
     components:
@@ -93548,6 +93957,16 @@ entities:
     components:
     - type: Transform
       pos: 10.5,-30.5
+      parent: 2
+  - uid: 11506
+    components:
+    - type: Transform
+      pos: 11.5,20.5
+      parent: 2
+  - uid: 11507
+    components:
+    - type: Transform
+      pos: 3.5,21.5
       parent: 2
   - uid: 12841
     components:
@@ -98387,11 +98806,6 @@ entities:
     - type: Transform
       pos: 51.5,-5.5
       parent: 2
-  - uid: 13826
-    components:
-    - type: Transform
-      pos: 4.5,19.5
-      parent: 2
   - uid: 13828
     components:
     - type: Transform
@@ -98457,11 +98871,6 @@ entities:
     components:
     - type: Transform
       pos: 25.5,-39.5
-      parent: 2
-  - uid: 13841
-    components:
-    - type: Transform
-      pos: 4.5,20.5
       parent: 2
   - uid: 13842
     components:
@@ -99499,6 +99908,26 @@ entities:
     - type: Transform
       pos: 40.5,-5.5
       parent: 2
+  - uid: 15556
+    components:
+    - type: Transform
+      pos: 7.5,22.5
+      parent: 2
+  - uid: 15563
+    components:
+    - type: Transform
+      pos: 15.5,22.5
+      parent: 2
+  - uid: 15564
+    components:
+    - type: Transform
+      pos: 15.5,21.5
+      parent: 2
+  - uid: 15661
+    components:
+    - type: Transform
+      pos: 7.5,21.5
+      parent: 2
   - uid: 15803
     components:
     - type: Transform
@@ -99526,6 +99955,31 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -60.5,2.5
+      parent: 2
+  - uid: 16065
+    components:
+    - type: Transform
+      pos: 11.5,19.5
+      parent: 2
+  - uid: 16193
+    components:
+    - type: Transform
+      pos: 3.5,23.5
+      parent: 2
+  - uid: 16194
+    components:
+    - type: Transform
+      pos: 7.5,23.5
+      parent: 2
+  - uid: 16195
+    components:
+    - type: Transform
+      pos: 11.5,23.5
+      parent: 2
+  - uid: 16196
+    components:
+    - type: Transform
+      pos: 15.5,23.5
       parent: 2
 - proto: WallReinforcedDiagonal
   entities:
@@ -103211,6 +103665,23 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,-39.5
       parent: 2
+  - uid: 16208
+    components:
+    - type: Transform
+      pos: 8.5,19.5
+      parent: 2
+  - uid: 16209
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,19.5
+      parent: 2
+  - uid: 16210
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,19.5
+      parent: 2
 - proto: WindowDirectional
   entities:
   - uid: 14600
@@ -103528,6 +103999,21 @@ entities:
     - type: Transform
       pos: 39.5,0.5
       parent: 2
+  - uid: 16238
+    components:
+    - type: Transform
+      pos: 10.5,22.5
+      parent: 2
+  - uid: 16239
+    components:
+    - type: Transform
+      pos: 8.5,22.5
+      parent: 2
+  - uid: 16240
+    components:
+    - type: Transform
+      pos: 9.5,22.5
+      parent: 2
 - proto: WindowTintedDirectional
   entities:
   - uid: 14641
@@ -103544,12 +104030,6 @@ entities:
       parent: 2
 - proto: Wirecutter
   entities:
-  - uid: 9828
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -39.714306,-70.42871
-      parent: 2
   - uid: 14643
     components:
     - type: Transform


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Mono finally fixes the Shoukou docks and makes the arrivals identical to evac, makes a decent pathfinder parking spot, and nukes the docks at the shipyard area, replacing them with external doors with this one weird trick. Runs locally.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/a6d32759-dadd-402b-9966-93bf7332d8e7)
It is not actually named Evil Fucking Fox.
![image](https://github.com/user-attachments/assets/ee9e75d7-2925-4ae8-a1e9-27cd7dcf673f)
Reference image for how the pathfinder parks which was used for the shape of the one that docks. I hope the salami lid fits.

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Tweaked all of Shoukou's docks so that arrivals only goes to evac and arrivals in theory. Also, makes sure the salami lid of the Pathfinder fits, in theory.
- remove: Removed Pluey.
