### PR TITLE
Corpsman Glasses Fix

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/Eyes/glasses.yml
@@ -37,11 +37,18 @@
   - type: Construction
     graph: GlassesCorpsHUD
     node: glassesCorps
+  - type: ShowHealthBars
+    damageContainers:
+    - Biological
+  - type: ShowHealthIcons
+    damageContainers:
+    - Biological
   - type: Tag
     tags:
     - HamsterWearable
     - WhitelistChameleon
     - SecDogWearable
+    - HudMedical
   - type: GuideHelp
     guides:
     - Security

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Eyes/glasses.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons]
   id: ClothingEyesGlassesMedSec
-  name: medsecglasses
+  name: BSO Glasses
   description: Sunglasses with a medical and security hud
   components:
   - type: Sprite
@@ -23,4 +23,4 @@
   - type: ShowHealthIcons
     damageContainers:
     - Biological
-    
+


### PR DESCRIPTION
# Description

Fixed the Corpsman Glasses not appropriately displaying health bars.
(also renames the "medsecglasses" to "BSO glasses")

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/ab19c74f-5cff-44ce-8b46-06c9b14d3ed7)
![image](https://github.com/user-attachments/assets/be182c29-0524-42af-b466-ef932ccea13d)


</p>
</details>

# Changelog

:cl:
- tweak: Renamed the "medsechud" to "BSO glasses".
- fix: Corpsman Glasses now properly display health bars.