### PR TITLE
Pistol Mag Fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -138,9 +138,17 @@
       gun_magazine:
         name: Magazine
         startingItem: null
+        priority: 2
+        whitelist:
+          tags:
+          - MagazinePistol
       gun_chamber:
         name: Chamber
         startingItem: null
+        priority: 1
+        whitelist:
+          tags:
+          - CartridgePistol
 
 - type: entity
   name: viper
@@ -250,9 +258,17 @@
       gun_magazine:
         name: Magazine
         startingItem: null
+        priority: 2
+        whitelist:
+          tags:
+          - MagazinePistol
       gun_chamber:
         name: Chamber
         startingItem: null
+        priority: 1
+        whitelist:
+          tags:
+          - CartridgePistol
 
 - type: entity
   name: mk 58
@@ -288,9 +304,17 @@
       gun_magazine:
         name: Magazine
         startingItem: null
+        priority: 2
+        whitelist:
+          tags:
+          - MagazinePistol
       gun_chamber:
         name: Chamber
         startingItem: null
+        priority: 1
+        whitelist:
+          tags:
+          - CartridgePistol
 
 - type: entity
   name: mk 58
@@ -395,9 +419,17 @@
       gun_magazine:
         name: Magazine
         startingItem: null
+        priority: 2
+        whitelist:
+          tags:
+          - MagazinePistol
       gun_chamber:
         name: Chamber
         startingItem: null
+        priority: 1
+        whitelist:
+          tags:
+          - CartridgePistol
 
 - type: entity
   name: N1984


### PR DESCRIPTION
# Description

You could put almost, if not literally anything into an Empty pistol magazine. Was missing the whitelist.

# Changelog

:cl:
- fix: Fixed a bug where you could put literally anything into a printed gun in the magazine slot.

