### PR TITLE
Tail Wagging Trait

### DIFF
--- a/Resources/Locale/en-US/_DEN/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/traits.ftl
@@ -25,3 +25,8 @@ trait-description-ZeroGAverse =
 
 trait-name-HoneyProducer = Honey Stomach
 trait-description-HoneyProducer = Your abdomen contains an extra stomach that processes nutrients into honey.
+
+trait-name-TailWag = Tail Wag
+trait-description-TailWag =
+    Your species has the innate ability to wag their tails, often used as an avenue to express untold emotions.
+    Note: [color=red]This will only work if the tail marking your character uses has wagging animations available.[/color]

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -110,7 +110,7 @@
     eyeDamageChance: 0.3
     eyeDamage: 1
     durationMultiplier: 1.5
-  - type: Wagging
+
   - type: LanguageKnowledge
     speaks:
     - TauCetiBasic

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -29,7 +29,6 @@
     - TauCetiBasic
     - SolCommon
   - type: FootPrints
-  - type: Wagging # Allows HumanHybrids to wag
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -66,7 +66,6 @@
       301: 0.8
       295: 0.6
       285: 0.4
-  - type: Wagging
   - type: LanguageKnowledge
     speaks:
     - TauCetiBasic

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -122,7 +122,6 @@
   - type: FootPrints
     leftBarePrint: "footprint-left-bare-slime"
     rightBarePrint: "footprint-right-bare-slime"
-  - type: Wagging
 
 - type: entity
   parent: MobHumanDummy

--- a/Resources/Prototypes/_DEN/Traits/physical.yml
+++ b/Resources/Prototypes/_DEN/Traits/physical.yml
@@ -132,3 +132,18 @@
       components:
         - type: MovementSpeedModifier
           weightlessAcceleration: 0.35
+
+- type: trait
+  id: Tail Wag
+  category: Physical
+  points: 0
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+    - Borg
+    - MedicalBorg
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: Wagging


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

With more tail markings being available to humans, and due to code hurdles, tail wagging is now an optional free trait to prevent UI clutter, of course it'll only still work if the respective tail markings have their wagging animations.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tail Wagging feature changed into an optional trait to prevent clutter. Prior wagging mechanics still apply.
