### PR TITLE
Un-Stripping Engineering Holoprojector Battery Panel Screws

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/holoprojectors.yml
@@ -14,4 +14,3 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
-        locked: true


### PR DESCRIPTION
# Description

Unstripped the screws on the Engineering holoprojector-- now you can get the batteries out, consistent with the rest of the holoprojectors!

# Changelog

:cl:
- fix: Fixed the screws being stripped on the Engineering Holoprojector. Now you can take the battery out!

