### PR TITLE
Make Holding Down Arrow Keys Scroll the Pointer Thru Chat

### DIFF
--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -499,15 +499,19 @@ binds:
 - function: ArcadeUp
   type: State
   key: Up
+  priority: -1
 - function: ArcadeDown
   type: State
   key: Down
+  priority: -1
 - function: ArcadeLeft
   type: State
   key: Left
+  priority: -1
 - function: ArcadeRight
   type: State
   key: Right
+  priority: -1
 - function: Arcade1
   type: State
   key: Space


### PR DESCRIPTION
# Description

Makes it so when you hold down the arrow keys your text cursor will move back and forth.
No more mashing left arrow 5 morbillion times to fix a typo.

🆑 :
+ priority -1 to the arcade up/down/left/right binds