### PR TITLE
Adjusts Jobs Loadouts to Make Them More Uniform

### DIFF
--- a/Resources/Changelog/Den.yml
+++ b/Resources/Changelog/Den.yml
@@ -2997,3 +2997,12 @@ Entries:
   id: 254
   time: '2025-03-18T04:30:36.0000000+00:00'
   url: https://github.com/TheDenSS14/TheDen/pull/373
+- author: Rosycup
+  changes:
+    - type: Tweak
+      message: >-
+        Tail Wagging feature changed into an optional trait to prevent clutter.
+        Prior wagging mechanics still apply.
+  id: 255
+  time: '2025-03-18T06:50:21.0000000+00:00'
+  url: https://github.com/TheDenSS14/TheDen/pull/371

--- a/Resources/Locale/en-US/loadouts/jobs/heads/captain.ftl
+++ b/Resources/Locale/en-US/loadouts/jobs/heads/captain.ftl
@@ -10,3 +10,11 @@ loadout-description-LoadoutCommandCapHatCapcap = The Captain's cap, pretty nice.
 loadout-description-LoadoutCommandCapHatBeret = The Captain's beret, very nice.
 loadout-description-LoadoutCommandCapMaskGas = Why would the captain need this? I don't know, but it looks cool.
 loadout-description-LoadoutCommandCapItemDrinkFlask = The finest of flasks, for the finest of drinks.
+
+# The Den additions (Loadout fixes)
+loadout-name-LoadoutBackpackCaptain = captain's backpack (empty)
+loadout-name-LoadoutBackpackSatchelCaptain = captain's satchel (empty)
+loadout-name-LoadoutBackpackDuffelCaptain = captain's duffel bag (empty)
+loadout-name-LoadoutBackpackCaptainFilled = captain's backpack (filled)
+loadout-name-LoadoutBackpackSatchelCaptainFilled = captain's satchel (filled)
+loadout-name-LoadoutBackpackDuffelCaptainFilled = captain's duffel bag (filled)

--- a/Resources/Locale/en-US/loadouts/jobs/heads/headOfPersonnel.ftl
+++ b/Resources/Locale/en-US/loadouts/jobs/heads/headOfPersonnel.ftl
@@ -2,3 +2,7 @@ loadout-description-LoadoutCommandHOPNeckMantle = To show who has the authority 
 loadout-description-LoadoutCommandHOPNeckCloak = To really show who has the authority around here.
 loadout-description-LoadoutCommandHOPBackIan = A backpack that looks like Ian, how cute!
 loadout-description-LoadoutCommandHOPHatCap = The HOP's cap, pretty nice.
+
+# The Den additions (Loadout fixes)
+loadout-name-LoadoutCommandHOPBackIan = Ian's backpack (empty)
+loadout-name-LoadoutCommandHOPBackIanFilled = Ian's backpack (filled)

--- a/Resources/Locale/en-US/loadouts/jobs/medical/medical.ftl
+++ b/Resources/Locale/en-US/loadouts/jobs/medical/medical.ftl
@@ -17,3 +17,7 @@ loadout-name-LoadoutSeniorPhysicianBeltMedical = medical belt (empty)
 loadout-name-LoadoutSeniorPhysicianBeltMedicalAdvancedFilled = medical belt (filled, advanced)
 loadout-description-LoadoutSeniorPhysicianBeltMedicalAdvancedFilled =
     The standard alotment of topical medicines in this pouch have been replaced with their advanced varieties, such as medicated sutures and regenerative mesh.
+
+# The Den additions (Loadout fixes)
+loadout-name-LoadoutMedicalInternBeltMedical = medical belt (empty)
+loadout-name-LoadoutMedicalInternBeltMedicalFilled = medical belt (filled)

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/corpsman.yml
@@ -82,8 +82,12 @@
   maxItems: 1
   items:
     - type: loadout
+      id: LoadoutClothingUniformJumpsuitCorpsman
+    - type: loadout
+      id: LoadoutClothingUniformJumpskirtCorpsman
+    - type: loadout
       id: LoadoutClothingUniformJumpsuitCorpsmanSummer
- 
+
 
 #- type: characterItemGroup
 #  id: LoadoutCorpsmanOuter

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/detective.yml
@@ -63,7 +63,15 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutDetectiveUniforms
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutDetectiveUniforms
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutUniformJumpsuitDetective
+    - type: loadout
+      id: LoadoutUniformJumpskirtDetective
+    - type: loadout
+      id: LoadoutUniformJumpsuitDetectiveGrey
+    - type: loadout
+      id: LoadoutUniformJumpskirtDetectiveGrey

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/headOfSecurity.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/headOfSecurity.yml
@@ -122,6 +122,10 @@
       id: LoadoutCommandHOSJumpskirtParade
     - type: loadout
       id: LoadoutCommandHOSJumpskirtFormal
+    - type: loadout
+      id: LoadoutCommandHOSJumpsuit
+    - type: loadout
+      id: LoadoutCommandHOSJumpskirt
 
 - type: characterItemGroup
   id: LoadoutHeadOfSecurityTrinkets

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/uncategorized.yml
@@ -252,3 +252,7 @@
       id: LoadoutSecurityUniformEnvirosuitBlue
     - type: loadout
       id: LoadoutSecurityUniformEnvirosuitGrey
+    - type: loadout
+      id: LoadoutSecurityUniformJumpsuit
+    - type: loadout
+      id: LoadoutSecurityUniformJumpskirt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/warden.yml
@@ -86,3 +86,7 @@
       id: LoadoutUniformJumpskirtWardenBlue
     - type: loadout
       id: LoadoutUniformJumpskirtWardenGrey
+    - type: loadout
+      id: LoadoutUniformJumpsuitWarden
+    - type: loadout
+      id: LoadoutUniformJumpskirtWarden

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Service/bartender.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Service/bartender.yml
@@ -104,3 +104,7 @@
       id: LoadoutServiceJumpsuitBartenderIdris
     - type: loadout
       id: LoadoutServiceJumpsuitBartenderOrion
+    - type: loadout
+      id: LoadoutServiceBartenderUniformSuit
+    - type: loadout
+      id: LoadoutServiceBartenderUniformSkirt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Service/botanist.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Service/botanist.yml
@@ -77,3 +77,7 @@
       id: LoadoutServiceJumpsuitHydroponicsIdris
     - type: loadout
       id: LoadoutServiceJumpsuitHydroponicsOrion
+    - type: loadout
+      id: ClothingUniformJumpsuitHydroponics
+    - type: loadout
+      id: ClothingUniformJumpskirtHydroponics

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Service/chef.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Service/chef.yml
@@ -78,3 +78,7 @@
       id: LoadoutServiceJumpsuitChefIdris
     - type: loadout
       id: LoadoutServiceJumpsuitChefOrion
+    - type: loadout
+      id: LoadoutServiceJumpsuitChef
+    - type: loadout
+      id: LoadoutServiceJumpskirtChef

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Service/janitor.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Service/janitor.yml
@@ -75,3 +75,7 @@
       id: LoadoutServiceJumpsuitJanitorIdris
     - type: loadout
       id: LoadoutServiceJumpsuitJanitorOrion
+    - type: loadout
+      id: LoadoutServiceJumpsuitJanitor
+    - type: loadout
+      id: LoadoutServiceJumpskirtJanitor

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Service/lawyer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Service/lawyer.yml
@@ -79,3 +79,7 @@
       id: LoadoutServiceLawyerUniformGoodSuit
     - type: loadout
       id: LoadoutServiceLawyerUniformGoodSkirt
+    - type: loadout
+      id: LoadoutServiceLawyerUniformBlackSuit
+    - type: loadout
+      id: LoadoutServiceLawyerUniformBlackSkirt

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Service/mime.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Service/mime.yml
@@ -77,7 +77,11 @@
     - type: loadout
       id: LoadoutServiceMimeShoesBootsWinter
 
-#- type: characterItemGroup
-#  id: LoadoutMimeUniforms
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutMimeUniforms
+  maxItems: 1
+  items:
+    - type: loadout
+      id: LoadoutServiceJumpsuitMime
+    - type: loadout
+      id: LoadoutServiceJumpskirtMime

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/engineering.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/engineering.yml
@@ -6,11 +6,9 @@
   items:
   - ClothingHandsEngiWarmers
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - StationEngineer
-    - AtmosphericTechnician
-    - ChiefEngineer
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Engineering
 
 - type: loadout
   id: LoadoutClothingUnderSocksEngi
@@ -25,11 +23,9 @@
     species:
     - Diona
     - Harpy
-  - !type:CharacterJobRequirement
-    jobs:
-    - StationEngineer
-    - AtmosphericTechnician
-    - ChiefEngineer
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Engineering
 
 - type: loadout
   id: LoadoutClothingUniformEngiThong
@@ -39,21 +35,17 @@
   items:
   - ClothingUniformEngiThong
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - StationEngineer
-    - AtmosphericTechnician
-    - ChiefEngineer
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Engineering
 
 - type: loadout
   id: LoadoutEngineeringNeckCollar
   category: JobsEngineeringAAUncategorized
   cost: 1
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - StationEngineer
-    - AtmosphericTechnician
-    - ChiefEngineer
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Engineering
   items:
   - ClothingNeckCollarEngi

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/epistemics.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/epistemics.yml
@@ -7,12 +7,9 @@
   items:
   - ClothingHandsEpiWarmers
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - Scientist
-    - ResearchAssistant
-    - ResearchDirector
-    - ForensicMantis
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Epistemics
 
 - type: loadout
   id: LoadoutClothingUnderSocksEpi
@@ -27,12 +24,9 @@
     species:
     - Diona
     - Harpy
-  - !type:CharacterJobRequirement
-    jobs:
-    - Scientist
-    - ResearchAssistant
-    - ResearchDirector
-    - ForensicMantis
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Epistemics
 
 - type: loadout
   id: LoadoutClothingUniformEpiThong
@@ -42,23 +36,18 @@
   items:
   - ClothingUniformEpiThong
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - Scientist
-    - ResearchAssistant
-    - ResearchDirector
-    - ForensicMantis
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Epistemics
 
 - type: loadout
   id: LoadoutScienceNeckCollar
   category: JobsEpistemicsAAUncategorized
   cost: 1
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - Scientist
-    - ResearchAssistant
-    - ResearchDirector
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Epistemics
   items:
   - ClothingNeckCollarEpi
 

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/logistics.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/logistics.yml
@@ -45,12 +45,9 @@
   category: JobsLogisticsAUncategorized
   cost: 1
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - CargoTechnician
-    - SalvageSpecialist
-    - Quartermaster
-    - MailCarrier
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Logistics
   items:
   - ClothingNeckCollarLogi
 

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/medical.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/medical.yml
@@ -7,13 +7,9 @@
   items:
   - ClothingHandsMedicWarmers
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - MedicalDoctor
-    - Paramedic
-    - ChiefMedicalOfficer
-    - MedicalIntern
-    - Chemist
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Medical
 
 - type: loadout
   id: LoadoutClothingUnderSocksMedic
@@ -28,13 +24,9 @@
     species:
     - Diona
     - Harpy
-  - !type:CharacterJobRequirement
-    jobs:
-    - MedicalDoctor
-    - Paramedic
-    - ChiefMedicalOfficer
-    - MedicalIntern
-    - Chemist
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Medical
 
 - type: loadout
   id: LoadoutClothingUniformMedicThong
@@ -44,26 +36,23 @@
   items:
   - ClothingUniformMedicThong
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - MedicalDoctor
-    - Paramedic
-    - ChiefMedicalOfficer
-    - MedicalIntern
-    - Chemist
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Medical
 
 - type: loadout
   id: LoadoutMedicalNeckCollar
   category: JobsMedicalAUncategorized
   cost: 1
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - MedicalDoctor
-    - Paramedic
-    - ChiefMedicalOfficer
-    - MedicalIntern
-    - Brigmedic
+  - !type:CharacterLogicXorRequirement
+    requirements:
+    - !type:CharacterDepartmentRequirement
+      departments:
+      - Medical
+    - !type:CharacterJobRequirement
+      jobs:
+      - Brigmedic
   items:
   - ClothingNeckCollarMed
 

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/security.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/security.yml
@@ -7,13 +7,9 @@
   items:
   - ClothingHandsSecurityWarmers
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - SecurityOfficer
-    - SecurityCadet
-    - Warden
-    - Detective
-    - HeadOfSecurity
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Security
 
 - type: loadout
   id: LoadoutClothingUnderSocksSecurity
@@ -28,13 +24,9 @@
     species:
     - Diona
     - Harpy
-  - !type:CharacterJobRequirement
-    jobs:
-    - SecurityOfficer
-    - SecurityCadet
-    - Warden
-    - Detective
-    - HeadOfSecurity
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Security
 
 - type: loadout
   id: LoadoutClothingUniformSecurityThong
@@ -44,24 +36,18 @@
   items:
   - ClothingUniformSecurityThong
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - SecurityOfficer
-    - SecurityCadet
-    - Warden
-    - Detective
-    - HeadOfSecurity
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Security
 
 - type: loadout
   id: LoadoutSecurityNeckCollar
   category: JobsSecurityAUncategorized
   cost: 1
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - SecurityOfficer
-    - Warden
-    - HeadOfSecurity
+  - !type:CharacterDepartmentRequirement
+    departments:
+    - Security
   items:
   - ClothingNeckCollarSec
 

--- a/Resources/Prototypes/Floof/Loadouts/Jobs/service.yml
+++ b/Resources/Prototypes/Floof/Loadouts/Jobs/service.yml
@@ -7,14 +7,15 @@
   items:
   - ClothingHandsServiceWarmers
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - Bartender
-    - Botanist
-    - Reporter
-    - Musician
-    - Chef
-    - ServiceWorker
+  - !type:CharacterLogicAndRequirement
+    requirements:
+    - !type:CharacterDepartmentRequirement
+      departments:
+      - Civilian
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - Passenger
 
 - type: loadout
   id: LoadoutClothingUnderSocksService
@@ -29,14 +30,15 @@
     species:
     - Diona
     - Harpy
-  - !type:CharacterJobRequirement
-    jobs:
-    - Bartender
-    - Botanist
-    - Reporter
-    - Musician
-    - Chef
-    - ServiceWorker
+  - !type:CharacterLogicAndRequirement
+    requirements:
+    - !type:CharacterDepartmentRequirement
+      departments:
+      - Civilian
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - Passenger
 
 - type: loadout
   id: LoadoutClothingUniformServiceThong
@@ -46,14 +48,15 @@
   items:
   - ClothingUniformServiceThong
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - Bartender
-    - Botanist
-    - Reporter
-    - Musician
-    - Chef
-    - ServiceWorker
+  - !type:CharacterLogicAndRequirement
+    requirements:
+    - !type:CharacterDepartmentRequirement
+      departments:
+      - Civilian
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - Passenger
 
 - type: loadout
   id: LoadoutClothingUniformServiceUni
@@ -63,14 +66,15 @@
   items:
   - ClothingUniformServiceUni
   requirements:
-  - !type:CharacterJobRequirement
-    jobs:
-    - Bartender
-    - Botanist
-    - Reporter
-    - Musician
-    - Chef
-    - ServiceWorker
+  - !type:CharacterLogicAndRequirement
+    requirements:
+    - !type:CharacterDepartmentRequirement
+      departments:
+      - Civilian
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+      - Passenger
 
 #Bartender
 - type: loadout
@@ -290,7 +294,7 @@
 
 - type: loadout
   id: LoadoutClothingNeckCloakJanitor
-  category: JobsServiceAUncategorized
+  category: JobsServiceJanitor
   cost: 2
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystic.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystic.yml
@@ -61,7 +61,7 @@
 # Outer
 - type: loadout
   id: LoadoutScienceOuterLabcoatSeniorResearcher
-  category: JobsEpistemicsAAUncategorized
+  category: JobsEpistemicsMystic
   cost: 0
   exclusive: true
   customColorTint: true

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chemist.yml
@@ -6,7 +6,7 @@
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackSatchelChemistry
+    - ClothingBackpackChemistry
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutChemistBackpacks
@@ -300,7 +300,7 @@
 # Shoes
 - type: loadout
   id: LoadoutMedicalShoesEnclosedChem
-  category: JobsMedicalAUncategorized
+  category: JobsMedicalChemist
   cost: 0
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/psychologist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/psychologist.yml
@@ -10,9 +10,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutPsychologistBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Medical
+    - !type:CharacterJobRequirement
+      jobs:
+        - Psychologist
 
 - type: loadout
   id: LoadoutPsychologistBackpackSatchel
@@ -24,9 +24,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutPsychologistBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Medical
+    - !type:CharacterJobRequirement
+      jobs:
+        - Psychologist
 
 - type: loadout
   id: LoadoutPsychologistBackpackDuffel
@@ -38,9 +38,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutPsychologistBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Medical
+    - !type:CharacterJobRequirement
+      jobs:
+        - Psychologist
 
 # Belt
 
@@ -132,15 +132,16 @@
   items:
     - ClothingUniformJumpsuitPsychologist
 
-- type: loadout
-  id: LoadoutPsychologistJumpskirt
-  category: JobsMedicalPsychologist
-  cost: 0
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutPsychologistUniforms
-    - !type:CharacterJobRequirement
-      jobs:
-        - Psychologist
-  items:
-    - ClothingUniformJumpsuitPsychologist
+# psychologist jumpskirt doesnt exist
+#- type: loadout
+#  id: LoadoutPsychologistJumpskirt
+#  category: JobsMedicalPsychologist
+#  cost: 0
+#  requirements:
+#    - !type:CharacterItemGroupRequirement
+#      group: LoadoutPsychologistUniforms
+#    - !type:CharacterJobRequirement
+#      jobs:
+#        - Psychologist
+#  items:
+#    - ClothingUniformJumpskirtPsychologist

--- a/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
@@ -74,7 +74,7 @@
 # Eyes
 - type: loadout
   id: LoadoutClothingEyesGlassesCorpsman
-  category: JobsSecurityAUncategorized
+  category: JobsSecurityCorpsman
   cost: 2
   exclusive: true
   requirements:

--- a/Resources/Prototypes/Loadouts/Jobs/Service/botanist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Service/botanist.yml
@@ -10,9 +10,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutBotanistBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Civilian
+    - !type:CharacterJobRequirement
+      jobs:
+        - Botanist
 
 - type: loadout
   id: LoadoutServiceBotanistDuffelHydroponics
@@ -24,9 +24,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutBotanistBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Civilian
+    - !type:CharacterJobRequirement
+      jobs:
+        - Botanist
 
 - type: loadout
   id: LoadoutServiceBotanistSatchelHydroponics
@@ -38,9 +38,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutBotanistBackpacks
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Civilian
+    - !type:CharacterJobRequirement
+      jobs:
+        - Botanist
 
 # Belt
 

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/corpsman.yml
@@ -1,0 +1,27 @@
+- type: loadout
+  id: LoadoutUniformJumpsuitCorpsman
+  category: JobsSecurityCorpsman
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCorpsmanUniform
+    - !type:CharacterJobRequirement
+      jobs:
+        - Brigmedic
+  items:
+    - ClothingUniformJumpsuitBrigmedic
+
+- type: loadout
+  id: LoadoutUniformJumpskirtCorpsman
+  category: JobsSecurityCorpsman
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCorpsmanUniform
+    - !type:CharacterJobRequirement
+      jobs:
+        - Brigmedic
+  items:
+    - ClothingUniformJumpskirtBrigmedic

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/detective.yml
@@ -1,0 +1,55 @@
+- type: loadout
+  id: LoadoutUniformJumpsuitDetective
+  category: JobsSecurityDetective
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutDetectiveUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Detective
+  items:
+    - ClothingUniformJumpsuitDetective
+
+- type: loadout
+  id: LoadoutUniformJumpskirtDetective
+  category: JobsSecurityDetective
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutDetectiveUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Detective
+  items:
+    - ClothingUniformJumpskirtDetective
+
+- type: loadout
+  id: LoadoutUniformJumpsuitDetectiveGrey
+  category: JobsSecurityDetective
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutDetectiveUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Detective
+  items:
+    - ClothingUniformJumpsuitDetectiveGrey
+
+- type: loadout
+  id: LoadoutUniformJumpskirtDetectiveGrey
+  category: JobsSecurityDetective
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutDetectiveUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Detective
+  items:
+    - ClothingUniformJumpskirtDetectiveGrey

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/headOfSecurity.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/headOfSecurity.yml
@@ -1,0 +1,27 @@
+- type: loadout
+  id: LoadoutCommandHOSJumpsuit
+  category: JobsSecurityHeadOfSecurity
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHeadOfSecurityUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - HeadOfSecurity
+  items:
+    - ClothingUniformJumpsuitHoS
+
+- type: loadout
+  id: LoadoutCommandHOSJumpskirt
+  category: JobsSecurityHeadOfSecurity
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutHeadOfSecurityUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - HeadOfSecurity
+  items:
+    - ClothingUniformJumpskirtHoS

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/uncategorized.yml
@@ -67,3 +67,31 @@
         - Security
   items:
     - ClothingMaskGasSecurityBallistic
+
+- type: loadout
+  id: LoadoutSecurityUniformJumpsuit
+  category: JobsSecurityAUncategorized
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityUniforms
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+  items:
+    - ClothingUniformJumpsuitSec
+
+- type: loadout
+  id: LoadoutSecurityUniformJumpskirt
+  category: JobsSecurityAUncategorized
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityUniforms
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+  items:
+    - ClothingUniformJumpskirtSec

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/warden.yml
@@ -12,3 +12,31 @@
         - Warden
   items:
     - Greatsword
+
+- type: loadout
+  id: LoadoutUniformJumpsuitWarden
+  category: JobsSecurityWarden
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWardenUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Warden
+  items:
+    - ClothingUniformJumpsuitWarden
+
+- type: loadout
+  id: LoadoutUniformJumpskirtWarden
+  category: JobsSecurityWarden
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWardenUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Warden
+  items:
+    - ClothingUniformJumpskirtWarden

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/bartender.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/bartender.yml
@@ -1,0 +1,27 @@
+- type: loadout
+  id: LoadoutServiceBartenderUniformSuit
+  category: JobsServiceBartender
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBartenderUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Bartender
+  items:
+    - ClothingUniformJumpsuitBartender
+
+- type: loadout
+  id: LoadoutServiceBartenderUniformSkirt
+  category: JobsServiceBartender
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBartenderUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Bartender
+  items:
+    - ClothingUniformJumpskirtBartender

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/botanist.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/botanist.yml
@@ -1,0 +1,27 @@
+- type: loadout
+  id: LoadoutServiceJumpsuitHydroponics
+  category: JobsServiceBotanist
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBotanistUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Botanist
+  items:
+    - ClothingUniformJumpsuitHydroponics
+
+- type: loadout
+  id: LoadoutServiceJumpskirtHydroponics
+  category: JobsServiceBotanist
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutBotanistUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Botanist
+  items:
+    - ClothingUniformJumpskirtHydroponics

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/chef.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/chef.yml
@@ -1,0 +1,27 @@
+- type: loadout
+  id: LoadoutServiceJumpsuitChef
+  category: JobsServiceChef
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChefUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Chef
+  items:
+    - ClothingUniformJumpsuitChef
+
+- type: loadout
+  id: LoadoutServiceJumpskirtChef
+  category: JobsServiceChef
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutChefUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Chef
+  items:
+    - ClothingUniformJumpskirtChef

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/janitor.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/janitor.yml
@@ -1,0 +1,27 @@
+- type: loadout
+  id: LoadoutServiceJumpsuitJanitor
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+  items:
+    - ClothingUniformJumpsuitJanitor
+
+- type: loadout
+  id: LoadoutServiceJumpskirtJanitor
+  category: JobsServiceJanitor
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutJanitorUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Janitor
+  items:
+    - ClothingUniformJumpskirtJanitor

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/lawyer.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/lawyer.yml
@@ -1,0 +1,27 @@
+- type: loadout
+  id: LoadoutServiceLawyerUniformBlackSuit
+  category: JobsServiceLawyer
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutLawyerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Lawyer
+  items:
+    - ClothingUniformJumpsuitLawyerBlack
+
+- type: loadout
+  id: LoadoutServiceLawyerUniformBlackSkirt
+  category: JobsServiceLawyer
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutLawyerUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Lawyer
+  items:
+    - ClothingUniformJumpskirtLawyerBlack

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/mime.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Service/mime.yml
@@ -1,0 +1,27 @@
+- type: loadout
+  id: LoadoutServiceJumpsuitMime
+  category: JobsServiceMime
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMimeUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Mime
+  items:
+    - ClothingUniformJumpsuitMime
+
+- type: loadout
+  id: LoadoutServiceJumpskirtMime
+  category: JobsServiceMime
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMimeUniforms
+    - !type:CharacterJobRequirement
+      jobs:
+        - Mime
+  items:
+    - ClothingUniformJumpskirtMime


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

A simple reorganization and relaballing of certain items, only ONE of which has been removed (commented out) (as the item its associated with does not exist), collars are now accessable by the whole department rather than just some arbitrary jobs inside of it and some items have moved into the correct categories

Also adds the jumpsuits and jumpskirts of the default uniforms that a job has, those being for, corpsman, mime, security officer, warden, head of security, botonist, bartender and chef (i like using default jumpskirts :3c)

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Changes made
- [x] Tested

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Loadouts have been reorganized please make sure you update yours!