### PR TITLE
Speak to the Trees (Rootspeak Fix)

### DIFF
--- a/Resources/Prototypes/_DEN/Traits/languages.yml
+++ b/Resources/Prototypes/_DEN/Traits/languages.yml
@@ -67,9 +67,9 @@
   functions:
     - !type:TraitModifyLanguages
       languagesSpoken:
-        - Rootspeak
+        - RootSpeak
       languagesUnderstood:
-        - Rootspeak
+        - RootSpeak
 
 - type: trait
   id: Moffic


### PR DESCRIPTION
# Description

Uppercased an 's'.

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/af7bd73c-8199-4cba-989d-9980f00a9983)


</p>
</details>

:cl:
- fix: Fixed the RootSpeak trait to work correctly. You're not the Lorax, but you can speak to the trees!

