### PR TITLE
Localization and Fixes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_limbs.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_limbs.yml
@@ -53,7 +53,7 @@
     state: furred_r_foot
 
 - type: marking
-  id: FurArms
+  id: FurredLeftHand
   bodyPart: LHand
   markingCategory: LeftHand
   speciesRestriction: [Human, HumanHybrid]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -126,7 +126,7 @@
   - type: Bloodstream
     bloodMaxVolume: 0.1
   - type: MobPrice
-    price: 50
+    price: 10
   - type: NPCRetaliation
   - type: FactionException
   - type: NpcFactionMember

--- a/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
@@ -18,6 +18,8 @@
       - InsideEntityStorage # no clark kent going in phone booth and becoming superman
       - MindContainer # no
       - Pda # PDAs currently make you invisible /!\
+      - Paper
+      - FoodCookieFortune
     polymorph:
       entity: ChameleonDisguise
 

--- a/Resources/Prototypes/_DEN/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_DEN/Entities/Clothing/Hands/gloves.yml
@@ -1,0 +1,10 @@
+- type: entity
+  parent: ClothingHandsBase
+  id: ClothingHandsGoldenRing
+  name: golden ring
+  description: A well made ring made of real gold, usually given to the people you cherish the most.
+  components:
+  - type: Sprite
+    sprite: _DEN/Clothing/Hands/goldenring.rsi
+  - type: Clothing
+    sprite: _DEN/Clothing/Hands/goldenring.rsi

--- a/Resources/Prototypes/_DEN/Loadouts/items.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/items.yml
@@ -131,3 +131,11 @@
   canBeHeirloom: true
   items:
     - Clicker
+
+- type: loadout
+  id: LoadoutGoldenRing
+  category: Items
+  cost: 0
+  canBeHeirloom: true
+  items:
+    - ClothingHandsGoldenRing

--- a/Resources/Prototypes/_DEN/Traits/physical.yml
+++ b/Resources/Prototypes/_DEN/Traits/physical.yml
@@ -134,7 +134,7 @@
           weightlessAcceleration: 0.35
 
 - type: trait
-  id: Tail Wag
+  id: TailWag
   category: Physical
   points: 0
   requirements:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Alternative title: Satisfying the test gods demands like some warlock in a dark dreary temple.
Fixed localization for furred hands and tail wag trait.
Decreased sell prices of bees.
Prevented use of chameleon projector on paper and specifically cookie fortune paper due to invisibilty bug.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Decreased sell prices of bees, the Great Beepression.
- fix: Fixed the localization for the Furred Left Hand marking and Tail Wag trait.
- tweak: Paper and Cookie Fortunes added to Chameleon Projector blacklist following invisibility bug.