### PR TITLE
Dressification

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -1062,8 +1062,8 @@
 - type: entity
   parent: ClothingUniformSkirtBase
   id: ClothingUniformJumpskirtDressFlamenco
-  name: flamenco dress
-  description: A Mexican flamenco dress.
+  name: Oaxaqueño dress
+  description: A Mexican Oaxaqueño dress.
   components:
   - type: Sprite
     sprite: Clothing/Uniforms/Jumpskirt/flamenco.rsi


### PR DESCRIPTION
# Description

Changes the name of the "Flamenco" dress to be more accurately an "Oaxaqueño" dress, as per @Mossfruit's recommendation.
![image](https://github.com/user-attachments/assets/8f649eb2-9722-4bc9-baa4-15a177f1429f)

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Renamed "Flamenco" dress to more a more accurate "Oaxaqueño" dress.
