### PR TITLE
Psionic Stuff

### DIFF
--- a/Resources/Locale/en-US/psionics/psionic-powers.ftl
+++ b/Resources/Locale/en-US/psionics/psionic-powers.ftl
@@ -9,7 +9,7 @@ dispel-power-metapsionic-feedback = {CAPITALIZE($entity)} is a mighty stone, sta
 # Mass Sleep
 mass-sleep-power-description = Put targets in a small area to sleep.
 mass-sleep-initialization-feedback = Reaching out to the minds around me, I have located the words that can send others to the realm of dreams.
-mass-sleep-metapsionic-feedback = {CAPITALIZE($entity)} bears the indelible mark of a dream thief.
+mass-sleep-power-metapsionic-feedback = {CAPITALIZE($entity)} bears the indelible mark of a dream thief.
 
 # Mind Swap
 mind-swap-power-description = Swap minds with the target. Either can change back after 20 seconds.
@@ -94,7 +94,6 @@ xenoglossy-power-description = You understand all languages.
 xenoglossy-power-initialization-feedback =
     I feel an empathy with all creation, so that I may understand them and be understood.
     The barrier between thought and expressions is permeable to me.
-
 psionic-language-power-metapsionic-feedback = The noösphere flows freely through {CAPITALIZE($entity)}, who seems to digest it and pass it back out undisturbed.
 
 # Psychognomy
@@ -102,12 +101,14 @@ psychognomy-power-description = You have some vague sense of the form of the sou
 psychognomy-power-initialization-feedback =
     I have pierced the veil, and I know I'm not alone. More concerning, the piercing I made seems to be still indefinitely permeable.
     When energy passes through the perforations in the noösphere, I get a faint glimpse of the material origin.
+psychognomy-power-metapsionic-feedback = {CAPITALIZE($entity)} senses aspects of the source of the thoughts they receive from the noösphere.
 
 # Telepathy
 telepathy-power-description = You are capable of both sending and receiving telepathic messages.
 telepathy-power-initialization-feedback =
     The voices I've heard all my life begin to clear, yet they do not leave me. Before, they were as incoherent whispers,
     now my senses broaden, I come to a realization that they are part of a communal shared hallucination. Behind every voice is a glimmering sentience.
+telepathy-power-metapsionic-feedback = {CAPITALIZE($entity)} can project their thoughts into the noösphere, passing it along to other minds that are connected.
 
 # Shadeskip
 action-name-shadeskip = Shadeskip
@@ -129,7 +130,7 @@ action-description-telekinetic-pulse =
 telekinetic-pulse-power-description = { action-description-telekinetic-pulse }
 telekinetic-pulse-power-initialization-feedback =
     As I reach through the veil with my psyche, I discover a wellspring of pure kinetic energy. It courses through me, but I seem to lack fine control over it.
-telekinetic-pulse-power-metapsionic-feedback = {CAPITALIZE($entity)} has the essence of pure kinesis flowing through him.
+telekinetic-pulse-power-metapsionic-feedback = {CAPITALIZE($entity)} has the essence of pure kinesis flowing through them.
 
 # Pyrokinetic Flare
 action-name-pyrokinetic-flare = Pyrokinetic Flare
@@ -140,7 +141,7 @@ pyrokinetic-flare-power-initialization-feedback =
     My gaze is briefly filled with a flash of immense light and head, and for a single moment I can see a glimpse of a realm
     of fire and pain, of hunger and suffering. Just as soon as I glimpse it, the vision fades. But the memory of that flash lingers within my mind.
     I can recall it still, a glimpse of the fires of Gehenna.
-pyrokinetic-flare-power-metapsionic-feedback = Guh these don't even matter because nobody can read this line in-game and I don't know when I'm ever bringing back Narrow Pulse
+pyrokinetic-flare-power-metapsionic-feedback = {CAPITALIZE($entity)} can draw out the spark within them into a fleeting burst of light.
 
 # Summon Imp
 action-name-summon-imp = Summon Imp

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/knives.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/knives.yml
@@ -13,11 +13,10 @@
   - type: StaminaDamageOnHit
     damage: 0
   - type: AntiPsionicWeapon
+    punish: false
     modifiers:
       coefficients:
-        Blunt: 1.2
-        Slash: 1.2
-        Piercing: 1.2
+        Slash: 1.25
         Holy: 1.2
   - type: Sprite
     sprite: Nyanotrasen/Objects/Weapons/Melee/anti_psychic_knife.rsi

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -129,7 +129,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: GlimmerEvent
-    minimumGlimmer: 700
+    minimumGlimmer: 600
     maximumGlimmer: 1000
   - type: GlimmerMobRule
     mobPrototype: MobGlimmerWisp
@@ -167,7 +167,7 @@
   categories: [ HideSpawnMenu ]
   components:
     - type: GlimmerEvent
-      minimumGlimmer: 750
+      minimumGlimmer: 650
       maximumGlimmer: 900
       glimmerBurnLower: 120
       glimmerBurnUpper: 200

--- a/Resources/Prototypes/Psionics/psionics.yml
+++ b/Resources/Prototypes/Psionics/psionics.yml
@@ -290,13 +290,13 @@
     - !type:PsionicFeedbackSelfChat
       feedbackMessage: xenoglossy-power-initialization-feedback
     - !type:AddPsionicAssayFeedback
-      assayFeedback: psionic-language-power-feedback
+      assayFeedback: psionic-language-power-metapsionic-feedback
   removalFunctions:
     - !type:RemovePsionicPowerComponents
       components:
         - type: Telepathy
     - !type:RemoveAssayFeedback
-      assayFeedback: psionic-language-power-feedback
+      assayFeedback: psionic-language-power-metapsionic-feedback
   powerSlotCost: 0
 
 - type: psionicPower
@@ -312,13 +312,13 @@
     - !type:PsionicFeedbackSelfChat
       feedbackMessage: psychognomy-power-initialization-feedback
     - !type:AddPsionicAssayFeedback
-      assayFeedback: psionic-language-power-feedback
+      assayFeedback: psychognomy-power-metapsionic-feedback
   removalFunctions:
     - !type:RemovePsionicPowerComponents
       components:
         - type: Psychognomist
     - !type:RemoveAssayFeedback
-      assayFeedback: psionic-language-power-feedback
+      assayFeedback: psychognomy-power-metapsionic-feedback
   powerSlotCost: 0
 
 - type: psionicPower
@@ -334,7 +334,7 @@
     - !type:PsionicFeedbackSelfChat
       feedbackMessage: telepathy-power-initialization-feedback
     - !type:AddPsionicAssayFeedback
-      assayFeedback: psionic-language-power-feedback
+      assayFeedback: telepathy-power-metapsionic-feedback
     - !type:PsionicAddAvailablePowers
       powerPrototype: XenoglossyPower
       weight: 0.75
@@ -346,7 +346,7 @@
       components:
         - type: Telepathy
     - !type:RemoveAssayFeedback
-      assayFeedback: psionic-language-power-feedback
+      assayFeedback: telepathy-power-metapsionic-feedback
     - !type:PsionicRemoveAvailablePowers
       powerPrototype: XenoglossyPower
     - !type:PsionicRemoveAvailablePowers
@@ -369,7 +369,7 @@
     - !type:PsionicModifyGlimmer
       glimmerModifier: 4
     - !type:AddPsionicAssayFeedback
-      assayFeedback: healing-word-power-feedback
+      assayFeedback: healing-word-power-metapsionic-feedback
     - !type:AddPsionicStatSources
       amplificationModifier: 0.5
       dampeningModifier: 0.5
@@ -380,7 +380,7 @@
     - !type:RemovePsionicActions
     - !type:RemovePsionicStatSources
     - !type:RemoveAssayFeedback
-      assayFeedback: healing-word-power-feedback
+      assayFeedback: healing-word-power-metapsionic-feedback
     - !type:PsionicRemoveAvailablePowers
       powerPrototype: RevivifyPower
 
@@ -401,14 +401,14 @@
     - !type:PsionicModifyGlimmer
       glimmerModifier: 15
     - !type:AddPsionicAssayFeedback
-      assayFeedback: revivify-power-feedback
+      assayFeedback: revivify-power-metapsionic-feedback
     - !type:AddPsionicStatSources
       amplificationModifier: 2.5
   removalFunctions:
     - !type:RemovePsionicActions
     - !type:RemovePsionicStatSources
     - !type:RemoveAssayFeedback
-      assayFeedback: revivify-power-feedback
+      assayFeedback: revivify-power-metapsionic-feedback
 
 - type: psionicPower
   id: LowAmplification

--- a/Resources/Prototypes/_DEN/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Weapons/Melee/sword.yml
@@ -42,8 +42,8 @@
   - type: Item
     size: Ginormous
   - type: ClothingSpeedModifier
-    walkModifier: 0.85
-    sprintModifier: 0.85
+    walkModifier: 0.90
+    sprintModifier: 0.90
   - type: Tool
     qualities:
     - Axing #Funny


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Mantis Knife tweaked to not punish the user for grazing non-psionics since it deals about as much as the average knife to them, slash damage against psionics increased from a 1.2x modifier to 1.25, doing 15 slash on heavy attack and 12.5 on normal attack. Assay properly displays the power feedback texts from certain powers, also adds feedback text on powers that had them missing. 
Side Tweak: Changed the greatsword's slowdown to 10% from 15%.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added Assay feedback messages for Pyrokinetic Flare, Telepathy, and Psychognomy
- tweak: Tweaked the Mantis Knife to not be punishing as well as a slight slash damage modifier increase against psionics.
- tweak: Tweaked the Greatsword's slowdown to 10%.
- fix: Fixed certain Assay feedback messages not displaying correctly.
