### PR TITLE
Quickfixes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mail/Items/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mail/Items/misc.yml
@@ -41,7 +41,7 @@
 
 - type: entity
   id: SyringeCognizine
-  parent: Syringe
+  parent: BaseSyringe
   name: cognizine syringe
   components:
   - type: SolutionContainerManager
@@ -54,16 +54,16 @@
 
 - type: entity
   id: SyringeOpporozidone
-  parent: Syringe
+  parent: BaseSyringe
   name: opporozidone syringe
   components:
   - type: SolutionContainerManager
     solutions:
       drink:
         maxVol: 15
-#        reagents: # TODO: we don't have that yet. Guess the people will receive an empty syringe instead.
-#        - ReagentId: Opporozidone
-#          Quantity: 15
+        reagents: # TODO: we don't have that yet. Guess the people will receive an empty syringe instead.
+        - ReagentId: Opporozidone
+           Quantity: 15`
 
 - type: entity
   id: NecrosolChemistryBottle

--- a/Resources/Prototypes/Entities/Objects/Specific/Mail/Items/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mail/Items/misc.yml
@@ -63,7 +63,7 @@
         maxVol: 15
         reagents: # TODO: we don't have that yet. Guess the people will receive an empty syringe instead.
         - ReagentId: Opporozidone
-          Quantity: 15`
+          Quantity: 15
 
 - type: entity
   id: NecrosolChemistryBottle

--- a/Resources/Prototypes/Entities/Objects/Specific/Mail/Items/misc.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mail/Items/misc.yml
@@ -63,7 +63,7 @@
         maxVol: 15
         reagents: # TODO: we don't have that yet. Guess the people will receive an empty syringe instead.
         - ReagentId: Opporozidone
-           Quantity: 15`
+          Quantity: 15`
 
 - type: entity
   id: NecrosolChemistryBottle

--- a/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
@@ -25,6 +25,9 @@
           - Item
         tags:
           - Structure
+          - Airlock
+          - AirlockGlass
+          - HighSecDoor
     - type: Tag
       tags:
       - HandLabeler # DeltaV - fish labeler

--- a/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
@@ -26,7 +26,7 @@
         tags:
           - Structure
           - Airlock
-          - AirlockGlass
+          - GlassAirlock
           - HighSecDoor
     - type: Tag
       tags:

--- a/Resources/Prototypes/Psionics/PsionicPowerPool.yml
+++ b/Resources/Prototypes/Psionics/PsionicPowerPool.yml
@@ -2,7 +2,7 @@
   id: RandomPsionicPowerPool
   weights:
     MetapsionicPower: 1
-    AnoigoPower: 1
+    #AnoigoPower: 1 #Incredible consent violation waiting to happen
     DispelPower: 1
     #TelegnosisPower: 1
     PsionicRegenerationPower: 1

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1148,43 +1148,43 @@
           fontSize: 12
           requireDetailRange: true
 
-- type: trait
-  id: Bulky
-  category: Physical
-  points: -6
-  requirements:
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - Featherweight
-  functions:
-    - !type:TraitModifyDensity
-      densityModifier: 55
-      multiply: false
-    - !type:TraitPushDescription
-      descriptionExtensions:
-        - description: examine-bulky-message
-          fontSize: 12
-          requireDetailRange: true
+# - type: trait
+#   id: Bulky
+#   category: Physical
+#   points: -6
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       inverted: true
+#       traits:
+#         - Featherweight
+#   functions:
+#     - !type:TraitModifyDensity
+#       densityModifier: 55
+#       multiply: false
+#     - !type:TraitPushDescription
+#       descriptionExtensions:
+#         - description: examine-bulky-message
+#           fontSize: 12
+#           requireDetailRange: true
 
-- type: trait
-  id: Featherweight
-  category: Physical
-  points: 3
-  requirements:
-    - !type:CharacterTraitRequirement
-      inverted: true
-      traits:
-        - Bulky
-  functions:
-    - !type:TraitModifyDensity
-      densityModifier: 0.5
-      multiply: true
-    - !type:TraitPushDescription
-      descriptionExtensions:
-        - description: examine-featherweight-message
-          fontSize: 12
-          requireDetailRange: true
+# - type: trait
+#   id: Featherweight
+#   category: Physical
+#   points: 3
+#   requirements:
+#     - !type:CharacterTraitRequirement
+#       inverted: true
+#       traits:
+#         - Bulky
+#   functions:
+#     - !type:TraitModifyDensity
+#       densityModifier: 0.5
+#       multiply: true
+#     - !type:TraitPushDescription
+#       descriptionExtensions:
+#         - description: examine-featherweight-message
+#           fontSize: 12
+#           requireDetailRange: true
 
 - type: trait
   id: Bodybuilder

--- a/Resources/Prototypes/_ADT/Mobs/Customization/reptilian/Reptilian.yml
+++ b/Resources/Prototypes/_ADT/Mobs/Customization/reptilian/Reptilian.yml
@@ -234,7 +234,7 @@
   id: TailAxolotl
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Reptilian, SlimePerson, HumanHybrid, Human, IPC]
   sprites:
     - sprite: _ADT/Mobs/Customization/Reptilian/reptilian_tails.rsi
       state: axolotl
@@ -243,7 +243,7 @@
   id: TailDatashark
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Reptilian, SlimePerson, HumanHybrid, Human, IPC]
   sprites:
     - sprite: _ADT/Mobs/Customization/Reptilian/reptilian_tails.rsi
       state: datashark_ears_inner
@@ -260,7 +260,7 @@
   id: TailEasternDragon
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Reptilian, SlimePerson, HumanHybrid, Human, IPC]
   sprites:
     - sprite: _ADT/Mobs/Customization/Reptilian/reptilian_tails.rsi
       state: easternd_primary
@@ -271,7 +271,7 @@
   id: TailFish
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Reptilian, SlimePerson, HumanHybrid, Human, IPC]
   sprites:
     - sprite: _ADT/Mobs/Customization/Reptilian/reptilian_tails.rsi
       state: fish_primary
@@ -282,7 +282,7 @@
   id: TailMaw
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Reptilian, SlimePerson, HumanHybrid, Human, IPC, Vulpkanin]
   sprites:
     - sprite: _ADT/Mobs/Customization/Reptilian/reptilian_tails.rsi
       state: maw
@@ -291,7 +291,7 @@
   id: TailShark
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Reptilian, SlimePerson, HumanHybrid, Human, IPC]
   sprites:
     - sprite: _ADT/Mobs/Customization/Reptilian/reptilian_tails.rsi
       state: shark_fin
@@ -302,7 +302,7 @@
   id: TailSnake
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Reptilian]
+  speciesRestriction: [Reptilian, SlimePerson, HumanHybrid, Human, IPC]
   sprites:
     - sprite: _ADT/Mobs/Customization/Reptilian/reptilian_tails.rsi
       state: snake


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Certain Lizard tails are available to their old species prior to the merge, Cogni and Oppo mail syringes should be functional, Removed redundant weight traits (Bulky and Featherweight). Disabled Anoigo power, psionic power that can open locked and bolted doors due to consent reasons. Included airlocks to the Hand Labeler whitelist.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked certain lizard tails to be available to certain species as with pre-merge.
- tweak: Airlocks are able to be labeled with the hand labeler.
- fix: Fixed mail cognizine and opporozidone syringes.
- remove: Removed redundant weight traits.
- remove: Disabled Anoigo power due to being a potential consent violation.