### PR TITLE
(Temp) Hotfix for Wheel Chair Trait

### DIFF
--- a/Resources/Prototypes/_DEN/Traits/physical.yml
+++ b/Resources/Prototypes/_DEN/Traits/physical.yml
@@ -102,6 +102,7 @@
     inverted: true
     traits:
     - ZeroGAverse
+    - WheelchairBound
   functions:
     - !type:TraitReplaceComponent
       components:
@@ -127,6 +128,7 @@
     inverted: true
     traits:
     - ZeroGTraining
+    - WheelchairBound
   functions:
     - !type:TraitReplaceComponent
       components:


### PR DESCRIPTION
Makes both Zero G traits Exclusive till the core issue can be found as to why it restores your legs if your wheelchair bound.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Makes both Zero G traits Exclusive with the wheelchair trait till the core issue can be found.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->
Find out why these traits give back your legs
- [x] Task
- [ ] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>



</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:

- tweak: Tweaked both Zero G Traits to be exclusive with the Wheelchair trait, No more free legs.
