### PR TITLE
Localization Quickfixes

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/_Goobstation/lathe/lathe-categories.ftl
@@ -1,8 +1,8 @@
 lathe-category-mechs-vim = Vim
 lathe-category-mechs-honker = H.O.N.K.
 lathe-category-mechs-hamptr = H.A.M.P.T.R.
-lathe-category-mechs-ripley = Riley
-lathe-category-mechs-ripleymkii = Riley MK-II
+lathe-category-mechs-ripley = Ripley
+lathe-category-mechs-ripleymkii = Ripley MK-II
 lathe-category-mechs-clarke = Clarke
 lathe-category-mechs-gygax = Gygax
 lathe-category-mechs-durand = Durand

--- a/Resources/Locale/en-US/materials/materials.ftl
+++ b/Resources/Locale/en-US/materials/materials.ftl
@@ -3,6 +3,8 @@ materials-glass = glass
 materials-reinforced-glass = reinforced glass
 materials-plasma-glass = plasma glass
 materials-reinforced-plasma-glass = reinforced plasma glass
+materials-uranium-glass = uranium glass
+materials-reinforced-uranium-glass = reinforced uranium glass
 
 # Metals
 materials-steel = steel
@@ -33,6 +35,7 @@ materials-diamond = diamond
 materials-gunpowder = gunpowder
 materials-bluespace = bluespace
 materials-normality = normality
+materials-circuitry = circuitry
 
 # Ores
 materials-raw-iron = raw iron

--- a/Resources/Prototypes/Traits/mental.yml
+++ b/Resources/Prototypes/Traits/mental.yml
@@ -500,8 +500,6 @@
       inverted: true
       jobs:
         - Chaplain
-    - !type:CharacterItemGroupRequirement
-      group: TraitsMachine
   functions:
     - !type:TraitAddPsionics
       psionicPowers:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mech_construction.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mech_construction.yml
@@ -14,7 +14,7 @@
   parent: BaseRipleyMKIIPart
   id: RipleyMKIIHarness
   name: ripley MK-II harness
-  description: The core of the Ripley MK-II.
+  description: The core of the Ripley MK-II. Requires the Ripley limbs and the Ripley MK-II upgrade kit to begin assembly.
   components:
   - type: Appearance
   - type: ItemMapper

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mech_construction.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Mech/mech_construction.yml
@@ -14,7 +14,7 @@
   parent: BaseRipleyMKIIPart
   id: RipleyMKIIHarness
   name: ripley MK-II harness
-  description: The core of the Ripley MK-II. Requires the Ripley limbs and the Ripley MK-II upgrade kit to begin assembly.
+  description: The core of the Ripley MK-II. Requires the Ripley limbs and the Ripley MK-II upgrade kit inserted to begin assembly.
   components:
   - type: Appearance
   - type: ItemMapper


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Fixes localization for circuitry and uranium glass variants, Fixed Riley typo in the exofab categories to Ripley, Added info in the Ripley MK-II harness description for inserting the upgrade kit to start assembly. Removed mind over machine restrictions on the new healing word trait from upstream.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Fixed missing material localizations for circuitry and uranium glass variants.
- fix: Fixed typo in the exosuit fabricator drop down categories.
- tweak: Added info in the Ripley MK-II harness description on the initial parts required to be inserted to begin further construction.
- tweak: Removed mind over machine restriction on the new Healing Word trait from upstream.
