### PR TITLE
Language Trait Fixes, Tweaks and Changes

### DIFF
--- a/Resources/Locale/en-US/loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/loadouts/itemgroups.ftl
@@ -821,6 +821,7 @@ character-item-group-LoadoutPrisonerUniforms = Prisoner Uniforms
 character-item-group-TraitsLanguagesBasic = Basic Languages
 character-item-group-TraitsLanguagesRacial = Racial Languages
 character-item-group-TraitsAccents = Accents
+character-item-group-TraitsLanguagesTajaran = Tajaran Languages
 
 # Traits - Mind Or Machine
 character-item-group-TraitsMind = Mind Over Machine

--- a/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/languageGroups.yml
@@ -1,6 +1,6 @@
 - type: characterItemGroup
   id: TraitsLanguagesBasic
-  maxItems: 1
+  maxItems: 2
   items:
     - type: trait
       id: SignLanguage
@@ -19,7 +19,6 @@
 
 - type: characterItemGroup
   id: TraitsLanguagesRacial
-  maxItems: 1
   items:
     - type: trait
       id: ValyrianStandard
@@ -47,14 +46,6 @@
       id: Azaziba
     - type: trait
       id: SiikMaas
-    - type: trait
-      id: NalRasan
-    - type: trait
-      id: SiikTajr
-    - type: trait
-      id: YaSsa
-    - type: trait
-      id: Delvahii
     - type: trait
       id: Nehina
 
@@ -86,3 +77,16 @@
       id: MobsterAccent
     - type: trait
       id: SkeletonAccent
+
+- type: characterItemGroup
+  id: TraitsLanguagesTajaran
+  maxItems: 1
+  items:
+    - type: trait
+      id: NalRasan
+    - type: trait
+      id: SiikTajr
+    - type: trait
+      id: YaSsa
+    - type: trait
+      id: Delvahii

--- a/Resources/Prototypes/Traits/languages.yml
+++ b/Resources/Prototypes/Traits/languages.yml
@@ -45,10 +45,6 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsLanguagesBasic
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
   functions:
     - !type:TraitModifyLanguages
       languagesSpoken:
@@ -94,7 +90,7 @@
   points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
-      group: TraitsLanguagesBasic
+      group: TraitsLanguagesRacial
     - !type:CharacterNationalityRequirement
       inverted: true
       nationalities:

--- a/Resources/Prototypes/_EE/Traits/languages.yml
+++ b/Resources/Prototypes/_EE/Traits/languages.yml
@@ -1,10 +1,10 @@
 - type: trait
   id: SiikMaas
   category: TraitsSpeechLanguages
-  points: -1
+  points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
-      group: TraitsLanguagesBasic
+      group: TraitsLanguagesRacial
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
@@ -22,7 +22,7 @@
   points: -1
   requirements:
     - !type:CharacterItemGroupRequirement
-      group: TraitsLanguagesBasic
+      group: TraitsLanguagesTajaran
     - !type:CharacterSpeciesRequirement
       species:
         - Tajaran
@@ -39,7 +39,7 @@
   points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
-      group: TraitsLanguagesBasic
+      group: TraitsLanguagesTajaran
     - !type:CharacterSpeciesRequirement
       species:
         - Tajaran
@@ -56,7 +56,7 @@
   points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
-      group: TraitsLanguagesBasic
+      group: TraitsLanguagesTajaran
     - !type:CharacterSpeciesRequirement
       species:
         - Tajaran
@@ -73,7 +73,7 @@
   points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
-      group: TraitsLanguagesBasic
+      group: TraitsLanguagesTajaran
     - !type:CharacterSpeciesRequirement
       species:
         - Tajaran


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Mostly just some trait tweaks I missed last pr, these all language themed

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added new grouping for languages for Tajaran Languages (they can now take other languages plus their native)
- fix: Valyrian is back to being a racial language
- fix: Harpies can now take Tradeband again
- tweak: You can now take as many racial languages as you can afford
- tweak: Max basic languages now set to 2 up from 1
- tweak: Siik'Maas moved to racial language, now costs 2 from 1 to fit other racial languages
