### PR TITLE
Marking Whitelists

### DIFF
--- a/Resources/Prototypes/Floof/CharacterItemGroups/maskGroup.yml
+++ b/Resources/Prototypes/Floof/CharacterItemGroups/maskGroup.yml
@@ -50,10 +50,10 @@
     - type: loadout #TheDen
       id: LoadoutItemOniMaskRed
     - type: loadout #TheDen
-      id: LoadoutServiceMimeMask
+      id: LoadoutMimeMask
     - type: loadout #TheDen
-      id: LoadoutServiceMimeMaskSad
+      id: LoadoutMimeMaskSad
     - type: loadout #TheDen
-      id: LoadoutServiceMimeMaskScared
+      id: LoadoutMimeMaskScared
     - type: loadout #TheDen
-      id: LoadoutServiceMimeMaskSexy
+      id: LoadoutMimeMaskSexy

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -56,7 +56,7 @@
       points: 1
       required: false
     HeadTop:
-      points: 1
+      points: 4
       required: false
     HeadSide:
       points: 4

--- a/Resources/Prototypes/Species/slime.yml
+++ b/Resources/Prototypes/Species/slime.yml
@@ -57,10 +57,10 @@
       points: 1
       required: false
     Head:
-      points: 1
+      points: 4
       required: false
     HeadTop:
-      points: 2
+      points: 4
       required: false
     Chest:
       points: 4 # imp 1<4
@@ -78,7 +78,7 @@
       points: 1
       required: false
     RightLeg:
-      points: 2
+      points: 6
       required: false
     RightFoot:
       points: 6

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/misc.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Customization/Markings/misc.yml
@@ -112,7 +112,7 @@
   id: DionaFirefly
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [ Diona ]
+  speciesRestriction: [ Diona, IPC, Slimeperson ]
   forcedColoring: false
   followSkinColor: false
   sprites:
@@ -124,7 +124,7 @@
   id: DionaPollenDust
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [ Diona ]
+  speciesRestriction: [ Diona, IPC, Slimeperson ]
   forcedColoring: false
   followSkinColor: false
   sprites:
@@ -135,7 +135,7 @@
   id: DwarfBearCheeks
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   forcedColoring: true
   followSkinColor: false
   sprites:
@@ -147,7 +147,7 @@
   id: DwarfHeadGlow
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   forcedColoring: true
   followSkinColor: false
   sprites:
@@ -159,7 +159,7 @@
   id: DwarfConstellationHead
   bodyPart: Head
   markingCategory: Overlay
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -175,7 +175,7 @@
   id: DwarfConstellationChest
   bodyPart: Chest
   markingCategory: Overlay
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -191,7 +191,7 @@
   id: DwarfConstellationLArm
   bodyPart: LArm
   markingCategory: Overlay
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -207,7 +207,7 @@
   id: DwarfConstellationLHand
   bodyPart: LHand
   markingCategory: Overlay
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -223,7 +223,7 @@
   id: DwarfConstellationRArm
   bodyPart: RArm
   markingCategory: Overlay
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -239,7 +239,7 @@
   id: DwarfConstellationRHand
   bodyPart: RHand
   markingCategory: Overlay
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -255,7 +255,7 @@
   id: DwarfConstellationLLeg
   bodyPart: LLeg
   markingCategory: Overlay
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -271,7 +271,7 @@
   id: DwarfConstellationLFoot
   bodyPart: LFoot
   markingCategory: Overlay
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -287,7 +287,7 @@
   id: DwarfConstellationRLeg
   bodyPart: RLeg
   markingCategory: Overlay
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -303,7 +303,7 @@
   id: DwarfConstellationRFoot
   bodyPart: RFoot
   markingCategory: Overlay
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -319,7 +319,7 @@
   id: DwarfChestHair
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/markingsbundle1.rsi
     state: dwarfchesthair
@@ -328,7 +328,7 @@
   id: DwarfArmHair
   bodyPart: LArm
   markingCategory: LeftArm
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/markingsbundle1.rsi
     state: dwarfarmhair
@@ -337,7 +337,7 @@
   id: DwarfLegHair
   bodyPart: LLeg
   markingCategory: LeftLeg
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   sprites:
   - sprite: _Impstation/Mobs/Customization/markingsbundle1.rsi
     state: dwarfleghair
@@ -346,7 +346,7 @@
   id: DwarfTattooShootingStar
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -361,7 +361,7 @@
   id: DwarfMarkBear
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -376,7 +376,7 @@
   id: DwarfMarkKangarooLHand
   bodyPart: LHand
   markingCategory: LeftHand
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -391,7 +391,7 @@
   id: DwarfMarkKangarooRHand
   bodyPart: RHand
   markingCategory: RightHand
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -406,7 +406,7 @@
   id: DwarfMarkCobra
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:
@@ -421,7 +421,7 @@
   id: DwarfMarkSpider
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [ Dwarf ]
+  speciesRestriction: [ Dwarf, Human, Felinid, Canid, Oni, Slimeperson ]
   coloring:
     default:
       type:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Allows Onis, Humans, Canids, Felinids, and Slimepersons to have the dwarf glowing tattoos from the Impstation marking ports, also allows IPCs and Slimepersons to have the firefly and pollen overlay markings. Added more marking slots to head markings for Slimepersons and Humans by request.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Allowed Onis, Humans, Canids, Felinids, and Slimepersons to have the animated tattoo markings from the Impstation markings port.
- tweak: Gave Humans and Slimes more head marking slots.
