### PR TITLE
Vocal Dionae, Take Two

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3738,6 +3738,13 @@
       gender: epicene
   - type: Speech
     speechVerb: Plant
+    speechSounds: Alto
+    allowedEmotes: ['Chirp']
+  - type: Vocal
+    sounds:
+      Male: UnisexDiona
+      Female: UnisexDiona
+      Unsexed: UnisexDiona
   - type: Tag
     tags:
     - DoorBumpOpener

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -89,6 +89,7 @@
     templateId: diona
   - type: Speech
     speechVerb: Plant
+    allowedEmotes: ['Chirp']
   - type: Vocal
     sounds:
       Male: UnisexDiona

--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -364,6 +364,8 @@
       path: /Audio/Voice/Diona/diona_scream.ogg
     Laugh:
       collection: DionaLaugh
+    Chirp:
+      path: /Audio/Animals/nymph_chirp.ogg
     Honk:
       collection: BikeHorn
     Weh:

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -274,11 +274,16 @@
   id: Chirp
   name: chat-emote-name-chirp
   category: Vocal
+  available: false
   icon: Interface/Emotes/chirp.png
   whitelist:
     requireAll: false
     components:
     - Nymph
+    - Vocal
+  blacklist:
+    components:
+    - BorgChassis
     tags:
     - HarpyEmotes
   chatMessages: ["chat-emote-msg-chirp"]


### PR DESCRIPTION
# Description

My dumbass forgot to set the right branch the first time. Brings over PR #32511 by Pinkbat5 from WizDen, which (if I did this right) will allow for the whole three (3) Diona players on The Den to be able to use the chirp emote while in their adult Diona form, and allow for Nymphs to have the same screaming and laughing SFX as the aforementioned adult form.

---

# Changelog

:cl:
- add: Dionae can be noisy now! Added the chirp emote and associated sound for Diona, along with screaming and laughing sounds for Nymphs!