### PR TITLE
Belt Changes and Side Tweaks

### DIFF
--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -3,6 +3,10 @@ ghost-role-component-default-rules = All normal rules apply unless an administra
                                      You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
                                      You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
                                      You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
+ghost-role-information-freeagent-rules = You are a [color=yellow][bold]Free Agent[/bold][/color]. You are free to act as either an antagonist or a non-antagonist.
+                                         You don't remember any of your previous life, and you don't remember anything you learned as a ghost.
+                                         You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
+                                         You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 
 ghost-role-information-mouse-name = Mouse
 ghost-role-information-mouse-description = A hungry and mischievous mouse.
@@ -53,7 +57,7 @@ ghost-role-information-xeno-rules = You are an antagonist, smack, slash, and wac
 ghost-role-information-friendlyxeno-name = Xeno Subject
 ghost-role-information-friendlyxeno-description = You are a friendly xeno, co-operate with the crew and protect the station!
 ghost-role-information-friendlyxeno-rules = You are a friendly xeno.
-                                    Your objective is to cooperate with any sophonts and not bring harm to the crew. 
+                                    Your objective is to cooperate with any sophonts and not bring harm to the crew.
                                     Do your best to be helpful and don't give anyone a reason to fear you.
 
 ghost-role-information-revenant-name = Revenant

--- a/Resources/Prototypes/Entities/Clothing/Belt/base_clothingbelt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/base_clothingbelt.yml
@@ -46,7 +46,7 @@
     grid:
     - 0,0,7,1
   - type: Item
-    size: Large
+    size: Ginormous
   - type: ContainerContainer
     containers:
       storagebase: !type:Container

--- a/Resources/Prototypes/InventoryTemplates/ipc_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/ipc_inventory_template.yml
@@ -67,6 +67,8 @@
         - IdentityBlocker
         tags:
         - IPCMaskWearable
+        - Cigarette
+        - Cigar
     - name: eyes
       slotTexture: glasses
       slotFlags: EYES

--- a/Resources/Prototypes/_Imp/_Drone/Mobs_Player_silicon.yml
+++ b/Resources/Prototypes/_Imp/_Drone/Mobs_Player_silicon.yml
@@ -210,6 +210,12 @@
     mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
   - type: StepTriggerImmune
+    whitelist:
+    types:
+      - Shard
+      - Landmine
+      - Mousetrap
+      - SlipEntity
   - type: InputMover
   - type: MobMover
   - type: ContentEye

--- a/Resources/Prototypes/_Imp/_Drone/Mobs_Player_silicon.yml
+++ b/Resources/Prototypes/_Imp/_Drone/Mobs_Player_silicon.yml
@@ -211,11 +211,11 @@
     autoRot: true
   - type: StepTriggerImmune
     whitelist:
-    types:
-      - Shard
-      - Landmine
-      - Mousetrap
-      - SlipEntity
+      types:
+        - Shard
+        - Landmine
+        - Mousetrap
+        - SlipEntity
   - type: InputMover
   - type: MobMover
   - type: ContentEye


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Changes belt sizes back to their prior ginormous size, preventing them from fitting in bags. Fixed maintenance drones to not slip or step on shards. IPCs can now equip cigs for style points. Adds the missing localization for the free agent ghost roles from upstream.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Reverted belts to being unable to fit in bags once more.
- tweak: IPCs can look cool with cigs on their faces now.
- fix: Fixed maintenance drones being able to step on shards of glass.
