### PR TITLE
I Am Once Again Fixing Azaziba

### DIFF
--- a/Resources/Prototypes/Traits/languages.yml
+++ b/Resources/Prototypes/Traits/languages.yml
@@ -129,7 +129,7 @@
       species:
         - Reptilian
     - !type:CharacterItemGroupRequirement
-      group: TraitsLanguagesBasic
+      group: TraitsLanguagesRacial
   functions:
     - !type:TraitModifyLanguages
       languagesSpoken:


### PR DESCRIPTION
# Description


this time it'll work I swear.

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Azaziba language _SHOULD_ work now