### PR TITLE
Psionic Insulation Tweaks

### DIFF
--- a/Resources/Locale/en-US/_DEN/traits/misc.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/misc.ftl
@@ -1,1 +1,2 @@
 examine-hypnotist-message = {CAPITALIZE(POSS-ADJ($entity))} eyes hold the secrets of your mind.
+examine-psionic-insulation-message = {CAPITALIZE(POSS-ADJ($entity))} eyes carry the hallmarks of psionic insulation.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -323,8 +323,7 @@ trait-description-LatentPsychic =
 
 trait-name-PsionicInsulation = χ Waveform Misalignment
 trait-description-PsionicInsulation =
-    You are a flesh automaton animated by neurotransmitters. Within your skull lies a
-    1.5kg sack of meat pretending at sentience. By modern epistemiological theory, you aren't even a sophont.
+    Whether through implants or by way of innate psionic insulation, your consciousness is isolated from the noosphere.
     The good news is that you are immune to most positive and negative effects of psychic powers.
     There may be other consequences to this malady.
 
@@ -674,5 +673,5 @@ trait-description-Weakling =
 
 trait-name-Bodybuilder = Bodybuilder
 trait-description-Bodybuilder =
-    Through extensive training or body modification, you have achieved the pinnacle of physique. 
+    Through extensive training or body modification, you have achieved the pinnacle of physique.
     This trait halves the movement speed penalty when dragging something.

--- a/Resources/Prototypes/Actions/psionics.yml
+++ b/Resources/Prototypes/Actions/psionics.yml
@@ -29,10 +29,6 @@
       checkCanAccess: false
       range: 8
       itemIconStyle: BigAction
-      blacklist:
-        components:
-          - PsionicInsulation
-          - Mindbroken
       event: !type:MassSleepPowerActionEvent
 
 - type: entity

--- a/Resources/Prototypes/Actions/psionics.yml
+++ b/Resources/Prototypes/Actions/psionics.yml
@@ -29,6 +29,10 @@
       checkCanAccess: false
       range: 8
       itemIconStyle: BigAction
+      blacklist:
+        components:
+          - PsionicInsulation
+          - Mindbroken
       event: !type:MassSleepPowerActionEvent
 
 - type: entity

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -254,7 +254,11 @@
     - !type:TraitAddComponent
       components:
         - type: PsionicInsulation
-        - type: Mindbroken
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-psionic-insulation-message
+          fontSize: 12
+          requireDetailRange: true
   requirements:
     - !type:CharacterJobRequirement
       inverted: true


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Tweaks the waveform misalignment trait text on the loadout screen, adds a new examine text for it as well.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Grip someone firmly and get them to test the PR for me to see if Psionically Insulated people still gain powers and if the mass sleep immunity works.
- [x] Do the PR

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked the trait flavor text for Waveform Misalignment and the examine text for it.
