### PR TITLE
Ported a Number of Energy Gun Buffs and Tweaks From DeltaV

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -80,15 +80,15 @@
     startingCharge: 1000
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
-    fireCost: 50
+    fireCost: 25
   - type: EnergyGun
     fireModes:
     - proto: BulletDisabler
-      fireCost: 50
+      fireCost: 25
       name: disable
       state: disabler
     - proto: BulletEnergyGunLaser
-      fireCost: 100
+      fireCost: 50
       name: lethal
       state: lethal
     # - proto: BulletEnergyGunIon

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -263,8 +263,10 @@
 
 - type: entity
   name: IK-60 energy carbine
+  name: IK-60 energy carbine
   parent: BaseWeaponBattery
   id: WeaponGunLaserCarbineAutomatic
+  description: "A 20 round semi-automatic energy carbine."
   description: "A 20 round semi-automatic energy carbine."
   components:
   - type: Sprite

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -263,7 +263,6 @@
 
 - type: entity
   name: IK-60 energy carbine
-  name: IK-60 energy carbine
   parent: BaseWeaponBattery
   id: WeaponGunLaserCarbineAutomatic
   description: "A 20 round hybrid-fire energy carbine."

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -23,8 +23,8 @@
     soundEmpty:
       path: /Audio/DeltaV/Weapons/Guns/Empty/dry_fire.ogg
   - type: Battery
-    maxCharge: 1000
-    startingCharge: 1000
+    maxCharge: 1500
+    startingCharge: 1500
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
     fireCost: 50
@@ -210,8 +210,8 @@
     soundEmpty:
       path: /Audio/DeltaV/Weapons/Guns/Empty/dry_fire.ogg
   - type: Battery
-    maxCharge: 800
-    startingCharge: 800
+    maxCharge: 1000
+    startingCharge: 1000
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
     fireCost: 50
@@ -266,8 +266,7 @@
   name: IK-60 energy carbine
   parent: BaseWeaponBattery
   id: WeaponGunLaserCarbineAutomatic
-  description: "A 20 round semi-automatic energy carbine."
-  description: "A 20 round semi-automatic energy carbine."
+  description: "A 20 round hybrid-fire energy carbine."
   components:
   - type: Sprite
     sprite: DeltaV/Objects/Weapons/Guns/Battery/energygun_carbine.rsi
@@ -288,9 +287,10 @@
     fireRate: 3
     availableModes:
       - SemiAuto
+      - FullAuto
   - type: Battery
-    maxCharge: 2000
-    startingCharge: 2000
+    maxCharge: 3000
+    startingCharge: 3000
   - type: ProjectileBatteryAmmoProvider
     proto: BulletEnergyGunLaser
     fireCost: 100

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1041,7 +1041,7 @@
     impactEffect: BulletImpactEffectRedDisabler
     damage:
       types:
-        Heat: 20 # Slightly more damage than the 17heat from the Captain's Hitscan lasgun
+        Heat: 24 # Slightly more damage than the 17heat from the Captain's Hitscan lasgun, these will hurt but not quite a 4 shot
     soundHit:
       collection: MeatLaserImpact
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->
Ported a number of Energy Gun buffs from DeltaV. The aim is to make them more competitive with laser and ballistic weapons given their slow bolt projectile and limited battery life.
This primarily benefits security once E-Guns have been researched, and makes them a more viable option for a round start service weapon for Sec Offs & HoS.

- Charging times cut in half across the board
- Ik-60 given full auto-select fire
- X-01 Multiphase Energy Pistol given double the capacity

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: DeltaV
- tweak:  Improved energy guns across the board
