### PR TITLE
Remove Ashing

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -73,21 +73,21 @@
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:BurnBodyBehavior { }
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
+#    - trigger: # Removed ashing April 22nd 25
+#        !type:DamageTypeTrigger
+#        damageType: Heat
+#        damage: 1500
+#      behaviors:
+#      - !type:SpawnEntitiesBehavior
+#        spawnInContainer: true
+#        spawn:
+#          Ash:
+#            min: 1
+#            max: 1
+#      - !type:BurnBodyBehavior { }
+#      - !type:PlaySoundBehavior
+#        sound:
+#          collection: MeatLaserImpact
   - type: RadiationReceiver
   - type: Stamina
   - type: MobState


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Removes ashing from excessive heat damage/fire
Round Removal you cant even control, or do anything about, as the behaviour tends to occour fast, suddenly, and theres alotta times you cant do anything about it. No other damage besides  blunt is round-removing, and blunt has to be player-done, or a catastophic explosion.
Suppose theres poison or rads but you have cryogenics to fix that.
Theres so many sources of accidental heat, and the capacity to ash multiple people is crazy.
This PR simply removes the ashing behaviour, you can still be soft-RRd by taking billions of heat damage though.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Fox
- remove: Bodies will no longer ash when exposed to extreme heat. Toasty.
