### PR TITLE
Quicktweaks

### DIFF
--- a/Resources/Prototypes/Datasets/tips.yml
+++ b/Resources/Prototypes/Datasets/tips.yml
@@ -171,3 +171,4 @@
   - "NanoTrasen prefers to select its command staff for high psychic potential. Thus, all command staff are inherently more likely to obtain Psychic Powers should they also have the Latent Psychic trait."
   - "You can craft a tinfoil hat out of sheet metal. Wearing a tinfoil hat provides temporary protection from Psychic Powers! Beware, that it also disrupts the powers of any Psion who wears one."
   - "You can press the R key to lay down on the ground. While Laying down, you can crawl underneath certain objects. Additionally, bullets will pass harmlessly over someone laying down, unless the shooter targets them directly."
+  - "You can add hot water to ramen cups to cook them."

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
@@ -99,11 +99,15 @@
   - type: Clothing
     sprite: Nyanotrasen/Clothing/Head/Hats/cage.rsi
     equipDelay: 0.5
-    unequipDelay: 6
+    unequipDelay: 10
+  - type: TinfoilHat
+    destroyOnFry: false
   - type: HeadCage
   - type: Tag
     tags:
     - ForensicBeltEquip
+  - type: GuideHelp
+    guides: [ PsionicInsulation ]
 
 - type: entity
   parent: ClothingHeadTinfoil
@@ -115,6 +119,8 @@
     sprite: Nyanotrasen/Clothing/Head/Helmets/insulative_skullcap.rsi
   - type: Clothing
     sprite: Nyanotrasen/Clothing/Head/Helmets/insulative_skullcap.rsi
+  - type: TinfoilHat
+    destroyOnFry: false
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Recipes/Lathes/sheet.yml
+++ b/Resources/Prototypes/Recipes/Lathes/sheet.yml
@@ -3,7 +3,7 @@
   result: SheetSteel1
   applyMaterialDiscount: false
   miningPoints: 1
-  completetime: 0.0083 # 0.25 per 30
+  completetime: 0 # 0.25 per 30
   materials:
     RawIron: 100
     Coal: 30
@@ -21,7 +21,7 @@
   result: SheetGlass1
   applyMaterialDiscount: false
   miningPoints: 1 # 0.25 per 30
-  completetime: 0.0083
+  completetime: 0
   materials:
     RawQuartz: 100
 
@@ -37,7 +37,7 @@
   result: SheetRGlass1
   applyMaterialDiscount: false
   miningPoints: 1
-  completetime: 0.025 # 0.75 per 30
+  completetime: 0 # 0.75 per 30
   materials:
     Glass: 100
     Steel: 50
@@ -55,7 +55,7 @@
 - type: latheRecipe
   id: SheetPGlass1
   result: SheetPGlass1
-  completetime: 0.0083 # 0.75 per 30
+  completetime: 0 # 0.75 per 30
   miningPoints: 16
   materials:
     RawQuartz: 100
@@ -72,7 +72,7 @@
 - type: latheRecipe
   id: SheetRPGlass1
   result: SheetRPGlass1
-  completetime: 0.025 # 0.75 per 30
+  completetime: 0 # 0.75 per 30
   miningPoints: 16
   materials:
     RawQuartz: 100
@@ -93,7 +93,7 @@
 - type: latheRecipe
   id: SheetPlasma1
   result: SheetPlasma1
-  completetime: 0.0116 # 0.35 per 30
+  completetime: 0 # 0.35 per 30
   miningPoints: 15
   materials:
     RawPlasma: 100
@@ -108,7 +108,7 @@
 - type: latheRecipe
   id: SheetPlasteel1
   result: SheetPlasteel1
-  completetime: 0.025 # 0.75 per 30
+  completetime: 0 # 0.75 per 30
   miningPoints: 17
   materials:
     RawPlasma: 100
@@ -134,7 +134,7 @@
 - type: latheRecipe
   id: SheetUGlass1
   result: SheetUGlass1
-  completetime: 0.0083 # 0.25 per 30
+  completetime: 0 # 0.25 per 30
   miningPoints: 31
   materials:
     RawUranium: 100
@@ -151,7 +151,7 @@
 - type: latheRecipe
   id: SheetRUGlass1
   result: SheetRUGlass1
-  completetime: 0.025 # 0.75 per 30
+  completetime: 0 # 0.75 per 30
   miningPoints: 31
   materials:
     RawUranium: 100
@@ -193,7 +193,7 @@
 - type: latheRecipe
   id: MaterialDiamond
   result: MaterialDiamond1
-  completetime: 0.026 # 0.8 over 30
+  completetime: 0 # 0.8 over 30
   miningPoints: 50
   materials:
     RawDiamond: 100
@@ -201,7 +201,7 @@
 - type: latheRecipe
   id: SheetUranium1
   result: SheetUranium1
-  completetime: 0.02 # 0.6 seconds for 30
+  completetime: 0 # 0.6 seconds for 30
   miningPoints: 30
   materials:
     RawUranium: 100
@@ -209,7 +209,7 @@
 - type: latheRecipe
   id: IngotGold1
   result: IngotGold1
-  completetime: 0.016 # 0.5 over 30
+  completetime: 0 # 0.5 over 30
   miningPoints: 18
   materials:
     RawGold: 100
@@ -217,7 +217,7 @@
 - type: latheRecipe
   id: IngotSilver1
   result: IngotSilver1
-  completetime: 0.013 # 0.4 over 30
+  completetime: 0 # 0.4 over 30
   miningPoints: 16
   materials:
     RawSilver: 100
@@ -233,7 +233,7 @@
 - type: latheRecipe
   id: MaterialBananium1
   result: MaterialBananium1
-  completetime: 0.1 # 1 over 10
+  completetime: 0 # 1 over 10
   miningPoints: 60
   materials:
     RawBananium: 100
@@ -291,7 +291,7 @@
   result: IngotTungsten1
   applyMaterialDiscount: false
   miningPoints: 5
-  completetime: 0.13 # Or, 4 seconds over 30 ingots.
+  completetime: 0 # Or, 4 seconds over 30 ingots.
   materials:
     RawTungsten: 100
     RawIron: 100

--- a/Resources/Prototypes/_Nuclear14/Recipes/Lathes/materials.yml
+++ b/Resources/Prototypes/_Nuclear14/Recipes/Lathes/materials.yml
@@ -3,14 +3,14 @@
   result: N14IngotLead1
   miningPoints: 10
   applyMaterialDiscount: false
-  completetime: 0.01 # 0.3 per 30
+  completetime: 0 # 0.3 per 30
   materials:
     RawLead: 100
 
 - type: latheRecipe
   id: IngotCopper1
   result: IngotCopper1
-  completetime: 0.016 # 0.5 per 30
+  completetime: 0 # 0.5 per 30
   miningPoints: 10
   materials:
     RawCopper: 100
@@ -19,7 +19,7 @@
 - type: latheRecipe
   id: N14IngotAluminium1
   result: N14IngotAluminium1
-  completetime: 0.016 # 0.5 per 30
+  completetime: 0 # 0.5 per 30
   miningPoints: 10
   materials:
     RawAluminium: 100


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds a tip to the loading screen about adding hot water to ramen cups, makes ore processing instant again to prevent client side crashes, makes headcages take longer to remove, makes both insulative skullcaps and headcages unable to burn up on noospheric fry events.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added loading screen tip about hot water in ramen cups.
- tweak: Tweaked ore processing to be instant again.
- tweak: Tweaked both insulative skullcaps and headcages to be unable to ignite on noospheric fry events. Headcages take longer to take off as well.
