### PR TITLE
Revert "Cyber Eye Changes (#1876)"

### DIFF
--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -528,11 +528,11 @@ trait-description-CyberEyesSecurity =
 
 trait-name-CyberEyesMedical = Cyber-Eyes: MedHud Module
 trait-description-CyberEyesMedical =
-    Your Cyber-Eyes have been upgraded to include a built-in Medical Hud, and a Chemical Analysis Hud, allowing you to track the relative health condition of biological organisms, and discern the chemicals in any solution.
+    Your eyes have been upgraded to include a built-in Diagnostic Hud and flare shielding, allowing you to track the condition of synthetic entities, and providing eye protection against welding arcs.
 
 trait-name-CyberEyesDiagnostic = Cyber-Eyes: Diagnostics Module
 trait-description-CyberEyesDiagnostic =
-    Your Cyber-Eyes have been upgraded to include a built-in Diagnostic Hud, allowing you to track the condition of synthetic entities.
+    Your Cyber-Eyes have been upgraded to include a built-in Diagnostic Hud and flare shielding, allowing you to track the condition of synthetic entities, and providing eye protection against welding arcs.
 
 trait-name-CyberEyesOmni = Cyber-Eyes: Premium Suite Module
 trait-description-CyberEyesOmni =

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -516,10 +516,10 @@ trait-description-CyberEyes =
     Their most basic functionality is to provide amelioration for weaknesses of the wearer's natural eyes.
     The functionality of these implants can be extended by a variety of commercially available modules.
 
-# trait-name-FlareShielding = Cyber-Eyes: Eye Damage Resistance
-# trait-description-FlareShielding =
-#    Your cybereyes have been fitted with a photochromic lense that automatically darkens in response to intense stimuli.
-#    This provides immunity from most bright flashes of light, such as those from welding arcs.
+trait-name-FlareShielding = Cyber-Eyes: Eye Damage Resistance
+trait-description-FlareShielding =
+    Your cybereyes have been fitted with a photochromic lense that automatically darkens in response to intense stimuli.
+    This provides immunity from most bright flashes of light, such as those from welding arcs.
 
 trait-name-CyberEyesSecurity = Cyber-Eyes: SecHud Module
 trait-description-CyberEyesSecurity =
@@ -532,7 +532,7 @@ trait-description-CyberEyesMedical =
 
 trait-name-CyberEyesDiagnostic = Cyber-Eyes: Diagnostics Module
 trait-description-CyberEyesDiagnostic =
-    Your Cyber-Eyes have been upgraded to include a built-in Diagnostic Hud and flare shielding, allowing you to track the condition of synthetic entities, and providing eye protection against welding arcs.
+    Your Cyber-Eyes have been upgraded to include a built-in Diagnostic Hud, allowing you to track the condition of synthetic entities.
 
 trait-name-CyberEyesOmni = Cyber-Eyes: Premium Suite Module
 trait-description-CyberEyesOmni =
@@ -632,7 +632,7 @@ trait-description-MedicalEyesModule =
 
 trait-name-DiagnosticEyesModule = I.P.C Eye Module: Diagnostics
 trait-description-DiagnosticEyesModule =
-    Your eyes have been upgraded to include a built-in Diagnostic Hud and flare shielding, allowing you to track the condition of synthetic entities, and providing eye protection against welding arcs.
+    You possess a built-in Diagnostic Hud, allowing you to track the condition of synthetic entities.
 
 trait-name-OmniEyesModule = I.P.C Eye Module: Premium Model
 trait-description-OmniEyesModule =

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -518,7 +518,7 @@ trait-description-CyberEyes =
 
 trait-name-FlareShielding = Cyber-Eyes: Eye Damage Resistance
 trait-description-FlareShielding =
-    Your cybereyes have been fitted with a photochromic lense that automatically darkens in response to intense stimuli.
+    Your cybereyes have been fitted with a photochromic lens that automatically darkens in response to intense stimuli.
     This provides immunity from most bright flashes of light, such as those from welding arcs.
 
 trait-name-CyberEyesSecurity = Cyber-Eyes: SecHud Module
@@ -618,7 +618,7 @@ trait-description-BionicLeg =
 
 trait-name-FlareShieldingModule = I.P.C Eye Module: Flare Shielding
 trait-description-FlareShieldingModule =
-   Your eyes have been fitted with a photochromic lense that automatically darkens in response to intense stimuli.
+   Your eyes have been fitted with a photochromic lens that automatically darkens in response to intense stimuli.
    This provides immunity from most bright flashes of light, such as those from welding arcs.
 
 trait-name-SecurityEyesModule = I.P.C Eye Module: Sechud

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -618,9 +618,8 @@ trait-description-BionicLeg =
 
 trait-name-FlareShieldingModule = I.P.C Eye Module: Flare Shielding
 trait-description-FlareShieldingModule =
-   Your cybereyes have been fitted with a photochromic lense that automatically darkens in response to intense stimuli.
-   This provides immunity from most bright flashes of light, such as those from welding arcs, exclusive to IPCs because it only needs the module
-   skipping the eye insertion process.
+   Your eyes have been fitted with a photochromic lense that automatically darkens in response to intense stimuli.
+   This provides immunity from most bright flashes of light, such as those from welding arcs.
 
 trait-name-SecurityEyesModule = I.P.C Eye Module: Sechud
 trait-description-SecurityEyesModule =
@@ -628,7 +627,7 @@ trait-description-SecurityEyesModule =
 
 trait-name-MedicalEyesModule = I.P.C Eye Module: Medical
 trait-description-MedicalEyesModule =
-    Your Cyber-Eyes have been upgraded to include a built-in Medical Hud, and a Chemical Analysis Hud, allowing you to track the relative health condition of biological organisms, and discern the chemicals in any solution.
+    Your eyes have been upgraded to include a built-in Medical Hud, and a Chemical Analysis Hud, allowing you to track the relative health condition of biological organisms, and discern the chemicals in any solution.
 
 trait-name-DiagnosticEyesModule = I.P.C Eye Module: Diagnostics
 trait-description-DiagnosticEyesModule =

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -528,11 +528,11 @@ trait-description-CyberEyesSecurity =
 
 trait-name-CyberEyesMedical = Cyber-Eyes: MedHud Module
 trait-description-CyberEyesMedical =
-    Your eyes have been upgraded to include a built-in Diagnostic Hud and flare shielding, allowing you to track the condition of synthetic entities, and providing eye protection against welding arcs.
+    Your Cyber-Eyes have been upgraded to include a built-in Medical Hud, and a Chemical Analysis Hud, allowing you to track the relative health condition of biological organisms, and discern the chemicals in any solution.
 
 trait-name-CyberEyesDiagnostic = Cyber-Eyes: Diagnostics Module
 trait-description-CyberEyesDiagnostic =
-    Your Cyber-Eyes have been upgraded to include a built-in Diagnostic Hud and flare shielding, allowing you to track the condition of synthetic entities, and providing eye protection against welding arcs.
+    Your eyes have been upgraded to include a built-in Diagnostic Hud and flare shielding, allowing you to track the condition of synthetic entities, and providing eye protection against welding arcs.
 
 trait-name-CyberEyesOmni = Cyber-Eyes: Premium Suite Module
 trait-description-CyberEyesOmni =

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -532,7 +532,7 @@ trait-description-CyberEyesMedical =
 
 trait-name-CyberEyesDiagnostic = Cyber-Eyes: Diagnostics Module
 trait-description-CyberEyesDiagnostic =
-    Your eyes have been upgraded to include a built-in Diagnostic Hud and flare shielding, allowing you to track the condition of synthetic entities, and providing eye protection against welding arcs.
+    Your Cyber-Eyes have been upgraded to include a built-in Diagnostic Hud and flare shielding, allowing you to track the condition of synthetic entities, and providing eye protection against welding arcs.
 
 trait-name-CyberEyesOmni = Cyber-Eyes: Premium Suite Module
 trait-description-CyberEyesOmni =
@@ -632,7 +632,7 @@ trait-description-MedicalEyesModule =
 
 trait-name-DiagnosticEyesModule = I.P.C Eye Module: Diagnostics
 trait-description-DiagnosticEyesModule =
-    You possess a built-in Diagnostic Hud, allowing you to track the condition of synthetic entities.
+    Your eyes have been upgraded to include a built-in Diagnostic Hud and flare shielding, allowing you to track the condition of synthetic entities, and providing eye protection against welding arcs.
 
 trait-name-OmniEyesModule = I.P.C Eye Module: Premium Model
 trait-description-OmniEyesModule =

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -14,6 +14,7 @@
         - Photophobia
         - Nearsighted
         - CyberEyes
+        - FlareShieldingModule
         - SecurityEyesModule
         - MedicalEyesModule
         - DiagnosticEyesModule
@@ -40,6 +41,7 @@
       traits:
         - Blindness
         - CyberEyes
+        - FlareShieldingModule
         - SecurityEyesModule
         - MedicalEyesModule
         - DiagnosticEyesModule
@@ -306,6 +308,7 @@
       traits:
         - Blindness
         - CyberEyes
+        - FlareShieldingModule
         - SecurityEyesModule
         - MedicalEyesModule
         - DiagnosticEyesModule

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -659,10 +659,9 @@
   category: Physical
   points: -4
   requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
     - !type:CharacterTraitRequirement
       traits:
         - CyberEyes
@@ -951,10 +950,9 @@
   category: Physical
   points: -4
   requirements:
-    - !type:CharacterJobRequirement
-      inverted: true
-      jobs:
-        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
     - !type:CharacterSpeciesRequirement
       species:
         - IPC

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -654,22 +654,23 @@
         - type: Flashable # Effectively, removes any flash-vulnerability species traits.
 
 
-# - type: trait
-#  id: FlareShielding
-#  category: Physical
-#  points: -3
-#  requirements:
-#    - !type:CharacterJobRequirement
-#      inverted: true
-#      jobs:
-#        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-#    - !type:CharacterTraitRequirement
-#      traits:
-#        - CyberEyes
-#  functions:
-#    - !type:TraitAddComponent
-#      components:
-#        - type: EyeProtection
+- type: trait
+  id: FlareShielding
+  category: Physical
+  points: -4
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterTraitRequirement
+      traits:
+        - CyberEyes
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: FlashImmunity
+        - type: EyeProtection
 
 
 - type: trait
@@ -945,33 +946,6 @@
       protoId: SpeedRightLeg
       slotId: "right leg"
 
-
-# - type: trait
-#  id: FlareShieldingModule
-#  category: Physical
-#  points: -4
-#  requirements:
-#    - !type:CharacterJobRequirement
-#      inverted: true
-#      jobs:
-#        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
-#    - !type:CharacterSpeciesRequirement
-#      species:
-#        - IPC
-#    - !type:CharacterTraitRequirement
-#      inverted: true
-#      traits:
-#       - Photophobia
-#        - Blindness
-#        - Nearsighted
-#    - !type:CharacterItemGroupRequirement
-#      group: TraitsMind
-#  functions:
-#    - !type:TraitAddComponent
-#      components:
-#        - type: FlashImmunity
-#        - type: EyeProtection
-
 - type: trait
   id: FlareShieldingModule
   category: Physical
@@ -984,6 +958,14 @@
     - !type:CharacterSpeciesRequirement
       species:
         - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - Photophobia
+        - Blindness
+        - Nearsighted
+    - !type:CharacterItemGroupRequirement
+      group: TraitsMind
   functions:
     - !type:TraitAddComponent
       components:


### PR DESCRIPTION
This reverts commit 516c53e8ea97680b8029b79dae9fab0a229d0709.

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Reverts the flash resistant eyes back to existing (though slightly more expensive to take in line with outer eye upgrades)

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Readded flash resistant cybereyes
