### PR TITLE
Mop Damage Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -11,14 +11,14 @@
     range: 1.85
     damage:
       types:
-        Blunt: 2
+        Blunt: 5
     bluntStaminaDamageFactor: 3
     heavyRateModifier: 1.25
     heavyRangeModifier: 1.25
     heavyDamageBaseModifier: 1.25
     heavyStaminaCost: 7.5
     maxTargets: 2
-    angle: 180
+    angle: 120
     soundHit:
       collection: MetalThud
   - type: DamageOtherOnHit
@@ -32,7 +32,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 5
+        Blunt: 4
   - type: Item
     size: Large
     sprite: Objects/Specific/Janitorial/mop.rsi
@@ -69,20 +69,20 @@
       range: 1.85
       damage:
         types:
-          Blunt: 2
+          Blunt: 7.5
       bluntStaminaDamageFactor: 3
       heavyRateModifier: 1.25
       heavyRangeModifier: 1.25
       heavyDamageBaseModifier: 1.25
       heavyStaminaCost: 7.5
       maxTargets: 2
-      angle: 180
+      angle: 120
       soundHit:
          collection: MetalThud
     - type: DamageOtherOnHit
       damage:
         types:
-          Blunt: 6
+          Blunt: 7
       staminaCost: 8
     - type: Spillable
       solution: absorbed
@@ -90,7 +90,7 @@
     - type: IncreaseDamageOnWield
       damage:
         types:
-          Blunt: 5
+          Blunt: 4.5
     - type: Item
       size: Large
       sprite: Objects/Specific/Janitorial/advmop.rsi


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Increase the damage of the mop and advanced mop so they are actually usable as improvised weapons (adv mop being slightly better than the standard mop) but reducing wideswing angle in return.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Increased mop and advanced mop damage! 
