### PR TITLE
Rodentia, Chitinid, FastMetabolism Hunger Fix

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/chitinid.yml
@@ -11,7 +11,7 @@
     - HeadTop
 
   - type: Hunger
-    baseDecayRate: 0.0467 #needs to eat more to survive
+    baseDecayRate: 0.0221666666 # Floofstation, changed from 0.0467 so it's actually 33% faster. Original number came from DeltaV, which has a much higher base hunger rate. Original comment: needs to eat more to survive
   - type: Thirst
 
   - type: Carriable

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/rodentia.yml
@@ -9,7 +9,7 @@
     species: Rodentia
   - type: Thirst
   - type: Hunger
-    baseDecayRate: 0.0467 # 33% faster than usual
+    baseDecayRate: 0.0221666666 # Floofstation, changed from 0.0467 so it's actually 33% faster. Original number came from DeltaV, which has a much higher base hunger rate
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Inventory
     speciesId: rodentia

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -10,7 +10,7 @@
   - type: Hunger
     baseDecayRate: 0.0083
   - type: Thirst
-    baseDecayRate: 0.0083
+    baseDecayRate: 0.05 # TheDen, changed from 0.0083 so it's properly at half the standard rate.
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Icon
     sprite: Mobs/Species/Diona/parts.rsi

--- a/Resources/Prototypes/_DEN/Traits/disabilities.yml
+++ b/Resources/Prototypes/_DEN/Traits/disabilities.yml
@@ -15,8 +15,9 @@
         - Chitinid
         - Rodentia
         - Tajaran
+        - Vulpkanin
   functions:
     - !type:TraitReplaceComponent
       components:
         - type: Hunger
-          baseDecayRate: 0.0467
+          baseDecayRate: 0.0221666666


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Ports https://github.com/Fansana/floofstation1/pull/897 and also fixes your FastMetabolism trait. Also locks Vulps out of Fast Metabolism since they already have accelerated hunger. 

For reference, DeltaV (originating fork of the races) has a much higher baseDecayRate for hunger. Rodentia, Chitinid, and Fast Metabolism all had a ~180% increase instead of 33%. Go figure.

Additionally makes a tweak on Diona thirst so it's not insanely slow based on discussion had in the PR.

This is a very silly thing I've done and I haven't even played on the server yet.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Cherry-pick https://github.com/Fansana/floofstation1/pull/897
- [x] Adjust Fast Metabolism
- [x] Adjust Diona thirst decay

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

Eh

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: Chitinid, Rodentia, and those with Fast Metabolism now get hungry at the intended rate. You poor, hungry souls.
- fix: Diona now get thirsty at the intended rate. They are not cacti.
