### PR TITLE
Renault Ate More Telecrystals

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -568,7 +568,7 @@
     spawned:
     - id: FoodMeat
       amount: 3
-    - id: Telecrystal5
+    - id: Telecrystal25
       amount: 1
   - type: Grammar
     attributes:

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -46,6 +46,14 @@
   - type: Stack
     count: 10
 
+- type: entity
+  parent: Telecrystal
+  id: Telecrystal25
+  suffix: 25 TC
+  components:
+  - type: Stack
+    count: 25
+
 # Uplinks
 - type: entity
   parent: [ BaseItem, StorePresetUplink ]


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Scales Renault's telecrystals appropriately with the telecrystal rework from 5 to 25.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Renault ate twenty more shiny telecrystals. Nom Nom.
