### PR TITLE
Crusher Axe and Glaive Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -111,6 +111,8 @@
     name: ghost-role-information-xeno-name
     description: ghost-role-information-xeno-description
     rules: ghost-role-information-xeno-rules
+    mindRoles:
+      - MindRoleGhostRoleTeamAntagonist
     raffle:
       settings: default
   - type: GhostTakeoverAvailable

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -140,7 +140,7 @@
     - HugObject
     - KissObject
     - LickObject
-  - type: PressureDamageChange # Lavaland Change: Pressure damage change for kinetic weapons
+#  - type: PressureDamageChange # Lavaland Change: Pressure damage change for kinetic weapons
 
 - type: entity
   parent: BaseWeaponCrusher
@@ -169,7 +169,7 @@
     capacity: 1
     count: 1
   - type: MeleeWeapon
-    attackRate: 1.5 # Lavaland/Eris Change
+    attackRate: 0.65 # Lavaland/Eris Change
     range: 1.65
     wideAnimationRotation: -135
     damage:
@@ -177,9 +177,9 @@
         Blunt: 13 # Lavaland Change: no damage when unwielded
         Slash: 7
     bluntStaminaDamageFactor: 2.0
-    heavyRateModifier: 1.5
+    heavyRateModifier: .75
     heavyDamageBaseModifier: 1.2
-    heavyStaminaCost: 2.5
+    heavyStaminaCost: 3
     angle: 120
     soundHit:
       collection: MetalThud
@@ -199,9 +199,17 @@
     slots:
     - back
     - suitStorage
+  - type: IncreaseDamageOnWield
+    damage:
+      types:
+        Blunt: 5
+        Slash: 5
+        Structural: 30
+  - type: LeechOnMarker
+    leech:
+      groups:
+        Brute: -10
   # Lavaland Change Start
-  - type: MeleeRequiresWield
-    fumbleOnAttempt: true
   - type: DamageBoostOnMarker
     boost:
       types: # Totals to 70 damage when hitting marked targets


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Tweaked the Crusher Axe to have its lifesteal back, its increased damage on wield and removed the wield requirements for swinging, and added the old attack speed values for both axe and glaive. Also removes the pressure requirements for both of them.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked the crusher axe to have its lifesteal and increased damage on wield back.
- tweak: Tweaked both the crusher axe and glaive to its old speed values, and removed the pressure and wield requirements.
