### PR TITLE
Detail Examine Range Constraint Removal

### DIFF
--- a/Content.Server/DetailExaminable/DetailExaminableystem.cs
+++ b/Content.Server/DetailExaminable/DetailExaminableystem.cs
@@ -21,8 +21,8 @@ namespace Content.Server.DetailExaminable
             if (Identity.Name(args.Target, EntityManager) != MetaData(args.Target).EntityName)
                 return;
 
-            var detailsRange = _examineSystem.IsInDetailsRange(args.User, uid);
-
+            // var detailsRange = _examineSystem.IsInDetailsRange(args.User, uid); 
+            var detailsRange = true; //removed the range limitation due to player requests, the detail examine button should now be active all the time
             var verb = new ExamineVerb()
             {
                 Act = () =>


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

The variable which determines if you're in close enough proximity to an entity to see its detailed examine text is now always true. Removing it completely and setting the disabled flag to be false caused some issues, so I opted to do it this way instead. (I have no idea what I'm doing.) 

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Removed the range limitation on detail examine. 
