### PR TITLE
Security Sawn Off

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/uncategorized.yml
@@ -70,6 +70,8 @@
       id: LoadoutMagazineMagnumMagnumLeverRifle
     - type: loadout
       id: LoadoutMagazineMagnumMagnumLeverRifleSpare
+    - type: loadout
+      id: LoadoutMagazineShotgunBeanbag
 
 - type: characterItemGroup
   maxItems: 1
@@ -135,6 +137,8 @@
       id: LoadoutSecurityArgentiNonLethal
     - type: loadout
       id: LoadoutSecurityPistolEnergyRevolver
+    - type: loadout
+      id: LoadoutSecurityShotgunSawn
 
 - type: characterItemGroup
   id: LoadoutSecurityEyes

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
@@ -16,16 +16,23 @@
   id: AmmoProviderShotgunShell
   abstract: true
   components:
+    - type: Sprite
+      sprite: Objects/Weapons/Guns/Ammunition/Boxes/shotgun.rsi
     - type: BallisticAmmoProvider
       mayTransfer: true
       whitelist:
         tags:
         - ShellShotgun
       capacity: 16
+    - type: MagazineVisuals
+      magState: mag
+      steps: 5
+      zeroVisible: false
+    - type: Appearance
 
 # Shotgun Shells
 - type: entity
-  name: shotgun beanbag cartridges dispenser
+  name: shell box (beanbag)
   parent: AmmoProviderShotgunShell
   id: BoxBeanbag
   description: A dispenser box full of beanbag shots, designed for riot shotguns.
@@ -34,11 +41,14 @@
       proto: ShellShotgunBeanbag
     - type: Sprite
       layers:
-        - state: boxwide
-        - state: shellbeanbag
+        - state: base
+          map: ["enum.GunVisualLayers.Base"]
+        - state: mag-1
+          map: ["enum.GunVisualLayers.Mag"]
+        - state: beanbag
 
 - type: entity
-  name: shotgun lethal cartridges dispenser
+  name: shell box (lethal)
   parent: AmmoProviderShotgunShell
   id: BoxLethalshot
   description: A dispenser box full of lethal pellet shots, designed for riot shotguns.
@@ -47,24 +57,34 @@
       proto: ShellShotgun
     - type: Sprite
       layers:
-        - state: boxwide
-        - state: shelllethal
+        - state: base
+          map: ["enum.GunVisualLayers.Base"]
+        - state: mag-1
+          map: ["enum.GunVisualLayers.Mag"]
+        - state: lethal
 
 - type: entity
-  name: shotgun slug cartridges dispenser
+  name: shell box (slug)
   parent: AmmoProviderShotgunShell
   id: BoxShotgunSlug
   description: A dispenser box full of slugs, designed for riot shotguns.
   components:
     - type: BallisticAmmoProvider
       proto: ShellShotgunSlug
+    - type: MagazineVisuals
+      magState: mag-alt
+      steps: 5
+      zeroVisible: false
     - type: Sprite
       layers:
-        - state: boxwide
-        - state: shellslug
+        - state: base
+          map: ["enum.GunVisualLayers.Base"]
+        - state: mag-alt-1
+          map: ["enum.GunVisualLayers.Mag"]
+        - state: slug
 
 - type: entity
-  name: shotgun flare cartridges dispenser
+  name: shell box (flare)
   parent: AmmoProviderShotgunShell
   id: BoxShotgunFlare
   description: A dispenser box full of flare cartridges, designed for riot shotguns.
@@ -73,11 +93,14 @@
       proto: ShellShotgunFlare
     - type: Sprite
       layers:
-        - state: boxwide
-        - state: shellflare
+        - state: base
+          map: ["enum.GunVisualLayers.Base"]
+        - state: mag-1
+          map: ["enum.GunVisualLayers.Mag"]
+        - state: flare
 
 - type: entity
-  name: shotgun incendiary cartridges dispenser
+  name: shell box (incendiary)
   parent: AmmoProviderShotgunShell
   id: BoxShotgunIncendiary
   description: A dispenser box full of incendiary cartridges, designed for riot shotguns.
@@ -86,24 +109,34 @@
       proto: ShellShotgunIncendiary
     - type: Sprite
       layers:
-        - state: boxwide
-        - state: shellincendiary
+        - state: base
+          map: ["enum.GunVisualLayers.Base"]
+        - state: mag-1
+          map: ["enum.GunVisualLayers.Mag"]
+        - state: incendiary
 
 - type: entity
-  name: shotgun uranium cartridges dispenser
+  name: shell box (uranium)
   parent: AmmoProviderShotgunShell
   id: BoxShotgunUranium
   description: A dispenser box full of uranium cartridges, designed for riot shotguns.
   components:
     - type: BallisticAmmoProvider
       proto: ShellShotgunUranium
+    - type: MagazineVisuals
+      magState: mag-alt
+      steps: 5
+      zeroVisible: false
     - type: Sprite
       layers:
-        - state: boxwide
-        - state: shelluranium
+        - state: base
+          map: ["enum.GunVisualLayers.Base"]
+        - state: mag-alt-1
+          map: ["enum.GunVisualLayers.Mag"]
+        - state: uranium
 
 - type: entity
-  name: shotgun practice cartridges dispenser
+  name: shell box (practice)
   parent: AmmoProviderShotgunShell
   id: BoxShotgunPractice
   description: A dispenser box full of practice cartridges, designed for riot shotguns.
@@ -112,11 +145,14 @@
       proto: ShellShotgunPractice
     - type: Sprite
       layers:
-        - state: boxwide
-        - state: shellpractice
+        - state: base
+          map: ["enum.GunVisualLayers.Base"]
+        - state: mag-1
+          map: ["enum.GunVisualLayers.Mag"]
+        - state: practice
 
 - type: entity
-  name: tranquilizer cartridges dispenser
+  name: shell box (tranquilizer)
   parent: AmmoProviderShotgunShell
   id: BoxShellTranquilizer
   description: A dispenser box full of tranquilizer cartridges, designed for riot shotguns.
@@ -125,11 +161,14 @@
       proto: ShellTranquilizer
     - type: Sprite
       layers:
-        - state: boxwide
-        - state: shellslug
+        - state: base
+          map: ["enum.GunVisualLayers.Base"]
+        - state: mag-1
+          map: ["enum.GunVisualLayers.Mag"]
+        - state: tranquilizer
 
 - type: entity
-  name: ".50 Birdshot Box"
+  name: "shellbox (Birdshot)"
   parent: AmmoProviderShotgunShell
   id: BoxShotgunBirdshot
   description: A dispenser box full of .50 birdshot. Used for centuries by colonists to hunt small game on alien worlds.
@@ -138,11 +177,14 @@
       proto: ShellShotgunBirdshot
     - type: Sprite
       layers:
-        - state: boxwide
-        - state: shelllethal
+        - state: base
+          map: ["enum.GunVisualLayers.Base"]
+        - state: mag-1
+          map: ["enum.GunVisualLayers.Mag"]
+        - state: lethal
 
 - type: entity
-  name: ".50 00-Buckshot Box"
+  name: "shell box (00-Buckshot)"
   parent: AmmoProviderShotgunShell
   id: BoxShotgun00Buckshot
   description: A dispenser box full of .50 "Double-Aught" buckshot. Used for centuries by colonists to hunt mid-sized game. The knowledge of what a "Buck" means has been lost to time.
@@ -151,11 +193,14 @@
       proto: ShellShotgun00Buckshot
     - type: Sprite
       layers:
-        - state: boxwide
-        - state: shelllethal
+        - state: base
+          map: ["enum.GunVisualLayers.Base"]
+        - state: mag-1
+          map: ["enum.GunVisualLayers.Mag"]
+        - state: lethal
 
 - type: entity
-  name: ".50 0000-Buckshot Box"
+  name: "shell box (0000-Buckshot)"
   parent: AmmoProviderShotgunShell
   id: BoxShotgun0000Buckshot
   description: A dispenser box full of .50 "Quad-Aught" buckshot. Used for centuries by colonists to hunt alien megafauna. It'll rip through a hardsuit just as easily as thick hides.
@@ -164,5 +209,8 @@
       proto: ShellShotgun0000Buckshot
     - type: Sprite
       layers:
-        - state: boxwide
-        - state: shelllethal
+        - state: base
+          map: ["enum.GunVisualLayers.Base"]
+        - state: mag-1
+          map: ["enum.GunVisualLayers.Mag"]
+        - state: lethal

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -318,6 +318,23 @@
     deconstructionTarget: null
 
 - type: entity
+  name: sawn-off shotgun
+  parent: WeaponShotgunSawn
+  id: WeaponShotgunSawnSecurity
+  description: Groovy! Uses .50 shotgun shells. Preloaded with non-lethals.
+               The serial number on the handguard marks this gun as belonging to an NT Security Officer.
+  suffix: Security # TheDen
+  components:
+  - type: BallisticAmmoProvider
+    proto: ShellShotgunBeanbag
+  - type: Construction
+    graph: ShotgunSawn
+    node: shotgunsawn
+    deconstructionTarget: null
+  - type: GuideHelp
+    guides: [ SecurityWeapons ]
+
+- type: entity
   name: handmade pistol
   parent: BaseWeaponShotgun
   id: WeaponShotgunHandmade

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/uncategorized.yml
@@ -13,18 +13,42 @@
     - ClothingHeadHatSeniorTrooper
 
 - type: loadout
-  id: LoadoutSecurityUniformJumpsuitSeniorTrooper
+  id: LoadoutMagazineShotgunBeanbag
   category: JobsSecurityAUncategorized
   cost: 0
-  exclusive: true
   requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Security
+      min: 10800 # 3 hours
     - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityUniforms
-    - !type:CharacterDepartmentRequirement
-      departments:
-        - Security
+      group: LoadoutSecurityEquipment
+    - !type:CharacterLogicOrRequirement
+      requirements:
+      - !type:CharacterDepartmentRequirement
+        departments:
+          - Security
   items:
-    - ClothingUniformJumpsuitSeniorTrooper
+    - MagazineShotgunBeanbag
+
+- type: loadout
+  id: LoadoutSecurityShotgunSawn
+  category: JobsSecurityAUncategorized
+  cost: 4
+  canBeHeirloom: true
+  guideEntry: SecurityWeapons
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Security
+      min: 10800 # 3 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityWeapons
+    - !type:CharacterLogicOrRequirement
+      requirements:
+      - !type:CharacterDepartmentRequirement
+        departments:
+          - Security
+  items:
+    - WeaponShotgunSawnSecurity
 
 - type: loadout
   id: LoadoutSecurityHeadHelmetCombat
@@ -67,6 +91,20 @@
         - Security
   items:
     - ClothingMaskGasSecurityBallistic
+
+- type: loadout
+  id: LoadoutSecurityUniformJumpsuitSeniorTrooper
+  category: JobsSecurityAUncategorized
+  cost: 0
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityUniforms
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+  items:
+    - ClothingUniformJumpsuitSeniorTrooper
 
 - type: loadout
   id: LoadoutSecurityUniformJumpsuit


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adds a sawn off loaded with non-lethals and a beanbag magazine to the security loadout. Brings back the shell box sprites from Frontier after they got reverted by a past merge.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Added a sawn off shotgun loaded with non-lethals and a beanbag magazine to the security loadouts. Please practice gun safety and self-restraint.
- tweak: Tweaked shotgun shell boxes sprites to the ones from Frontier once again.
