### PR TITLE
Directional Ghost Construction Not Working as Intended

### DIFF
--- a/Content.Server/Construction/Completions/SnapToGrid.cs
+++ b/Content.Server/Construction/Completions/SnapToGrid.cs
@@ -2,6 +2,7 @@ using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Construction;
 using JetBrains.Annotations;
 
+
 namespace Content.Server.Construction.Completions
 {
     [UsedImplicitly]
@@ -15,11 +16,13 @@ namespace Content.Server.Construction.Completions
             var transform = entityManager.GetComponent<TransformComponent>(uid);
 
             if (!transform.Anchored)
+            {
                 transform.Coordinates = transform.Coordinates.SnapToGrid(entityManager);
 
-            if (SouthRotation)
-            {
-                transform.LocalRotation = Angle.Zero;
+                if (SouthRotation)
+                {
+                    transform.LocalRotation = Angle.Zero;
+                }
             }
         }
     }


### PR DESCRIPTION
Updated SnapToGrid.cs component to only apply south rotation when unanchored

# Description

Bug Link: https://discord.com/channels/1301753657024319488/1358826299388596455
Credit: Apfy 

When ghosts are constructed, they always face south. 

For some reason, many prototypes (Such as the railing) have the action "SnapToGrid" attached, with southRotation set to true. 

I'm not really sure why someone made this decision, or if there are any cases where it even makes sense? To solve this, I've shifted some code around so it *only* applies the rotation if the entity is not anchored, as the position should be more or less confirmed by such? 

The other option would have been too remove this action from all of the construction graphs. I didn't do this under the assumption that the grid snap is still useful, and that surely this feature was added for reason (And also, there's like, 10 billion prototypes containing it. I dunno which ones should and shouldn't snap. Not epic.).



# Changelog
- fix: Construction ghosts always building facing south

# Media

![Discord_Tq7TIl1LXl](https://github.com/user-attachments/assets/1e27a6dc-8b28-47fa-88cb-420dc88d28f2)
![Discord_gsJT1uOMhm](https://github.com/user-attachments/assets/210b982a-0599-42c3-bc26-b9782a2bdb79)
