### PR TITLE
Fix for Mirror GUI Closing Instantly when Mirror Is on a Wall. 

### DIFF
--- a/Content.Shared/MagicMirror/SharedMagicMirrorSystem.cs
+++ b/Content.Shared/MagicMirror/SharedMagicMirrorSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Interaction;
+using Content.Shared.Physics;
 using Content.Shared.UserInterface;
 using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
@@ -39,7 +40,7 @@ public abstract class SharedMagicMirrorSystem : EntitySystem
 
         DebugTools.Assert(component.Target != null && Exists(component.Target));
 
-        if (!_interaction.InRangeUnobstructed(uid, component.Target.Value))
+        if (!_interaction.InRangeUnobstructed(uid, component.Target.Value, collisionMask: CollisionGroup.None))
             args.Result = BoundUserInterfaceRangeResult.Fail;
     }
 

--- a/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
+++ b/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
@@ -88,11 +88,11 @@ public sealed class GlimmerSystem : EntitySystem
 
         return glimmer switch
         {
-            <= 49 => GlimmerTier.Minimal,
-            >= 50 and <= 399 => GlimmerTier.Low,
-            >= 400 and <= 599 => GlimmerTier.Moderate,
-            >= 600 and <= 699 => GlimmerTier.High,
-            >= 700 and <= 899 => GlimmerTier.Dangerous,
+            < 50 => GlimmerTier.Minimal,
+            < 400 => GlimmerTier.Low,
+            < 600 => GlimmerTier.Moderate,
+            < 700 => GlimmerTier.High,
+            < 900 => GlimmerTier.Dangerous,
             _ => GlimmerTier.Critical,
         };
     }


### PR DESCRIPTION
# Description

Mirror GUI for mirrors in walls would instantly close due to failing obstruction test.
Bug Link: https://discord.com/channels/1301753657024319488/1302263137902530704/1373067714842853436
Credit: WallflowerGhost

# Changelog

Set collision mask to ignore walls. 

Not much else to say. 

