### PR TITLE
Machete Fix+Shadowkin Telepathy Fix when Chaplin

### DIFF
--- a/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.Functions.cs
+++ b/Content.Server/Abilities/Psionics/PsionicAbilitiesSystem.Functions.cs
@@ -99,8 +99,18 @@ public sealed partial class AddPsionicPowerComponents : PsionicPowerFunction
     {
         foreach (var entry in Components.Values)
         {
-            if (entityManager.HasComponent(uid, entry.Component.GetType()))
-                continue;
+            var type = entry.Component.GetType();
+            if (entityManager.TryGetComponent(uid, type, out var existing))
+            {
+                if (existing.LifeStage != ComponentLifeStage.Running)
+                {
+                    entityManager.RemoveComponent(uid, existing);
+                }
+                else
+                {
+                    continue;
+                }
+            }
 
             var comp = (Component) serializationManager.CreateCopy(entry.Component, notNullableOverride: true);
             comp.Owner = uid;

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
@@ -187,6 +187,7 @@
     soundHit:
       collection: MetalThud
     angle: 0
+    wideAnimationRotation: -135
     animation: WeaponArcSlash
     range: 1.6
   - type: Item


### PR DESCRIPTION
# Description

Tweaked swing angle on the kinetic machete to look similar to the other kinetic weapons. Resolves #423 

Shadowkin now retain their telepathy upon choosing a job with innate telepathic abilities (i.e. Chaplin). Resolves #491 
- Before adding a component, the code now checks if the entity already has a component of the same type.
- If the component exists but is not in the 'running' state (i.e., it is being removed), it is removed immediately so it can be safely re-added.
- If the component exists and is running, it is skipped as before.

---

<details><summary><h1>Media</h1></summary>
<p>

Kinetic Machete
![4e7b8362be6d7b753efeb8f72baaca94](https://github.com/user-attachments/assets/cefb961d-080e-4093-b572-b0e6a1cc5c3e)

Shadowkin Chaplin
![fb7a526abb48bbd478909eaf260dbc93](https://github.com/user-attachments/assets/d3417850-8c68-4919-90b5-b725eed7dec9)


</p>
</details>

---

# Changelog

:cl: Wheels
- tweak: Kinetic machete swing now looks better
- fix: Shadowkin no longer lose their telepathy upon picking role with innate telepathy