### PR TITLE
Recharger Fix

### DIFF
--- a/Resources/Locale/en-US/power/components/charger.ftl
+++ b/Resources/Locale/en-US/power/components/charger.ftl
@@ -1,2 +1,3 @@
 charger-examine = Charges at [color={$color}]{$chargeRate}W[/color].
 charger-component-charge-rate = Charge rate
+charger-content = The charge indicator reads [color=green]{ $chargePercentage }%[/color].


### PR DESCRIPTION
# Description

Defined 'charger-content' in charger.ftl
Recharger now correctly displays charge levels instead of 'charger-content'

---

<details><summary><h1>Media</h1></summary>
<p>

![a7748d1c92769b49158cab3aa5613ee0](https://github.com/user-attachments/assets/b30cf373-ef75-4c6b-9272-49ff77366b51)

</p>
</details>

---

# Changelog

:cl: Wheels
- fix: Rechargers now correctly display charge level
