### PR TITLE
Glimmer Tier Calculation Fixed

### DIFF
--- a/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
+++ b/Content.Shared/Psionics/Glimmer/GlimmerSystem.cs
@@ -88,15 +88,15 @@ public sealed class GlimmerSystem : EntitySystem
 
         return glimmer switch
         {
-            <= 49 => GlimmerTier.Minimal,
-            >= 50 and <= 399 => GlimmerTier.Low,
-            >= 400 and <= 599 => GlimmerTier.Moderate,
-            >= 600 and <= 699 => GlimmerTier.High,
-            >= 700 and <= 899 => GlimmerTier.Dangerous,
+            < 50 => GlimmerTier.Minimal,
+            < 400 => GlimmerTier.Low,
+            < 600 => GlimmerTier.Moderate,
+            < 700 => GlimmerTier.High,
+            < 900 => GlimmerTier.Dangerous,
             _ => GlimmerTier.Critical,
         };
     }
-
+    
     /// <summary>
     ///     Returns a 0 through 10 range of glimmer. Do not divide by this for any reason.
     /// </summary>


### PR DESCRIPTION
# Description
Glimmer tier was previously defined by: 
            <= 49 => GlimmerTier.Minimal,
            >= 50 and <= 399 => GlimmerTier.Low,
            >= 400 and <= 599 => GlimmerTier.Moderate,
            >= 600 and <= 699 => GlimmerTier.High,
            >= 700 and <= 899 => GlimmerTier.Dangerous,
            _ => GlimmerTier.Critical,

There are gaps between each tier. 
.I.e 49.5, 399.5, 599.5 etc would result in critical tier. And then, we roll the dice to see if we explode! 

Given we are an inclusive community, I have updated the calculations to also be inclusive. 

Good fun. Great meme. Now fixed. 

# Changelog
 - updated glimmer tier calculation to not be stupid