### PR TITLE
HOPEFULLY Fixes Drug Withdrawal Spam Bug

### DIFF
--- a/Content.Server/Mood/MoodComponent.cs
+++ b/Content.Server/Mood/MoodComponent.cs
@@ -1,5 +1,7 @@
-﻿using Content.Shared.Alert;
+﻿using System.Threading;
+using Content.Shared.Alert;
 using Content.Shared.FixedPoint;
+using Content.Shared.Mood;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
 
@@ -96,6 +98,9 @@ public sealed partial class MoodComponent : Component
         { "HealthLightDamage", 0.1f },
         { "HealthNoDamage", 0.05f }
     };
+
+    // DEN: Bugfix. Allows timeout timers to be cancelled after they are created.
+    public Dictionary<ProtoId<MoodEffectPrototype>, CancellationTokenSource> EffectTimeoutSources = new();
 }
 
 [Serializable]

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -229,11 +229,11 @@
   plantMetabolism:
   - !type:PlantAdjustHealth
     amount: -5
-#  metabolisms:
-#    Narcotic:
-#      effects:
-#      - !type:ChemAddMoodlet                   #commenting this out until someone can somehow make this popup less spammy. Tired of getting this mood popup every five seconds whenever I smoke.
-#        moodPrototype: NicotineBenefit
+  metabolisms:
+    Narcotic:
+      effects:
+      - !type:ChemAddMoodlet
+        moodPrototype: NicotineBenefit
 
 # TODO: Replace these nonstandardized effects with generic brain damage
 - type: reagent


### PR DESCRIPTION
# Description

There was a bug with nicotine addiction (among other drug addictions, but it's especially noticeable for nicotine) that, for some unknown reason, smoking cigarettes sometimes leads to moodlet text spam. You'll be bombarded with the "Nicotine Benefit" moodlet's description repeatedly, and it was quite annoying.

Leo applied a bandaid fix a week ago at #521, but this introduced a second bug; now the nicotine withdrawal moodlet is permanent. This PR fixes it for real.

"Tested" in the sense that I reduced all the moodlet timers to like, 15 seconds in my testing environment, so please don't hesitate to report if it doesn't work as intended in a live round.

## Technical explanation

I went and dug through the code and found what I think the issue is. So, say you're smoking a cigarette. It'll add a tiny amount of nicotine to your bloodstream every "tick" (1-2 second interval). Then the nicotine gets processed, which gives you the "Nicotine Benefit" moodlet. However, every time you get the "Nicotine Benefit" moodlet, a timer starts representing its timeout. Approximately 17 minutes after the moodlet is applied, the moodlet will "expire" and turn into withdrawal. This timer is never **cleaned up or removed** until it expires.

In effect, when you smoke a cigarette, it queues up several minutes worth of these "moodlet expired" timers, all scheduled for 17 minutes from now. Then, 17 minutes later, the first timer will expire, giving you withdrawal. A nicotine addict will likely see this mood impact and scramble to get out their cigarette and lighter. However, each tick that you're smoking the second cigarette, you will gain Nicotine Benefit and Nicotine Withdrawal simultaneously, resulting in message spam.

This PR makes it so that these expiry timers are properly cancelled before the moodlet is reapplied. So, when you smoke a cigarette, the effect will be continuously re-applied, and the countdown reset, until you are done smoking the cigarette. From the moment the cigarette is finished, you will have 17 minutes before it expires and becomes withdrawal. Because there's no backlogged queue of expiry timers, if you smoke another cigarette at this point, it should show just one message again.

## Additional notes

In case you're wondering; a separate, unrelated bug makes it so that none of the Nicotine Withdrawal messages will show up at all, which is why this bug was so confusing. This is due to the way that moodlet message sending works. When you gain a "categorized" moodlet (like the nicotine addiction moodlets), it will only send a message if you have _another_ moodlet in the same category; I.e. you're switching from one state to another. However, the "previous" moodlet expires and is removed before the switch to the next state, so the next moodlet thinks the category is empty and does not send a message. 

This behavior, I believe, is meant to get around the fact that you start with multiple categorized moodlets when the round starts (hunger, thirst) and the previous coder probably did not want these messages spamming your screen the moment the round starts. I have not touched it in this PR because I don't know what behavior people would prefer - being able to see nicotine withdrawal messages, or not being flashed with the hunger/thirst messages on spawning.

---

# TODO

- [x] Fix that nicotine bug.
- [x] Make Nicotine Addict trait functional again.
- [ ] (optional; based on consensus) Do we fix the nicotine withdrawal messages or not? 

---

<details><summary><h1>Media</h1></summary>
<p>

You're just gonna have to take my word for this one sorry.

</p>
</details>

---

# Changelog

:cl:
- fix: Drugs with effect and withdrawal moodlets should hopefully no longer spam you with moodlet messages.
- fix: Restores nicotine's ability to give you a positive moodlet.