### PR TITLE
Made Wall Lockers Airtight

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -153,6 +153,7 @@
       map: ["enum.WeldableLayers.BaseWelded"]
   - type: EntityStorage
     isCollidableWhenOpen: true
+    airtight: true
     enteringOffset: 0, -0.75
     closeSound:
       path: /Audio/Items/deconstruct.ogg


### PR DESCRIPTION

# Description

When you get into a wall locker, it would use the outside atmosphere. Now, it is "airtight". I assume that means you can still deplete the oxygen or whatever, but at least you don't die super quick. 

Ideally, it would grab the atmosphere at the entry position whenever it's opened and copy that for inside, i feel like this is good enough for now? 

# Changelog
 
 - Made wall lockers airtight