### PR TITLE
Arachne and Harpy RGB Skin Tones

### DIFF
--- a/Resources/Prototypes/Species/arachne.yml
+++ b/Resources/Prototypes/Species/arachne.yml
@@ -7,7 +7,7 @@
   defaultSkinTone: "#c0967f"
   markingLimits: MobArachneMarkingLimits
   dollPrototype: MobArachneDummy
-  skinColoration: HumanToned
+  skinColoration: HumanAnimal
   minAge: 18
   youngAge: 20
   oldAge: 70

--- a/Resources/Prototypes/Species/harpy.yml
+++ b/Resources/Prototypes/Species/harpy.yml
@@ -7,7 +7,7 @@
   defaultSkinTone: "#c0967f"
   markingLimits: MobHarpyMarkingLimits
   dollPrototype: MobHarpyDummy
-  skinColoration: HumanToned
+  skinColoration: HumanAnimal
   minHeight: 0.6
   defaultHeight: 0.8
   maxHeight: 1.1


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description


Sets Harpy and Arachne skin tone options to have both humanoid skintone slider and RGB slider (akin to humans/felinids)

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Content Client_nRGL3Z59d3](https://github.com/user-attachments/assets/b0908e4c-1fff-46fb-ab5a-c7d7fa71dcf8)
![Content Client_450Nif3u5P](https://github.com/user-attachments/assets/71c943e0-04ea-4fbd-99ba-d428d8a6337f)


</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Added rgb skintone slider to Harpy and Arachne (humanoid skintone slider still available, like humans)