### PR TITLE
Disable Egg Layer Trait (Pending Changes/Removal)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/eggs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/eggs.yml
@@ -1,0 +1,53 @@
+- type: entity
+  parent: BaseItem
+  id: ItemEggTraitBase
+  description: An egg! Laid by a crewmember. Not for consumption.
+  abstract: true
+  components:
+  - type: Sprite
+    sprite: Objects/Consumable/Food/egg.rsi
+    scale: 1.25, 1.25
+  - type: Item
+    sprite: Objects/Consumable/Food/egg.rsi
+    size: Tiny
+  # egg fragile
+  - type: DamageOnHighSpeedImpact
+    minimumSpeed: 0.1
+    damage:
+      types:
+        Blunt: 1
+  - type: Damageable
+    damageContainer: Biological
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: desecration
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Eggshells:
+            min: 1
+            max: 1
+          # Wow double-yolk you're so lucky!
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+
+- type: entity
+  parent: ItemEggTraitBase
+  id: ItemEggTrait
+  name: oversized egg
+  description:
+  components:
+  - type: Sprite
+    layers:
+      - state: icon
+        map: [ "enum.DamageStateVisualLayers.Base" ]
+  - type: RandomSprite
+    available:
+      - enum.DamageStateVisualLayers.Base:
+          icon: ""
+          white: ""

--- a/Resources/Prototypes/Entities/Objects/Misc/eggs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/eggs.yml
@@ -10,6 +10,23 @@
   - type: Item
     sprite: Objects/Consumable/Food/egg.rsi
     size: Tiny
+
+
+- type: entity
+  parent: ItemEggTraitBase
+  id: ItemEggTrait
+  name: oversized egg
+  description: An egg! Laid by a crewmember. Not for consumption.
+  components:
+  - type: Sprite
+    layers:
+      - state: icon
+        map: [ "enum.DamageStateVisualLayers.Base" ]
+  - type: RandomSprite
+    available:
+      - enum.DamageStateVisualLayers.Base:
+          icon: ""
+          white: ""
   # egg fragile
   - type: DamageOnHighSpeedImpact
     minimumSpeed: 0.1
@@ -35,19 +52,3 @@
           # Wow double-yolk you're so lucky!
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
-
-- type: entity
-  parent: ItemEggTraitBase
-  id: ItemEggTrait
-  name: oversized egg
-  description:
-  components:
-  - type: Sprite
-    layers:
-      - state: icon
-        map: [ "enum.DamageStateVisualLayers.Base" ]
-  - type: RandomSprite
-    available:
-      - enum.DamageStateVisualLayers.Base:
-          icon: ""
-          white: ""

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1249,19 +1249,20 @@
           - Crayon
           - Paper
 
-- type: trait
-  id: EggLaying
-  category: Physical
-  points: 0
-  requirements:
-  - !type:CharacterJobRequirement
-    inverted: true
-    jobs:
-    - Borg
-    - MedicalBorg
-  functions:
-    - !type:TraitAddComponent
-      components:
-        - type: EggLayer
-          eggSpawn:
-            - id: ItemEggTrait
+# Commented out upon request for the time being
+#- type: trait
+#  id: EggLaying
+#  category: Physical
+#  points: 0
+#  requirements:
+#  - !type:CharacterJobRequirement
+#    inverted: true
+#    jobs:
+#    - Borg
+#    - MedicalBorg
+#  functions:
+#    - !type:TraitAddComponent
+#      components:
+#        - type: EggLayer
+#          eggSpawn:
+#            - id: ItemEggTrait

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1252,7 +1252,7 @@
 - type: trait
   id: EggLaying
   category: Physical
-  points: -1 # After discussion in its initial suggestion thread, point cost was voted for balance
+  points: 0
   requirements:
   - !type:CharacterJobRequirement
     inverted: true
@@ -1264,4 +1264,4 @@
       components:
         - type: EggLayer
           eggSpawn:
-            - id: FoodEgg
+            - id: ItemEggTrait


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Moving the egg layer trait more towards being a kink trait, making the eggs that it creates inert, also room to make variant eggs for more species specific eggs (spriting is hard so i aint making them)

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] New base egg used for trait (not for cooking)
- [ ] Descriptions and name for base egg for clarity to other players what it is, so it is not mistaken

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Egg Layer trait made inert and not usable for cooking
