### PR TITLE
BUG Voyeurism Is Not a Feature

### DIFF
--- a/Resources/Prototypes/Shaders/Stencils.yml
+++ b/Resources/Prototypes/Shaders/Stencils.yml
@@ -20,6 +20,6 @@
   id: StencilDraw
   kind: canvas
   stencil:
-    ref: 1
+    ref: 2
     op: Keep
     func: NotEqual

--- a/Resources/Prototypes/Shaders/displacement.yml
+++ b/Resources/Prototypes/Shaders/displacement.yml
@@ -3,7 +3,7 @@
   kind: source
   path: "/Textures/Shaders/displacement.swsl"
   stencil:
-    ref: 1
+    ref: 2
     op: Keep
     func: NotEqual
   params:


### PR DESCRIPTION
# Description.

Some weird shit. Clothing with no shader set in the jumpsuit renderlayer gets defaulted to use the StencilDraw shader. The stencil buffer order reference was set wrong, so certain over shaders would just ignore them. 

When the sprite was rendered in an inventory or otherwise, it got switched to the DisplacedStencilDraw shader. Not really sure why, but i would have had to dig more into Robust's rendering code to get to the bottom of it, which is pointless since I'm not going to push a fix to robust. 

Pretty sure all the renderlayer ordering shit is fucked up anyway. 

I'm not really paying much attention to what i'm writing, so i hope that all makes some kind of sense. 

I have a migraine now. 

Well. It works now, I think. Hopefully. 

# Changelog

:cl:
- fix: Clothes no longer vanish with NVB / in Inventory. 
