### PR TITLE
Fix: Readded a Missing Comma in the Bunny Ears Marking

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_ears.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/kemonomimi_ears.yml
@@ -18,7 +18,7 @@
   id: BunnyEars
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Human, SlimePerson IPC]
+  speciesRestriction: [Human, SlimePerson, IPC]
   coloring:
     default:
       type:


### PR DESCRIPTION
# Description

recent PR broke this for slimepeople and IPCs by accident

---

# Changelog

:cl:
- fix: Fixed the "bunny ears" marking to reappear for slimepeople and IPCs.
