### PR TITLE
BUG - Weather No Longer Overrenders 

### DIFF
--- a/Content.Client/Overlays/StencilOverlay.RestrictedRange.cs
+++ b/Content.Client/Overlays/StencilOverlay.RestrictedRange.cs
@@ -45,7 +45,7 @@ public sealed partial class StencilOverlay
         }, Color.Transparent);
 
         worldHandle.SetTransform(Matrix3x2.Identity);
-        worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("StencilMask").Instance());
+        worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("+StencilMaskWeather").Instance());
         worldHandle.DrawTextureRect(_blep!.Texture, worldBounds);
         var curTime = _timing.RealTime;
         var sprite = _sprite.GetFrame(new SpriteSpecifier.Texture(new ResPath("/Textures/Parallaxes/noise.png")), curTime);

--- a/Content.Client/Overlays/StencilOverlay.Weather.cs
+++ b/Content.Client/Overlays/StencilOverlay.Weather.cs
@@ -59,7 +59,7 @@ public sealed partial class StencilOverlay
         var sprite = _sprite.GetFrame(weatherProto.Sprite, curTime);
 
         // Draw the rain
-        worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("StencilDraw").Instance());
+        worldHandle.UseShader(_protoManager.Index<ShaderPrototype>("StencilDrawWeather").Instance());
         _parallax.DrawParallax(worldHandle, worldAABB, sprite, curTime, position, Vector2.Zero, modulate: (weatherProto.Color ?? Color.White).WithAlpha(alpha));
 
         worldHandle.SetTransform(Matrix3x2.Identity);

--- a/Resources/Prototypes/Shaders/Stencils.yml
+++ b/Resources/Prototypes/Shaders/Stencils.yml
@@ -17,6 +17,24 @@
     func: Always
 
 - type: shader
+  id: StencilMaskWeather
+  kind: source
+  path: "/Textures/Shaders/stencil_mask.swsl"
+  stencil:
+    ref: 2
+    op: Replace
+    func: Always
+
+
+- type: shader
+  id: StencilDrawWeather
+  kind: canvas
+  stencil:
+    ref: 1
+    op: Keep
+    func: NotEqual
+
+- type: shader
   id: StencilDraw
   kind: canvas
   stencil:


### PR DESCRIPTION

# Description

Weather was overrendering because of the stencil buffer ref changes. Weather now has it's own shader so ref can be adjusted

# Changelog


:cl:
- fix: Weather no longer over-renders. 