### PR TITLE
Nerf Healing Word & Tweak Breath of Life

### DIFF
--- a/Content.Server/Abilities/Psionics/Abilities/HealOtherPowerSystem.cs
+++ b/Content.Server/Abilities/Psionics/Abilities/HealOtherPowerSystem.cs
@@ -123,10 +123,17 @@ public sealed class RevivifyPowerSystem : EntitySystem
             || args.Cancelled)
             return;
 
-        // Fails if the target is not alive
+        // Healing Word fails if the target is not alive
         if (!TryComp<MobStateComponent>(args.Target, out var mobState) || _mobState.IsDead((EntityUid) args.Target, mobState) && !args.DoRevive)
         {
-            _popUp.PopupEntity(Loc.GetString("psionic-deaf-ears"), (EntityUid) args.Target, uid);
+            _popUp.PopupEntity(Loc.GetString("healing-word-fail"), (EntityUid) args.Target, uid);
+            return;
+        }
+
+        // Healing Word fails if the target is not alive
+        if (_mobState.IsAlive((EntityUid) args.Target, mobState) && args.DoRevive)
+        {
+            _popUp.PopupEntity(Loc.GetString("revifiy-fail"), (EntityUid) args.Target, uid);
             return;
         }
 

--- a/Resources/Locale/en-US/abilities/psionic.ftl
+++ b/Resources/Locale/en-US/abilities/psionic.ftl
@@ -71,5 +71,3 @@ action-desc-rf-sensitivity = Toggle your ability to interpret radio waves on and
 
 action-name-assay = Assay
 action-description-assay = Probe an entity at close range to glean metaphorical information about any powers they may have
-
-psionic-deaf-ears = Your words fall on deaf ears.

--- a/Resources/Locale/en-US/psionics/psionic-powers.ftl
+++ b/Resources/Locale/en-US/psionics/psionic-powers.ftl
@@ -59,6 +59,7 @@ healing-word-power-initialization-feedback =
     I need only speak it.
 healing-word-power-metapsionic-feedback = {CAPITALIZE($entity)} bears the Lesser Secret of Life.
 healing-word-begin = {CAPITALIZE($entity)} mutters a word that brings both joy and pain alike to those who hear it.
+healing-word-fail = Your words fall on deaf ears.
 
 # Revivify
 action-name-revivify = Breath of Life
@@ -70,6 +71,7 @@ revivify-power-initialization-feedback =
     Power flows through me as a mighty river, begging to be released with a simple spoken word.
 revivify-power-metapsionic-feedback = {CAPITALIZE($entity)} bears the Greater Secret of Life.
 revivify-begin = {CAPITALIZE($entity)} enunciates a word of such divine power, that those who hear it weep from joy.
+revivify-fail = Your words do not work on the living.
 
 # Telegnosis
 telegnosis-power-description = Create a telegnostic projection to remotely observe things.


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Nerfs healing word closer to that of Tricordrazine, though this is still stronger.
Nerfs include
- Removal of Caustic Healing
- Removal of Asphyxiation Healing
- Removal of Blood loss Healing
- Removal of Genetic Healing
- Removal of Rot Reduction
- Removal of ability to use it on yourself
- No longer works on corpses

Largely this is to give medical more opportunity to actually do their job and not have a psion walk in and heal everyone of all their ailments. As well as giving Regeneration it's spot back for self healing. And Revivify the only power to reduce rot (as it is intended for use on corpses)

To follow along Breath of Life no longer works on the living.

The goal is partially to bring Healing Word back into being a trait ability, but at least with this, chaplains or people who random roll it wont be Medical but better

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Healing word nerfed to a level similar, but stronger than tricordrazine.
- tweak: Healing word no longer works on corpses.
- tweak: Breath of Life no longer works on the living.