### PR TITLE
Accentless Cost Removal

### DIFF
--- a/Resources/Prototypes/Traits/neutral.yml
+++ b/Resources/Prototypes/Traits/neutral.yml
@@ -12,7 +12,7 @@
 - type: trait
   id: Accentless
   category: TraitsSpeechAccents
-  points: -1
+  points: 0
   requirements:
     - !type:CharacterJobRequirement
       inverted: true


### PR DESCRIPTION
# Description
Removes cost of the Accentless trait.

Accentless simply removes a species accent, so I see no reason for it to have a point cost if it's a simple RP change to a character.


# Changelog
:cl:
- tweak: Removed cost of the Accentless trait
