### PR TITLE
Traitor Telecrystal Tweaks

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/TraitorRuleComponent.cs
@@ -87,5 +87,5 @@ public sealed partial class TraitorRuleComponent : Component
     /// The amount of TC traitors start with.
     /// </summary>
     [DataField]
-    public int StartingBalance = 100;
+    public int StartingBalance = 115;
 }

--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -61,7 +61,7 @@
   - SyndicatePersonalAI
   - ClothingHeadHatSyndieMAA
   - CigPackSyndicate
-  - Telecrystal10 #The thief cannot use them, but it may induce communication with traitors
+  - Telecrystal50 #The thief cannot use them, but it may induce communication with traitors
 
 - type: thiefBackpackSet
   id: SleeperSet

--- a/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/syndicate.yml
@@ -54,6 +54,14 @@
   - type: Stack
     count: 25
 
+- type: entity
+  parent: Telecrystal
+  id: Telecrystal50
+  suffix: 50 TC
+  components:
+  - type: Stack
+    count: 50
+
 # Uplinks
 - type: entity
   parent: [ BaseItem, StorePresetUplink ]


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Adjusts the thief telecrystal to the appropriate converted values from 10 -> 50, increases the traitor telecrystal count from 100 -> 115 to hopefully give them a slight edge.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked the thief toolbox telecrystal from 10 -> 50 as it should have been with the TC rework.
- tweak: Tweaked the traitor telecrystal from 100 -> 115 to give them a slight edge.