### PR TITLE
Thieves as RP Antagonists

### DIFF
--- a/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ThiefRuleSystem.cs
@@ -39,7 +39,7 @@ public sealed class ThiefRuleSystem : GameRuleSystem<ThiefRuleComponent>
     {
         var isHuman = HasComp<HumanoidAppearanceComponent>(ent);
         var briefing = isHuman
-            ? Loc.GetString("thief-role-greeting-human")
+            ? Loc.GetString("thief-role-greeting-human-deltav") // DeltaV - no pacifism
             : Loc.GetString("thief-role-greeting-animal");
 
         if (isHuman)

--- a/Resources/Locale/en-US/_DV/game-ticking/game-presets/preset-thief.ftl
+++ b/Resources/Locale/en-US/_DV/game-ticking/game-presets/preset-thief.ftl
@@ -1,0 +1,5 @@
+thief-role-greeting-human-deltav =
+    You are criminal scum, a kleptomaniac
+    previously arrested and on parole for petty theft.
+    You need to add more to your collection.
+    Get your fix by any means necessary, steal all the things!

--- a/Resources/Locale/en-US/thief/backpack.ftl
+++ b/Resources/Locale/en-US/thief/backpack.ftl
@@ -24,7 +24,7 @@ thief-backpack-category-tools-description =
     A set of tools for roughing up doors, walls, windows,
     and anything else that for whatever reason doesn't
     want to let you in where you need to go.
-    Includes two C4s, a multitool, jaws of life,
+    Includes two breaching charges, a multitool, jaws of life,
     a pair of advanced welder meson glasses and some insulated gloves.
 
 thief-backpack-category-chemistry-name = chemistry kit

--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -29,8 +29,8 @@
   - ClothingHandsGlovesColorYellow
   - JawsOfLife
   - Multitool
-  - C4
-  - C4
+  - BreachingCharge
+  - BreachingCharge
   - ClothingMaskClown
 
 - type: thiefBackpackSet

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -7,14 +7,14 @@
   - type: AntagObjectives
     objectives:
     - EscapeThiefShuttleObjective
-  - type: AntagRandomObjectives
-    sets:
-    - groups: ThiefBigObjectiveGroups
-      prob: 0.7
-      maxPicks: 1
-    - groups: ThiefObjectiveGroups
-      maxPicks: 10
-    maxDifficulty: 2.5
+  # - type: AntagRandomObjectives
+  #   sets:
+  #   - groups: ThiefBigObjectiveGroups
+  #     prob: 0.7
+  #     maxPicks: 1
+  #   - groups: ThiefObjectiveGroups
+  #     maxPicks: 10
+  #   maxDifficulty: 2.5
   - type: AntagSelection
     agentName: thief-round-end-agent-name
     definitions:
@@ -25,8 +25,8 @@
       allowNonHumans: true
       multiAntagSetting: All
       startingGear: ThiefGear
-      components:
-      - type: Pacified
+      # components:
+      # - type: Pacified
       mindRoles:
       - MindRoleThief
       briefing:

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -550,8 +550,8 @@
   categories: [ HideSpawnMenu ]
   parent: [BaseThiefObjective, BaseLivingObjective]
   id: EscapeThiefShuttleObjective
-  name: Escape to centcom alive and unrestrained.
-  description: You don't want your illegal activities to be discovered by anyone, do you?
+  name: Become the greatest thief of all time
+  description: Pull off the biggest heist in the galaxy, make it one for the history books.
   components:
   - type: Objective
     difficulty: 1.3


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Makes thieves more RP leaning, removing their preset objectives in favor of a freeform one as well as removing their pacifist status. Also replaces the C4s in their toolset with Breaching Charges.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Thieves are now RP antags, preset objectives replaced with a freeform objective, as well as their pacifism implant removed.
- tweak: Replaced the C4s in the thief toolset with breaching charges.

