### PR TITLE
Made Loadout Icons Bigger

### DIFF
--- a/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
+++ b/Content.Client/Lobby/UI/LoadoutPreferenceSelector.xaml.cs
@@ -114,7 +114,7 @@ public sealed partial class LoadoutPreferenceSelector : Control
             // Create a sprite preview of the loadout item
             previewLoadout = new SpriteView
             {
-                Scale = new Vector2(1, 1),
+                Scale = new Vector2(2, 2),
                 OverrideDirection = Direction.South,
                 VerticalAlignment = VAlignment.Center,
                 SizeFlagsStretchRatio = 1,
@@ -126,7 +126,7 @@ public sealed partial class LoadoutPreferenceSelector : Control
             // Create a sprite preview of the loadout item
             previewLoadout = new SpriteView
             {
-                Scale = new Vector2(1, 1),
+                Scale = new Vector2(2, 2),
                 OverrideDirection = Direction.South,
                 VerticalAlignment = VAlignment.Center,
                 SizeFlagsStretchRatio = 1,


### PR DESCRIPTION
# Description

Loadout icons smol and hard to see. Now they are less smol.

# Changelog


:cl:
- tweak: Loadout icons bigger
