### PR TITLE
Add Antag Target Preferences. (DONT MERGE)

### DIFF
--- a/Resources/Locale/en-US/_CD/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/_CD/prototypes/roles/antags.ftl
@@ -1,0 +1,15 @@
+roles-low-impact-antag = 1. Low-Impact Antagonist
+roles-low-impact-antag-desc = Often small, basic tasks that result in little more than jail time.
+
+roles-moderate-impact-antag = 2. Moderate-Impact Antagonist
+roles-moderate-impact-antag-desc = More complicated tasks that may take the focus of your round and/or have multi-round punishments.
+
+roles-high-impact-antag = 3. High-Impact Antagonist
+roles-high-impact-antag-desc = Incredibly disruptive actions that are likely to define a character once done.
+
+roles-antag-target-opt-in = 4. Antag Target Opt in
+roles-antag-target-opt-in-desc = Admins or other players may take intentional antagonistic action against you (short of round removal).
+
+roles-round-removal-opt-in = 5. Round-Removal Target Opt in
+roles-round-removal-opt-in-desc = Admins or other players are permitted to intentionally round-remove you thorough events or antagonistic action.
+

--- a/Resources/Prototypes/_CD/Roles/Antags/preferences.yml
+++ b/Resources/Prototypes/_CD/Roles/Antags/preferences.yml
@@ -1,0 +1,39 @@
+- type: antag
+  id: LowImpactAntag
+  name: roles-low-impact-antag
+  antagonist: true
+  setPreference: true
+  objective: roles-low-impact-antag-desc
+  visiblePreference: true
+
+- type: antag
+  id: ModerateImpactAntag
+  name: roles-moderate-impact-antag
+  antagonist: true
+  setPreference: true
+  objective: roles-moderate-impact-antag-desc
+  visiblePreference: true
+
+- type: antag
+  id: HighImpactAntag
+  name: roles-high-impact-antag
+  antagonist: true
+  setPreference: true
+  objective: roles-high-impact-antag-desc
+  visiblePreference: true
+
+- type: antag
+  id: RoundRemovalOptIn
+  name: roles-round-removal-opt-in
+  antagonist: true
+  setPreference: true
+  objective: roles-round-removal-opt-in-desc
+  visiblePreference: true
+
+- type: antag
+  id: AntagTargetOptIn
+  name: roles-antag-target-opt-in
+  antagonist: true
+  setPreference: true
+  objective: roles-antag-target-opt-in-desc
+  visiblePreference: true


### PR DESCRIPTION

# Description
(cherry picked from commit 1e04a4e09b136c2f495da9aa37dff7446abeb4d5)

This is the antag target selection preferences, exactly as from CN. 

I didn't spend a ton of time looking yet, but as far as I can see, there isn't any extra logic to control the selection. I think it works purely by the fact that an antag cannot be the target of another antag, and the preferences just give you their own antag role? Meaning, the different categories do nothing...? 

We should probably rework this, once we've discussed what we actually want. 

# Changelog

:cl:
- add: Antag target selection preferences
