### PR TITLE
Disable Ion Damage

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
@@ -340,7 +340,7 @@
     Cold: 0.2
     Heat: 1
     Shock: 2
-    Ion: 1 # They are already the only player species to take this damage at all, so no need to compound that weakness
+#    Ion: 1 # They are already the only player species to take this damage at all, so no need to compound that weakness
     Blunt: 1
     Slash: 1
     Piercing: 1

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -75,7 +75,7 @@
       types: # these are all split across multiple types. IPCs can still take cold damage, they just heavily resist it.
         Heat: -8
         Shock: -8
-        ion: -6
+        #ion: -6
         Cold: -2
   - type: Fixtures
     fixtures:
@@ -161,7 +161,7 @@
       types: # these are all split across multiple types. IPCs can still take cold damage, they just heavily resist it.
         Heat: -4
         Shock: -4
-        ion: -3
+        #ion: -3
         Cold: -1
   - type: Fixtures
     fixtures:
@@ -246,7 +246,7 @@
       types: # these are all split across multiple types. IPCs can still take cold damage, they just heavily resist it.
         Heat: -2
         Shock: -2
-        ion: -1.5
+        #ion: -1.5
         Cold: -0.5
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -82,7 +82,7 @@
     types:
       Heat: 10
       Radiation: 10
-      Ion: 15 #Goobstation
+      #Ion: 15 #Goobstation
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_xray

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -284,7 +284,7 @@
     damage:
       types:
         Heat: 5
-        Ion: 10 #Goobstation
+        #Ion: 10 #Goobstation
     soundHit:
       collection: WeakHit
     forceSound: true
@@ -367,7 +367,7 @@
     damage:
       types:
         Heat: 1
-        Ion: 5 #Goobstation
+        #Ion: 5 #Goobstation
     soundHit:
       collection: WeakHit
     forceSound: true
@@ -1401,41 +1401,41 @@
     soundHit:
       collection: MeatLaserImpact
 
-- type: entity #Goobstation, put here so the X-01 stuff isnt spread everywhere.
-  name: ion bolt
-  id: BulletEnergyGunIon
-  parent: BaseBullet
-  categories: [ HideSpawnMenu ]
-  components:
-  - type: Reflective
-    reflective:
-    - Energy
-  - type: FlyBySound
-    sound:
-      collection: EnergyMiss
-      params:
-        volume: 5
-  - type: Sprite
-    sprite: Objects/Weapons/Guns/Projectiles/projectiles_tg.rsi
-    layers:
-    - state: omnilaser_greyscale
-      shader: unshaded
-      color: blue
-  - type: Ammo
-  - type: Physics
-  - type: Fixtures
-    fixtures:
-      projectile:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.2,-0.2,0.2,0.2"
-        hard: false
-        mask:
-        - Opaque
-  - type: Projectile
-    impactEffect: BulletImpactEffectDisabler
-    damage:
-      types:
-        Ion: 20
-    soundHit:
-      collection: MeatLaserImpact
+# - type: entity #Goobstation, put here so the X-01 stuff isnt spread everywhere.
+#   name: ion bolt
+#   id: BulletEnergyGunIon
+#   parent: BaseBullet
+#   categories: [ HideSpawnMenu ]
+#   components:
+#   - type: Reflective
+#     reflective:
+#     - Energy
+#   - type: FlyBySound
+#     sound:
+#       collection: EnergyMiss
+#       params:
+#         volume: 5
+#   - type: Sprite
+#     sprite: Objects/Weapons/Guns/Projectiles/projectiles_tg.rsi
+#     layers:
+#     - state: omnilaser_greyscale
+#       shader: unshaded
+#       color: blue
+#   - type: Ammo
+#   - type: Physics
+#   - type: Fixtures
+#     fixtures:
+#       projectile:
+#         shape:
+#           !type:PhysShapeAabb
+#           bounds: "-0.2,-0.2,0.2,0.2"
+#         hard: false
+#         mask:
+#         - Opaque
+#   - type: Projectile
+#     impactEffect: BulletImpactEffectDisabler
+#     damage:
+#       types:
+#         Ion: 20
+#     soundHit:
+#       collection: MeatLaserImpact

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -91,10 +91,6 @@
       fireCost: 50
       name: lethal
       state: lethal
-    - proto: BulletEnergyGunIon
-      fireCost: 250
-      name: ion
-      state: special
   - type: MagazineVisuals
     magState: mag
     steps: 5

--- a/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
@@ -114,7 +114,7 @@
     Piercing: 0.9
     Shock: 0.9
     Heat: 0.9
-    Ion: 2.0 # double damage from ion
+    #Ion: 2.0 # double damage from ion
 
 - type: damageModifierSet
   id: BingleUpgraded
@@ -124,4 +124,4 @@
     Piercing: 0.8
     Shock: 0.8
     Heat: 0.8
-    Ion: 2.0 # double damage from ion
+    #Ion: 2.0 # double damage from ion

--- a/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Mobs/Player/bingle.yml
@@ -52,7 +52,7 @@
       types:
         Blunt: 7
         Structural: 14 # breaks down the walls and airlocks in 10 hits
-        Ion: 5
+        #Ion: 5
     bluntStaminaDamageFactor: 2.0
   - type: MovementSpeedModifier
     baseWalkSpeed : 2 # same as slime
@@ -138,7 +138,7 @@
       types:
         Blunt: 14
         Structural: 28
-        Ion: 7
+        #Ion: 7
   - type: Damageable
     damageContainer: Biological
     damageModifierSet: BingleUpgraded


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Forgot to do this when we got it, disables all sources of Ion damage as a whole since it was entirely designed as a rage PR against IPCs and terribly implemented.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- remove: Disabled the Ion damage type as well as all sources of it.
