### PR TITLE
Better Autocall

### DIFF
--- a/Content.Client/Voting/VoteManager.cs
+++ b/Content.Client/Voting/VoteManager.cs
@@ -138,7 +138,9 @@ namespace Content.Client.Voting
                     return;
                 }
 
-                _voteSource?.Restart();
+                if (message.PlayVoteSound)
+                    _voteSource?.Restart();
+
                 @new = true;
 
                 // Refresh

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -61,7 +61,6 @@ namespace Content.Server.RoundEnd
         /// <summary>
         /// How long should a round last until you can no longer recall without admin intervention?
         /// </summary>
-        // public TimeSpan RoundHardEnd { get; set; } = TimeSpan.FromHours(5);
         public TimeSpan RoundHardEnd { get; set; } = TimeSpan.FromHours(5);
 
         /// <summary>

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -23,6 +23,9 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Timer = Robust.Shared.Timing.Timer;
 using Content.Server.Announcements.Systems;
+using Content.Server.Voting.Managers;
+using Robust.Server.Player;
+
 
 namespace Content.Server.RoundEnd
 {
@@ -44,6 +47,9 @@ namespace Content.Server.RoundEnd
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly StationSystem _stationSystem = default!;
         [Dependency] private readonly AnnouncerSystem _announcer = default!;
+        [Dependency] private readonly IVoteManager _voteManager = default!;
+        [Dependency] private readonly IPlayerManager _playerManager = default!;
+        [Dependency] private readonly ILogManager _logManager = default!;
 
         public TimeSpan DefaultCooldownDuration { get; set; } = TimeSpan.FromSeconds(30);
 
@@ -56,12 +62,12 @@ namespace Content.Server.RoundEnd
         /// How long should a round last until you can no longer recall without admin intervention?
         /// </summary>
         // public TimeSpan RoundHardEnd { get; set; } = TimeSpan.FromHours(5);
-        public TimeSpan RoundHardEnd { get; set; } = TimeSpan.FromMinutes(2);
+        public TimeSpan RoundHardEnd { get; set; } = TimeSpan.FromHours(5);
 
         /// <summary>
         /// How long before round hard end should the warning be sent?
         /// </summary>
-        public TimeSpan RoundHardEndWarningTime { get; set; } = TimeSpan.FromMinutes(1);
+        public TimeSpan RoundHardEndWarningTime { get; set; } = TimeSpan.FromMinutes(15);
 
         /// <summary>
         /// Should we not allow recall due to round hard end being met?
@@ -74,8 +80,8 @@ namespace Content.Server.RoundEnd
         public TimeSpan? ExpectedCountdownEnd { get; set; } = null;
         public TimeSpan? ExpectedShuttleLength => ExpectedCountdownEnd - LastCountdownStart;
         public TimeSpan? ShuttleTimeLeft => ExpectedCountdownEnd - _gameTiming.CurTime;
-
         public TimeSpan AutoCallStartTime;
+
         private bool _autoCalledBefore = false;
 
         public override void Initialize()
@@ -146,7 +152,23 @@ namespace Content.Server.RoundEnd
             var ev = new CanCallOrRecallEvent(station.Value);
             RaiseLocalEvent(ref ev);
 
-            return _cooldownTokenSource == null || !ev.Cancelled;
+            if (ev.Cancelled)
+                return false;
+
+            return _cooldownTokenSource == null;
+        }
+
+        public bool CanCallOrRecallIgnoringCooldown()
+        {
+            var station = GetStation();
+
+            if (station == null)
+                return true;
+
+            var ev = new CanCallOrRecallEvent(station.Value);
+            RaiseLocalEvent(ref ev);
+
+            return !ev.Cancelled;
         }
 
         public bool IsRoundEndRequested()
@@ -263,10 +285,15 @@ namespace Content.Server.RoundEnd
 
         public void CancelRoundEndCountdown(EntityUid? requester = null, bool checkCooldown = true)
         {
-            if (_gameTicker.RunLevel != GameRunLevel.InRound) return;
-            if (checkCooldown && _cooldownTokenSource != null) return;
+            if (_gameTicker.RunLevel != GameRunLevel.InRound)
+                return;
 
-            if (_countdownTokenSource == null) return;
+            if (checkCooldown && _cooldownTokenSource != null)
+                return;
+
+            if (_countdownTokenSource == null)
+                return;
+
             _countdownTokenSource.Cancel();
             _countdownTokenSource = null;
 
@@ -427,8 +454,8 @@ namespace Content.Server.RoundEnd
             {
                 if (!_shuttle.EmergencyShuttleArrived && ExpectedCountdownEnd is null)
                 {
-                    RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");
-                    _autoCalledBefore = true;
+                    var ev = new ShuttleAutoCallAttemptedEvent();
+                    RaiseLocalEvent(ref ev);
                 }
 
                 // Always reset auto-call in case of a recall.
@@ -444,6 +471,9 @@ namespace Content.Server.RoundEnd
 
     [ByRefEvent]
     public record struct CanCallOrRecallEvent(EntityUid Station, bool Cancelled = false);
+
+    [ByRefEvent]
+    public record struct ShuttleAutoCallAttemptedEvent;
 
     public enum RoundEndBehavior : byte
     {

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -55,12 +55,13 @@ namespace Content.Server.RoundEnd
         /// <summary>
         /// How long should a round last until you can no longer recall without admin intervention?
         /// </summary>
-        public TimeSpan RoundHardEnd { get; set; } = TimeSpan.FromHours(5);
+        // public TimeSpan RoundHardEnd { get; set; } = TimeSpan.FromHours(5);
+        public TimeSpan RoundHardEnd { get; set; } = TimeSpan.FromMinutes(2);
 
         /// <summary>
         /// How long before round hard end should the warning be sent?
         /// </summary>
-        public TimeSpan RoundHardEndWarningTime { get; set; } = TimeSpan.FromMinutes(15);
+        public TimeSpan RoundHardEndWarningTime { get; set; } = TimeSpan.FromMinutes(1);
 
         /// <summary>
         /// Should we not allow recall due to round hard end being met?

--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -30,7 +30,7 @@ namespace Content.Server.RoundEnd
     /// Handles ending rounds normally and also via requesting it (e.g. via comms console)
     /// If you request a round end then an escape shuttle will be used.
     /// </summary>
-    public sealed class RoundEndSystem : EntitySystem
+    public sealed partial class RoundEndSystem : EntitySystem
     {
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
@@ -52,6 +52,21 @@ namespace Content.Server.RoundEnd
         /// </summary>
         public TimeSpan DefaultCountdownDuration { get; set; } = TimeSpan.FromMinutes(10);
 
+        /// <summary>
+        /// How long should a round last until you can no longer recall without admin intervention?
+        /// </summary>
+        public TimeSpan RoundHardEnd { get; set; } = TimeSpan.FromHours(5);
+
+        /// <summary>
+        /// How long before round hard end should the warning be sent?
+        /// </summary>
+        public TimeSpan RoundHardEndWarningTime { get; set; } = TimeSpan.FromMinutes(15);
+
+        /// <summary>
+        /// Should we not allow recall due to round hard end being met?
+        /// </summary>
+        public bool RespectRoundHardEnd { get; set; } = true;
+
         private CancellationTokenSource? _countdownTokenSource = null;
         private CancellationTokenSource? _cooldownTokenSource = null;
         public TimeSpan? LastCountdownStart { get; set; } = null;
@@ -66,7 +81,9 @@ namespace Content.Server.RoundEnd
         {
             base.Initialize();
             SubscribeLocalEvent<RoundRestartCleanupEvent>(_ => Reset());
+
             SetAutoCallTime();
+            InitializeDen();
         }
 
         private void SetAutoCallTime()
@@ -103,6 +120,7 @@ namespace Content.Server.RoundEnd
             AllEntityQuery<StationEmergencyShuttleComponent, StationDataComponent>().MoveNext(out _, out _, out var data);
             if (data == null)
                 return null;
+
             var targetGrid = _stationSystem.GetLargestGrid(data);
             return targetGrid == null ? null : Transform(targetGrid.Value).MapUid;
         }
@@ -119,7 +137,15 @@ namespace Content.Server.RoundEnd
 
         public bool CanCallOrRecall()
         {
-            return _cooldownTokenSource == null;
+            var station = GetStation();
+
+            if (station == null)
+                return _cooldownTokenSource == null;
+
+            var ev = new CanCallOrRecallEvent(station.Value);
+            RaiseLocalEvent(ref ev);
+
+            return _cooldownTokenSource == null || !ev.Cancelled;
         }
 
         public bool IsRoundEndRequested()
@@ -182,16 +208,32 @@ namespace Content.Server.RoundEnd
                 units = "eta-units-minutes";
             }
 
-            _announcer.SendAnnouncement(_announcer.GetAnnouncementId("ShuttleCalled"),
-                Filter.Broadcast(),
-                text,
-                name,
-                Color.Gold,
-                null,
-                null,
-                ("time", time),
+            if (_gameTicker.RoundDuration() >= RoundHardEnd && RespectRoundHardEnd)
+            {
+                _announcer.SendAnnouncement(_announcer.GetAnnouncementId("ShuttleCalled"),
+                    Filter.Broadcast(),
+                    "round-end-system-shuttle-no-longer-recall",
+                    name,
+                    Color.Gold,
+                    null,
+                    null,
+                    ("time", time),
                     ("units", Loc.GetString(units))
-            );
+                );
+            }
+            else
+            {
+                _announcer.SendAnnouncement(_announcer.GetAnnouncementId("ShuttleCalled"),
+                    Filter.Broadcast(),
+                    text,
+                    name,
+                    Color.Gold,
+                    null,
+                    null,
+                    ("time", time),
+                    ("units", Loc.GetString(units))
+                );
+            }
 
             LastCountdownStart = _gameTiming.CurTime;
             ExpectedCountdownEnd = _gameTiming.CurTime + countdownTime;
@@ -398,6 +440,9 @@ namespace Content.Server.RoundEnd
     {
         public static RoundEndSystemChangedEvent Default { get; } = new();
     }
+
+    [ByRefEvent]
+    public record struct CanCallOrRecallEvent(EntityUid Station, bool Cancelled = false);
 
     public enum RoundEndBehavior : byte
     {

--- a/Content.Server/Voting/Managers/VoteManager.cs
+++ b/Content.Server/Voting/Managers/VoteManager.cs
@@ -210,7 +210,7 @@ namespace Content.Server.Voting.Managers
             var start = _timing.RealTime;
             var end = start + options.Duration;
             var reg = new VoteReg(id, entries, options.Title, options.InitiatorText,
-                options.InitiatorPlayer, start, end);
+                options.InitiatorPlayer, start, end, options.PlayVoteSound);
 
             var handle = new VoteHandle(this, reg);
 
@@ -252,6 +252,7 @@ namespace Content.Server.Voting.Managers
                 msg.VoteInitiator = v.InitiatorText;
                 msg.StartTime = v.StartTime;
                 msg.EndTime = v.EndTime;
+                msg.PlayVoteSound = v.PlayVoteSound;
             }
 
             if (v.CastVotes.TryGetValue(player, out var cast))
@@ -445,6 +446,7 @@ namespace Content.Server.Voting.Managers
             public readonly HashSet<ICommonSession> VotesDirty = new();
 
             public bool Cancelled;
+            public bool PlayVoteSound;
             public bool Finished;
             public bool Dirty = true;
 
@@ -453,7 +455,7 @@ namespace Content.Server.Voting.Managers
             public ICommonSession? Initiator { get; }
 
             public VoteReg(int id, VoteEntry[] entries, string title, string initiatorText,
-                ICommonSession? initiator, TimeSpan start, TimeSpan end)
+                ICommonSession? initiator, TimeSpan start, TimeSpan end, bool playVoteSound)
             {
                 Id = id;
                 Entries = entries;
@@ -462,6 +464,7 @@ namespace Content.Server.Voting.Managers
                 Initiator = initiator;
                 StartTime = start;
                 EndTime = end;
+                PlayVoteSound = playVoteSound;
             }
         }
 

--- a/Content.Server/Voting/VoteOptions.cs
+++ b/Content.Server/Voting/VoteOptions.cs
@@ -40,6 +40,11 @@ namespace Content.Server.Voting
         public List<(string text, object data)> Options { get; set; } = new();
 
         /// <summary>
+        ///     Whether the iconic vote sound should play or not.
+        /// </summary>
+        public bool PlayVoteSound { get; set; } = true;
+
+        /// <summary>
         ///     Sets <see cref="InitiatorPlayer"/> and <see cref="InitiatorText"/>
         ///     by setting the latter to the player's name.
         /// </summary>

--- a/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
+++ b/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
@@ -17,15 +17,6 @@ public sealed partial class RoundEndSystem
         SubscribeLocalEvent<CanCallOrRecallEvent>(CheckIfCanCallOrRecall);
     }
 
-    public void RestartHardEndWarning()
-    {
-        _roundHardEndWarningToken?.Cancel();
-
-        InitializeTimer();
-    }
-
-    public void CancelHardEndWarning() => _roundHardEndWarningToken?.Cancel();
-
     private TimeSpan WarnAt() => RoundHardEnd - RoundHardEndWarningTime;
 
     private void InitializeTimer()
@@ -43,6 +34,9 @@ public sealed partial class RoundEndSystem
 
     private void SendWarningAnnouncement()
     {
+        if (!RespectRoundHardEnd)
+            return;
+
         var warnAt = WarnAt();
 
         int time;

--- a/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
+++ b/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
@@ -1,0 +1,74 @@
+using System.Threading;
+using Robust.Shared.Player;
+using Timer = Robust.Shared.Timing.Timer;
+
+
+namespace Content.Server.RoundEnd;
+
+
+public sealed partial class RoundEndSystem
+{
+    private CancellationTokenSource? _roundHardEndWarningToken;
+
+    private void InitializeDen()
+    {
+        InitializeTimer();
+
+        SubscribeLocalEvent<CanCallOrRecallEvent>(CheckIfCanCallOrRecall);
+    }
+
+    public void RestartHardEndWarning()
+    {
+        _roundHardEndWarningToken?.Cancel();
+
+        InitializeTimer();
+    }
+
+    public void CancelHardEndWarning() => _roundHardEndWarningToken?.Cancel();
+
+    private TimeSpan WarnAt() => RoundHardEnd - RoundHardEndWarningTime;
+
+    private void InitializeTimer()
+    {
+        _roundHardEndWarningToken = new();
+
+        Timer.Spawn(WarnAt(), SendWarningAnnouncement, _roundHardEndWarningToken.Token);
+    }
+
+    private void CheckIfCanCallOrRecall(ref CanCallOrRecallEvent ev)
+    {
+        if (_gameTicker.RoundDuration() > RoundHardEnd && RespectRoundHardEnd)
+            ev.Cancelled = true;
+    }
+
+    private void SendWarningAnnouncement()
+    {
+        var warnAt = WarnAt();
+
+        int time;
+        string units;
+
+        if (warnAt.TotalSeconds < 60)
+        {
+            time = warnAt.Seconds;
+            units = "eta-units-seconds";
+        }
+        else
+        {
+            time = warnAt.Minutes;
+            units = "eta-units-minutes";
+        }
+
+        _announcer.SendAnnouncement(
+            _announcer.GetAnnouncementId("CommandReport"),
+            Filter.Broadcast(),
+            "round-end-system-shuttle-no-longer-recall-soon",
+            "Station",
+            Color.Gold,
+            null,
+            null,
+            ("time", time),
+            ("units", Loc.GetString(units))
+        );
+    }
+}

--- a/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
+++ b/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
@@ -1,4 +1,6 @@
 using System.Threading;
+using Content.Server.Voting;
+using Content.Shared.CCVar;
 using Robust.Shared.Player;
 using Timer = Robust.Shared.Timing.Timer;
 
@@ -8,22 +10,20 @@ namespace Content.Server.RoundEnd;
 
 public sealed partial class RoundEndSystem
 {
-    private CancellationTokenSource? _roundHardEndWarningToken;
-
     private void InitializeDen()
     {
         InitializeTimer();
 
         SubscribeLocalEvent<CanCallOrRecallEvent>(CheckIfCanCallOrRecall);
+        SubscribeLocalEvent<ShuttleAutoCallAttemptedEvent>(OnShuttleAutoCallAttempted);
     }
 
     private TimeSpan WarnAt() => RoundHardEnd - RoundHardEndWarningTime;
 
     private void InitializeTimer()
     {
-        _roundHardEndWarningToken = new();
-
-        Timer.Spawn(WarnAt(), SendWarningAnnouncement, _roundHardEndWarningToken.Token);
+        Timer.Spawn(WarnAt(), SendWarningAnnouncement);
+        Timer.Spawn(RoundHardEnd, UpdateRoundEnd);
     }
 
     private void CheckIfCanCallOrRecall(ref CanCallOrRecallEvent ev)
@@ -31,6 +31,51 @@ public sealed partial class RoundEndSystem
         if (_gameTicker.RoundDuration() > RoundHardEnd && RespectRoundHardEnd)
             ev.Cancelled = true;
     }
+
+    private void ShuttleRecallVoteFinished(VoteFinishedEventArgs args)
+    {
+        if (args.Winner == null)
+            return;
+
+        var votedYes = (bool) args.Winner;
+
+        if (!votedYes || !CanCallOrRecallIgnoringCooldown())
+            return;
+
+        RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");
+        _autoCalledBefore = true;
+    }
+
+    /// <summary>
+    /// Send recall vote.
+    /// </summary>
+    private void OnShuttleAutoCallAttempted(ref ShuttleAutoCallAttemptedEvent ev)
+    {
+        if (!CanCallOrRecallIgnoringCooldown())
+            return;
+
+        var alone = _playerManager.PlayerCount == 1;
+        var options = new VoteOptions
+        {
+            Title = Loc.GetString("ui-vote-recall-title"),
+            Duration = alone
+                ? TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerAlone))
+                : TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.VoteTimerRestart)) // just use restart vote timer
+        };
+
+        var localeYes = Loc.GetString("ui-vote-restart-yes");
+        var localeNo = Loc.GetString("ui-vote-restart-no");
+
+        options.InitiatorText = "Server";
+        options.PlayVoteSound = false; // we expect to be doing this several times a shift.
+        options.Options.Add((localeYes, true));
+        options.Options.Add((localeNo, false));
+
+        var recallVote = _voteManager.CreateVote(options);
+        recallVote.OnFinished += (_, args) => ShuttleRecallVoteFinished(args);
+    }
+
+    public void UpdateRoundEnd() => RaiseLocalEvent(RoundEndSystemChangedEvent.Default);
 
     private void SendWarningAnnouncement()
     {

--- a/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
+++ b/Content.Server/_DEN/RoundEnd/RoundEndSystem.DEN.cs
@@ -39,7 +39,7 @@ public sealed partial class RoundEndSystem
 
         var votedYes = (bool) args.Winner;
 
-        if (!votedYes || !CanCallOrRecallIgnoringCooldown())
+        if (votedYes || !CanCallOrRecallIgnoringCooldown())
             return;
 
         RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");

--- a/Content.Server/_DEN/RoundEnd/ToggleHardEndCommand.cs
+++ b/Content.Server/_DEN/RoundEnd/ToggleHardEndCommand.cs
@@ -7,22 +7,16 @@ namespace Content.Server.RoundEnd;
 [AdminCommand(AdminFlags.Admin)]
 public sealed class ToggleHardEndCommand : IConsoleCommand
 {
-    [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
-
     public string Command { get; } = "togglehardend";
     public string Description { get; } = "Toggles whether or not recall should be allowed after hard end is reached.";
     public string Help { get; } = "togglehardend";
 
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        _roundEndSystem.RespectRoundHardEnd = !_roundEndSystem.RespectRoundHardEnd;
+        var roundEndSystem = IoCManager.Resolve<RoundEndSystem>();
+        roundEndSystem.RespectRoundHardEnd = !roundEndSystem.RespectRoundHardEnd;
 
-        if (_roundEndSystem.RespectRoundHardEnd)
-            _roundEndSystem.RestartHardEndWarning();
-        else
-            _roundEndSystem.CancelHardEndWarning();
-
-        var toggled = _roundEndSystem.RespectRoundHardEnd ? "will now " : "will no longer ";
+        var toggled = roundEndSystem.RespectRoundHardEnd ? "will now " : "will no longer ";
         shell.WriteLine($"The round {toggled} end when hard end is reached.");
     }
 }

--- a/Content.Server/_DEN/RoundEnd/ToggleHardEndCommand.cs
+++ b/Content.Server/_DEN/RoundEnd/ToggleHardEndCommand.cs
@@ -1,0 +1,28 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server.RoundEnd;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class ToggleHardEndCommand : IConsoleCommand
+{
+    [Dependency] private readonly RoundEndSystem _roundEndSystem = default!;
+
+    public string Command { get; } = "togglehardend";
+    public string Description { get; } = "Toggles whether or not recall should be allowed after hard end is reached.";
+    public string Help { get; } = "togglehardend";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        _roundEndSystem.RespectRoundHardEnd = !_roundEndSystem.RespectRoundHardEnd;
+
+        if (_roundEndSystem.RespectRoundHardEnd)
+            _roundEndSystem.RestartHardEndWarning();
+        else
+            _roundEndSystem.CancelHardEndWarning();
+
+        var toggled = _roundEndSystem.RespectRoundHardEnd ? "will now " : "will no longer ";
+        shell.WriteLine($"The round {toggled} end when hard end is reached.");
+    }
+}

--- a/Content.Server/_DEN/RoundEnd/ToggleHardEndCommand.cs
+++ b/Content.Server/_DEN/RoundEnd/ToggleHardEndCommand.cs
@@ -13,10 +13,12 @@ public sealed class ToggleHardEndCommand : IConsoleCommand
 
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        var roundEndSystem = IoCManager.Resolve<RoundEndSystem>();
+        var sysManager = IoCManager.Resolve<IEntitySystemManager>();
+        var roundEndSystem = sysManager.GetEntitySystem<RoundEndSystem>();
         roundEndSystem.RespectRoundHardEnd = !roundEndSystem.RespectRoundHardEnd;
+        roundEndSystem.UpdateRoundEnd();
 
-        var toggled = roundEndSystem.RespectRoundHardEnd ? "will now " : "will no longer ";
+        var toggled = roundEndSystem.RespectRoundHardEnd ? "will now" : "will no longer";
         shell.WriteLine($"The round {toggled} end when hard end is reached.");
     }
 }

--- a/Content.Shared/Voting/MsgVoteData.cs
+++ b/Content.Shared/Voting/MsgVoteData.cs
@@ -14,6 +14,7 @@ namespace Content.Shared.Voting
         public string VoteInitiator = string.Empty;
         public TimeSpan StartTime; // Server RealTime.
         public TimeSpan EndTime; // Server RealTime.
+        public bool PlayVoteSound;
         public (ushort votes, string name)[] Options = default!;
         public bool IsYourVoteDirty;
         public byte? YourVote;

--- a/Resources/Locale/en-US/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/communications/communications-console-component.ftl
@@ -2,9 +2,13 @@
 comms-console-menu-title = Communications Console
 comms-console-menu-announcement-placeholder = Announcement text...
 comms-console-menu-announcement-button = Announce
+comms-console-menu-announcement-button-tooltip = Send your message as a station-wide radio announcement.
 comms-console-menu-broadcast-button = Broadcast
+comms-console-menu-broadcast-button-tooltip = Broadcast your message to wall-mounted screens around the station. Note: They fit only ten characters!
+comms-console-menu-alert-level-button-tooltip = Change the station alert level. Applies immediately on selecting.
 comms-console-menu-call-shuttle = Call emergency shuttle
 comms-console-menu-recall-shuttle = Recall emergency shuttle
+comms-console-menu-emergency-shuttle-button-tooltip = Calls or recalls the emergency shuttle. You can only recall when there's enough time left.
 comms-console-menu-time-remaining = Time remaining: {$time}
 
 # Popup
@@ -21,3 +25,4 @@ comms-console-announcement-title-station = Communications Console
 comms-console-announcement-title-centcom = Central Command
 comms-console-announcement-title-nukie = Syndicate Nuclear Operative
 comms-console-announcement-title-station-ai = Station AI
+comms-console-announcement-title-wizard = Wizard

--- a/Resources/Locale/en-US/round-end/round-end-system.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-system.ftl
@@ -2,6 +2,8 @@
 
 round-end-system-shuttle-called-announcement = An emergency shuttle has been sent. ETA: {$time} {$units}.
 round-end-system-shuttle-already-called-announcement = An emergency shuttle has already been sent.
+round-end-system-shuttle-no-longer-recall-soon = The emergency shuttle will no longer be recallable in {$time} {$units}.
+round-end-system-shuttle-no-longer-recall = The maximum Central Command shift time has been reached, and the emergency shuttle can no longer be recalled. If Central Command does not intervene, the emergency shuttle will arrive as normal in {$time} {$units}.
 round-end-system-shuttle-auto-called-announcement = An automatic crew shift change shuttle has been sent. ETA: {$time} {$units}. Recall the shuttle to extend the shift.
 round-end-system-shuttle-recalled-announcement = The emergency shuttle has been recalled.
 round-end-system-round-restart-eta-announcement = Restarting the round in {$time} {$units}...

--- a/Resources/Locale/en-US/round-end/round-end-system.ftl
+++ b/Resources/Locale/en-US/round-end/round-end-system.ftl
@@ -10,3 +10,7 @@ round-end-system-round-restart-eta-announcement = Restarting the round in {$time
 
 eta-units-minutes = minutes
 eta-units-seconds = seconds
+
+ui-vote-recall-title = Extend the round?
+ui-vote-yes = Yes
+ui-vote-no = No


### PR DESCRIPTION
Tested, blah blah blah.
New admin command: togglehardend

If used after hard end is reached, it allows shuttle to be recalled again.

# TODO
- [x] Round hard end implementation
- [x] Server automated recall votes instead of votes controlled by command.

:cl:
- add: Round extension votes are now handled through an OOC vote, before the initial shuttle call is made.
- add: Rounds will no longer last 6 hours and are now capped at 5, unless an admin intervenes beforehand.