### PR TITLE
Fix: Displacement Maps No Longer Show on Custom RSI States

### DIFF
--- a/Content.Client/Clothing/ClientClothingSystem.cs
+++ b/Content.Client/Clothing/ClientClothingSystem.cs
@@ -370,6 +370,11 @@ public sealed class ClientClothingSystem : ClothingSystem
             sprite.LayerSetData(index, layerData);
             layer.Offset += slotDef.Offset;
 
+            // Begin TheDen - Ignore displacement maps for custom sprites
+            if (layerData.State != null && inventory.SpeciesId != null && layerData.State.Contains(inventory.SpeciesId))
+                continue;
+            // End TheDen
+
             if (displacementData != null)
             {
                 if (displacementData.ShaderOverride != null)


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Currently, displacement maps will always apply, even if an asset defines a custom state for the species (thus preventing the need for displacement maps). This PR prevents displacement maps from activating in those cases.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

Without a custom state:
![image](https://github.com/user-attachments/assets/9ba02e3e-0ecc-4f3d-b92d-8f8ac238c659)
![image](https://github.com/user-attachments/assets/cdffc179-94db-4556-85a5-1b091de06547)

With a custom state:
![image](https://github.com/user-attachments/assets/6f8a28b7-ed74-4627-9695-d3271b1579aa)
![image](https://github.com/user-attachments/assets/c10fcf79-a48a-4c9f-9b22-38c5664fa073)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: displacement maps no longer show on custom RSI states
