### PR TITLE
Recategorize all Physical traits into subcategories

### DIFF
--- a/Resources/Locale/en-US/traits/categories.ftl
+++ b/Resources/Locale/en-US/traits/categories.ftl
@@ -9,3 +9,9 @@ trait-category-TraitsSpeechUncategorized = Uncategorized
 trait-category-TraitsSpeechAccents = Accents
 trait-category-TraitsSpeechLanguages = Languages
 trait-category-Visual = Visual
+
+trait-category-TraitsPhysicalUncategorized = Uncategorized
+trait-category-TraitsPhysicalFeats = Feats
+trait-category-TraitsPhysicalDisabilities = Disabilities
+trait-category-TraitsPhysicalBiological = Biological
+trait-category-TraitsPhysicalAugmentations = Augmentations

--- a/Resources/Prototypes/Floof/Traits/lewd.yml
+++ b/Resources/Prototypes/Floof/Traits/lewd.yml
@@ -1,6 +1,6 @@
 - type: trait
   id: CumProducer
-  category: Physical
+  category: TraitsPhysicalBiological
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -33,7 +33,7 @@
 
 - type: trait
   id: MilkProducer
-  category: Physical
+  category: TraitsPhysicalBiological
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -66,7 +66,7 @@
 
 - type: trait
   id: SquirtProducer
-  category: Physical
+  category: TraitsPhysicalBiological
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -99,7 +99,7 @@
 
 - type: trait
   id: HoneyProducer
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -1 # Point cost added to balance with removal of species restriction
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Floof/Traits/physical.yml
+++ b/Resources/Prototypes/Floof/Traits/physical.yml
@@ -1,6 +1,6 @@
 - type: trait
   id: HollowFangs
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -2
   requirements:
   - !type:CharacterJobRequirement
@@ -26,7 +26,7 @@
 
 - type: trait
   id: Weakness
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 5
   requirements:
     - !type:CharacterJobRequirement
@@ -52,7 +52,7 @@
 
 - type: trait
   id: Lightweight
-  category: Physical
+  category: TraitsPhysicalBiological
   points: 2 # Has pros and cons, not sure
   requirements:
   - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -15,6 +15,12 @@
 - type: traitCategory
   id: Physical
   root: true
+  subCategories:
+    - TraitsPhysicalUncategorized
+    - TraitsPhysicalFeats
+    - TraitsPhysicalDisabilities
+    - TraitsPhysicalBiological
+    - TraitsPhysicalAugmentations
 
 - type: traitCategory
   id: Speech
@@ -40,3 +46,18 @@
 - type: traitCategory
   id: Language
   root: true
+
+- type: traitCategory
+  id: TraitsPhysicalUncategorized
+
+- type: traitCategory
+  id: TraitsPhysicalFeats
+
+- type: traitCategory
+  id: TraitsPhysicalDisabilities
+
+- type: traitCategory
+  id: TraitsPhysicalBiological
+
+- type: traitCategory
+  id: TraitsPhysicalAugmentations

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -121,7 +121,7 @@
 
 - type: trait
   id: Uncloneable
-  category: Physical
+  category: TraitsPhysicalBiological
   points: 1
   requirements:
     - !type:CharacterJobRequirement
@@ -178,7 +178,7 @@
 
 - type: trait
   id: BadKnees
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 5
   requirements:
     - !type:CharacterTraitRequirement
@@ -202,7 +202,7 @@
 
 - type: trait
   id: Sluggish
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 5
   requirements:
     - !type:CharacterTraitRequirement
@@ -225,7 +225,7 @@
 
 - type: trait
   id: SnailPaced
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 8
   requirements:
     - !type:CharacterTraitRequirement
@@ -248,7 +248,7 @@
 
 - type: trait
   id: BloodDeficiency
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 6
   requirements:
     - !type:CharacterJobRequirement
@@ -270,7 +270,7 @@
 
 - type: trait
   id: Hemophilia
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 4
   requirements:
     - !type:CharacterJobRequirement
@@ -325,7 +325,7 @@
 
 - type: trait
   id: Clumsy
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 4
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -1,6 +1,6 @@
 - type: trait
   id: LightweightDrunk
-  category: Physical
+  category: TraitsPhysicalBiological
   requirements:
     - !type:CharacterJobRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1,6 +1,6 @@
 - type: trait
   id: WillToLive
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -3
   requirements:
     - !type:CharacterJobRequirement
@@ -25,7 +25,7 @@
 
 - type: trait
   id: WillToDie
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 2
   requirements:
     - !type:CharacterJobRequirement
@@ -49,7 +49,7 @@
 
 - type: trait
   id: Tenacity
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -4
   requirements:
     - !type:CharacterJobRequirement
@@ -74,7 +74,7 @@
 
 - type: trait
   id: GlassJaw
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 2
   requirements:
     - !type:CharacterJobRequirement
@@ -98,7 +98,7 @@
 
 - type: trait
   id: Vigor
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -6
   requirements:
     - !type:CharacterJobRequirement
@@ -124,7 +124,7 @@
 
 - type: trait
   id: Lethargy
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 4
   requirements:
     - !type:CharacterJobRequirement
@@ -150,7 +150,7 @@
 
 - type: trait
   id: HighAdrenaline
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -5
   requirements:
     - !type:CharacterJobRequirement
@@ -175,7 +175,7 @@
 
 - type: trait
   id: AdrenalDysfunction
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 3
   requirements:
     - !type:CharacterJobRequirement
@@ -199,7 +199,7 @@
 
 - type: trait
   id: Masochism
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -5
   requirements:
     - !type:CharacterJobRequirement
@@ -220,7 +220,7 @@
 
 - type: trait
   id: LowPainTolerance
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 3
   requirements:
     - !type:CharacterJobRequirement
@@ -240,7 +240,7 @@
 
 - type: trait
   id: Steadfast
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -4
   requirements:
     - !type:CharacterJobRequirement
@@ -264,7 +264,7 @@
 
 - type: trait
   id: Feeble
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 3
   requirements:
     - !type:CharacterJobRequirement
@@ -288,7 +288,7 @@
 
 - type: trait
   id: MartialArtist
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -5
   requirements:
   - !type:CharacterJobRequirement
@@ -321,7 +321,7 @@
 
 - type: trait
   id: Small
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -2
   requirements:
     - !type:CharacterSpeciesRequirement
@@ -346,7 +346,7 @@
 
 - type: trait
   id: TemperatureTolerance
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -1
   requirements:
     - !type:CharacterSpeciesRequirement
@@ -365,7 +365,7 @@
 # When declared, componentRemovals work like a "RemComp" that activates upon joining a round.
 - type: trait
   id: Talons
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -1
   requirements:
     - !type:CharacterSpeciesRequirement
@@ -398,7 +398,7 @@
 
 - type: trait
   id: Claws
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -1
   requirements:
     - !type:CharacterSpeciesRequirement
@@ -433,7 +433,7 @@
 
 - type: trait
   id: NaturalWeaponRemoval
-  category: Physical
+  category: TraitsPhysicalBiological
   points: 0
   requirements:
     - !type:CharacterSpeciesRequirement
@@ -471,7 +471,7 @@
 
 - type: trait
   id: StrikingCalluses
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -3
   requirements:
     - !type:CharacterJobRequirement
@@ -523,7 +523,7 @@
 
 - type: trait
   id: Spinarette
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -3
   requirements:
     - !type:CharacterJobRequirement
@@ -552,7 +552,7 @@
 
 - type: trait
   id: BionicArm
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -6
   requirements:
     - !type:CharacterJobRequirement
@@ -579,7 +579,7 @@
 
 - type: trait
   id: PlateletFactories
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -10
   requirements:
     - !type:CharacterJobRequirement
@@ -608,7 +608,7 @@
 
 - type: trait
   id: DermalArmor
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -6
   requirements:
     - !type:CharacterJobRequirement
@@ -627,7 +627,7 @@
 
 - type: trait
   id: CyberEyes
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -4
   requirements:
     - !type:CharacterJobRequirement
@@ -657,7 +657,7 @@
 
 - type: trait
   id: FlareShielding
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -4
   requirements:
     - !type:CharacterDepartmentRequirement
@@ -675,7 +675,7 @@
 
 - type: trait
   id: CyberEyesSecurity
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -1
   requirements:
     - !type:CharacterJobRequirement
@@ -703,7 +703,7 @@
 
 - type: trait
   id: CyberEyesMedical
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -2
   requirements:
     - !type:CharacterJobRequirement
@@ -731,7 +731,7 @@
 
 - type: trait
   id: CyberEyesDiagnostic
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -2
   requirements:
     - !type:CharacterJobRequirement
@@ -757,7 +757,7 @@
 
 - type: trait
   id: CyberEyesOmni
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -3
   requirements:
     - !type:CharacterJobRequirement
@@ -798,7 +798,7 @@
 
 - type: trait
   id: Redshirt
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 8
   requirements:
     - !type:CharacterJobRequirement
@@ -822,7 +822,7 @@
 
 - type: trait
   id: BrittleBoneDisease
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 10
   requirements:
     - !type:CharacterJobRequirement
@@ -846,7 +846,7 @@
 
 - type: trait
   id: LightAmplification
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -4
   requirements:
     - !type:CharacterJobRequirement
@@ -863,7 +863,7 @@
 
 - type: trait
   id: ThermographicVision
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -4
   requirements:
     - !type:CharacterJobRequirement
@@ -887,7 +887,7 @@
 
 - type: trait
   id: NaniteAutoRepairBots
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -10
   requirements:
     - !type:CharacterJobRequirement
@@ -914,7 +914,7 @@
 
 - type: trait
   id: BionicLeg
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -8
   requirements:
     - !type:CharacterJobRequirement
@@ -948,7 +948,7 @@
 
 - type: trait
   id: FlareShieldingModule
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -4
   requirements:
     - !type:CharacterDepartmentRequirement
@@ -973,7 +973,7 @@
 
 - type: trait
   id: SecurityEyesModule
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -1
   requirements:
     - !type:CharacterJobRequirement
@@ -1001,7 +1001,7 @@
 
 - type: trait
   id: MedicalEyesModule
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -2
   requirements:
     - !type:CharacterJobRequirement
@@ -1029,7 +1029,7 @@
 
 - type: trait
   id: DiagnosticEyesModule
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -2
   requirements:
     - !type:CharacterJobRequirement
@@ -1055,7 +1055,7 @@
 
 - type: trait
   id: OmniEyesModule
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -3
   requirements:
     - !type:CharacterJobRequirement
@@ -1099,7 +1099,7 @@
 
 - type: trait
   id: LightAmplificationModule
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -4
   requirements:
     - !type:CharacterJobRequirement
@@ -1116,7 +1116,7 @@
 
 - type: trait
   id: ThermographicVisionModule
-  category: Physical
+  category: TraitsPhysicalAugmentations
   points: -4
   requirements:
     - !type:CharacterJobRequirement
@@ -1140,7 +1140,7 @@
 
 # - type: trait
 #   id: Bulky
-#   category: Physical
+#   category: TraitsPhysicalBiological
 #   points: -6
 #   requirements:
 #     - !type:CharacterTraitRequirement
@@ -1159,7 +1159,7 @@
 
 # - type: trait
 #   id: Featherweight
-#   category: Physical
+#   category: TraitsPhysicalBiological
 #   points: 3
 #   requirements:
 #     - !type:CharacterTraitRequirement
@@ -1178,7 +1178,7 @@
 
 - type: trait
   id: Bodybuilder
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -6
   requirements:
     - !type:CharacterTraitRequirement
@@ -1202,7 +1202,7 @@
 
 - type: trait
   id: Weakling
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 3
   requirements:
     - !type:CharacterTraitRequirement
@@ -1226,7 +1226,7 @@
 
 - type: trait
   id: Vampirism # You may port this to EE, you have my permission!
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -3
   requirements:
     - !type:CharacterJobRequirement
@@ -1252,7 +1252,7 @@
 # Commented out upon request for the time being
 #- type: trait
 #  id: EggLaying
-#  category: Physical
+#  category: TraitsPhysicalBiological
 #  points: 0
 #  requirements:
 #  - !type:CharacterJobRequirement
@@ -1269,7 +1269,7 @@
 
 - type: trait # Based on Cosmatic Drift's Synth trait
   id: Synthetic
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -2 # Can detect ion storms, poison blood
   requirements:
     - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Traits/skills.yml
+++ b/Resources/Prototypes/Traits/skills.yml
@@ -40,7 +40,7 @@
 
 - type: trait
   id: HeavyweightDrunk
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -1
   requirements:
     - !type:CharacterJobRequirement
@@ -66,7 +66,7 @@
 
 - type: trait
   id: LiquorLifeline
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -6
   requirements:
     - !type:CharacterJobRequirement
@@ -93,7 +93,7 @@
 
 - type: trait
   id: Thieving
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -8
   functions:
     - !type:TraitReplaceComponent
@@ -111,7 +111,7 @@
 
 - type: trait
   id: Voracious
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -2
   functions:
     - !type:TraitReplaceComponent
@@ -129,7 +129,7 @@
 
 - type: trait
   id: ParkourTraining
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -5
   requirements:
     - !type:CharacterTraitRequirement
@@ -324,7 +324,7 @@
 
 - type: trait
   id: TrapAvoider
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -3
   functions:
     - !type:TraitAddComponent

--- a/Resources/Prototypes/Traits/species.yml
+++ b/Resources/Prototypes/Traits/species.yml
@@ -1,6 +1,6 @@
 - type: trait
   id: Swashbuckler
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -1
   functions:
     - !type:TraitReplaceComponent
@@ -25,7 +25,7 @@
 
 - type: trait
   id: Spearmaster
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -1
   functions:
     - !type:TraitReplaceComponent
@@ -49,7 +49,7 @@
 
 - type: trait
   id: WeaponsGeneralist
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -1
   functions:
     - !type:TraitReplaceComponent
@@ -127,7 +127,7 @@
 
 - type: trait
   id: MothFlight
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -5
   functions:
     - !type:TraitAddComponent

--- a/Resources/Prototypes/_DEN/Traits/disabilities.yml
+++ b/Resources/Prototypes/_DEN/Traits/disabilities.yml
@@ -1,6 +1,6 @@
 - type: trait
   id: FastMetabolism
-  category: Physical
+  category: TraitsPhysicalBiological
   points: 2
   requirements:
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/_DEN/Traits/physical.yml
+++ b/Resources/Prototypes/_DEN/Traits/physical.yml
@@ -1,6 +1,6 @@
 - type: trait
   id: Heavyweight
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -2 # Has pros and cons, not sure
   requirements:
   - !type:CharacterJobRequirement
@@ -23,7 +23,7 @@
 
 - type: trait
   id: UltraHeavyweight
-  category: Physical
+  category: TraitsPhysicalBiological
   points: -4 # Has pros and cons, not sure
   requirements:
   - !type:CharacterJobRequirement
@@ -46,7 +46,7 @@
 
 - type: trait
   id: UltraLightweight
-  category: Physical
+  category: TraitsPhysicalBiological
   points: 4 # Has pros and cons, not sure
   requirements:
   - !type:CharacterJobRequirement
@@ -69,7 +69,7 @@
 
 - type: trait
   id: ZeroGTraining
-  category: Physical
+  category: TraitsPhysicalFeats
   points: -2 # Suggested value, tweak as appropriate
   requirements:
   - !type:CharacterJobRequirement
@@ -95,7 +95,7 @@
 
 - type: trait
   id: ZeroGAverse
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 2 # Suggested value, tweak as appropriate
   requirements:
   - !type:CharacterJobRequirement
@@ -121,7 +121,7 @@
 
 - type: trait
   id: TailWag
-  category: Physical
+  category: TraitsPhysicalBiological
   points: 0
   requirements:
   - !type:CharacterJobRequirement

--- a/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Goobstation/Traits/disabilities.yml
@@ -1,6 +1,6 @@
 - type: trait
   id: WheelchairBound
-  category: Physical
+  category: TraitsPhysicalDisabilities
   points: 10
   requirements:
     - !type:CharacterJobRequirement


### PR DESCRIPTION
# Description

this PR recategorizes all physical traits under one of four subcategories, because our physical traits list is so long. they come out to four roughly evenly-distributed subcategories

<details><summary><h2>List of Trait Categories</h2></summary>
<p>

### Feats
- Spearmaster
- Swashbuckler
- Weapons Generalist
- Voracious
- Zero G Training
- Trap Avoider
- Will To Live
- Steadfast
- Tenacity
- High Adrenaline
- Martial Artist
- Masochism
- Parkour Training
- Bodybuilder
- Vigor
- Thieving

### Disabilities
- Osteogenesis Imperfecta
- Wheelchair User
- Redshirt
- Snail-Paced
- Blood Deficiency
- Bad Knees
- Sluggish
- Weakness
- Clumsy
- Hemophilia
- Lethargy
- Adrenal Dysfunction
- Feeble
- Low Pain Tolerance
- Weakling
- Glass Jaw
- Will To Die
- Zero G Averse

### Biological
- Ultra Lightweight
- Fast Metabolism
- Lightweight
- Uncloneable
- [the genital traits]
- Lightweight Drunk
- Natural Weapons Removal
- Claws
- Talons
- Tail Wag
- Alcohol Tolerance
- Honey Stomach
- Temperature Tolerance
- Heavyweight
- Hollow Fangs
- Small
- Synthetic
- Vampirism
- Ultra Heavyweight
- True Flight
- Liquor Lifeline

### Augmentations
- Bionic Spinarette
- Upgradable Cyber-Eyes
- all cyber-eye modules
- all IPC eye modules
- Bionic Arm
- Bionic Legs
- Dermal Armor
- Nanite Auto-Repair Bots
- Platelet Factories

</p>
</details>

---

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/7ed51d0c-a52f-4a66-8720-9714c812c321)

</p>
</details>

---

# Changelog

:cl:
- tweak: All Physical traits are now divided into four subcategories: Feats, Disabilities, Biological, and Augmentations.
