### PR TITLE
Fishing Guide + Guidebook Reorganization

### DIFF
--- a/Resources/Locale/en-US/_DEN/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_DEN/guidebook/guides.ftl
@@ -1,0 +1,2 @@
+guide-entry-mechanics = Mechanics
+guide-entry-fishing = Fishing

--- a/Resources/Prototypes/Guidebook/antagonist.yml
+++ b/Resources/Prototypes/Guidebook/antagonist.yml
@@ -10,6 +10,7 @@
   - MinorAntagonists
   - SpaceNinja
   - BloodCult
+  - Changelings
 
 - type: guideEntry
   id: Traitors

--- a/Resources/Prototypes/Guidebook/mechanics.yml
+++ b/Resources/Prototypes/Guidebook/mechanics.yml
@@ -1,0 +1,14 @@
+- type: guideEntry
+  id: Mechanics
+  name: guide-entry-mechanics
+  text: "/ServerInfo/Guidebook/Mechanics/Mechanics.xml"
+  children:
+  - Fishing
+  - Psionics
+  - Survival
+  - Writing
+
+- type: guideEntry
+  id: Fishing
+  name: guide-entry-fishing
+  text: "/ServerInfo/Guidebook/Mechanics/Fishing.xml"

--- a/Resources/Prototypes/Guidebook/science.yml
+++ b/Resources/Prototypes/Guidebook/science.yml
@@ -10,6 +10,7 @@
   - MachineUpgrading
   - ReverseEngineering
   - MantisGuide
+  - TraversalDistorter
 
 - type: guideEntry
   id: Technologies

--- a/Resources/Prototypes/Guidebook/ss14.yml
+++ b/Resources/Prototypes/Guidebook/ss14.yml
@@ -5,15 +5,13 @@
   children:
   - Controls
   - Jobs
-  - Survival
+  - Mechanics
   - Chemicals
   - Antagonists
   - Species
-  - Writing
-  - Glossary
   - LoadoutInfo
   - SettingLore
-  - Psionics
+  - Glossary
 
 - type: guideEntry
   id: Writing

--- a/Resources/ServerInfo/Guidebook/Mechanics/Fishing.xml
+++ b/Resources/ServerInfo/Guidebook/Mechanics/Fishing.xml
@@ -1,0 +1,58 @@
+<Document>
+  # Fishing
+
+  Certain liquids can be fished in to obtain fish and other treasures. It's a great way to pass the time, and your spoils may be of interest to the Chef or Logistics.
+
+  To start fishing, you will need to obtain a [color=#a4885c]fishing rod[/color] (of course). You can try assembling one by hand with some wood and cloth (crafting menu), otherwise a standard rod will need to be purchased from Logistics.
+
+  <Box>
+  <GuideEntityEmbed Entity="FishingRodMakeshift"/>
+  <GuideEntityEmbed Entity="FishingRod"/>
+  <GuideEntityEmbed Entity="FishingRodGolden"/>
+  </Box>
+
+  ## How to fish
+
+  <Box>
+  <GuideEntityEmbed Entity="FishingSpotWater"/>
+  <GuideEntityEmbed Entity="ToiletEmpty"/>
+  <GuideEntityEmbed Entity="FloorLavaEntity"/>
+  <GuideEntityEmbed Entity="FloorLiquidPlasmaEntity"/>
+  <GuideEntityEmbed Entity="FloorWaterEntity"/>
+  </Box>
+
+  Your first step, after obtaining a fishing rod, is to find a [color=#a4885c]liquid source[/color]. Not all sources of liquid make good fishing spots; you can't fish out of your sink, for instance. A good place to find fishing spots are [color=#a4885c]salvage expeditions[/color]; many planets contain naturally-occuring sources of liquid.
+
+  Second, take your fishing rod into your hands. You should see an [color=#a4885c]action[/color] allowing you to [color=#a4885c]throw your lure[/color]. Activate this action, then click where you want to cast your lure. When you cast upon a valid fishing spot, the lure should "attach" to the spot. You can also [color=#a4885c]reel[/color] the lure at any time.
+
+  Third, wait until something gets caught on your lure.
+
+  You will see a bar appear next to you that will start rapidly decreasing. If you hook something, [bold]mash the [color=#a4885c]"use"[/color] key[/bold] (bound to [color=#a4885c][keybind="ActivateItemInHand"/][/color]) [bold]as fast as you can![/bold]
+
+  If you succeed, your catch will come flying from the water (or other liquid) - hopefully a fish. Congratulations! You just caught something!
+
+  ## What can I do with this?
+
+  <Box>
+  <GuideEntityEmbed Entity="FishBumpy" Caption="" />
+  <GuideEntityEmbed Entity="FishFirefish" Caption="" />
+  <GuideEntityEmbed Entity="FishLubefish" Caption="" />
+  </Box>
+
+  Fish will fetch you a nice price on the market, scaling with their rarity. Otherwise, most fish can be butchered for their meat. Some fish are special and may have secret, special uses for them.
+
+  What about all of that junk you keep fishing up, you ask? What, you've never seen it before? Some of these bits and pieces can be reclaimed for their materials.
+
+  ## Improving your fishing
+
+  Rods have different [color=#a4885c]efficiency[/color] levels, which determine their effectiveness at fishing. If you're really struggling up against your catches, it might be time to put away that mess of tape and twigs and get yourself a real rod.
+
+  Fish that you catch have three different tiers - Common, Rare, and Legendary. Each one (as well as other junk you can fish up) varies in [color=#a4885c]difficulty[/color], making them harder to catch.
+
+  Not only this, but each type of fishing spot is stocked with different fish (and garbage). If the toilet is giving you nothing but trash, it might be time to take the shuttle and go exploring.
+
+  <Box>
+  <GuideEntityEmbed Entity="FishSlimefish" Caption=""/>
+  </Box>
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/Mechanics/Mechanics.xml
+++ b/Resources/ServerInfo/Guidebook/Mechanics/Mechanics.xml
@@ -1,0 +1,5 @@
+<Document>
+  # Mechanics
+
+  This section contains information on mechanics not specific to any particular job.
+</Document>


### PR DESCRIPTION
# Description

this PR adds a new fishing guidebook entry to help people get into fishing

in addition, there is a new guidebook category called "Mechanics" for stuff that isn't job specific. writing, fishing, psionics, and survival have all been put in here. 

there is a bit of guidebook reorganization here too. changelings was moved into antagonists and traversal distorter was moved into epistemics. some categories are moved into more intuitive and accessible positions

---

<details><summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/0a7ef893-ffc7-46bd-8e3d-7470600e9fc2)

</p>
</details>

---

# Changelog

:cl:
- add: New "fishing" guidebook entry. Now you can learn to fish too!
- tweak: Mildly reorganized the guidebook - moved some articles into relevant categories, reordered some article lists.