### PR TITLE
Remove Space Between Name and Message From Emotes/Subtles Starting with 'S

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -608,13 +608,17 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         // get the entity's apparent name (if no override provided).
         var ent = Identity.Entity(source, EntityManager);
-        string name = FormattedMessage.EscapeText(nameOverride ?? Name(ent));
+        var name = FormattedMessage.EscapeText(nameOverride ?? Name(ent));
+        var formattedAction = FormattedMessage.RemoveMarkupPermissive(action);
+        var useSpace = !formattedAction.StartsWith("\'s");
+        var space = useSpace ? " " : "";
 
         // Emotes use Identity.Name, since it doesn't actually involve your voice at all.
         var wrappedMessage = Loc.GetString("chat-manager-entity-me-wrap-message",
             ("entityName", name),
             ("entity", ent),
-            ("message", FormattedMessage.RemoveMarkupPermissive(action)));
+            ("space", space),
+            ("message", formattedAction));
 
         if (checkEmote)
             TryEmoteChatInput(source, action);
@@ -642,14 +646,18 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         // get the entity's apparent name (if no override provided).
         var ent = Identity.Entity(source, EntityManager);
-        string name = FormattedMessage.EscapeText(nameOverride ?? Name(ent));
+        var name = FormattedMessage.EscapeText(nameOverride ?? Name(ent));
+        var formattedAction = FormattedMessage.RemoveMarkupPermissive(action);
+        var useSpace = !formattedAction.StartsWith("\'s");
+        var space = useSpace ? " " : "";
 
         // Emotes use Identity.Name, since it doesn't actually involve your voice at all.
         var wrappedMessage = Loc.GetString("chat-manager-entity-subtle-wrap-message",
             ("entityName", name),
             ("entity", ent),
             ("color", color ?? DefaultSpeakColor.ToHex()),
-            ("message", FormattedMessage.RemoveMarkupPermissive(action)));
+            ("space", space),
+            ("message", formattedAction));
 
         foreach (var (session, data) in GetRecipients(source, WhisperClearRange))
         {

--- a/Resources/Locale/en-US/chat/managers/chat-manager.ftl
+++ b/Resources/Locale/en-US/chat/managers/chat-manager.ftl
@@ -34,13 +34,13 @@ chat-manager-entity-whisper-unknown-wrap-message = [BubbleHeader][font size=10][
 
 # THE() is not used here because the entity and its name can technically be disconnected if a nameOverride is passed...
 chat-manager-entity-me-wrap-message = [italic]{ PROPER($entity) ->
-    *[false] the {$entityName} {$message}[/italic]
-     [true] {$entityName} {$message}[/italic]
+    *[false] the {$entityName}{$space}{$message}[/italic]
+     [true] {$entityName}{$space}{$message}[/italic]
     }
 
 chat-manager-entity-subtle-wrap-message = [italic][color={$color}]{ PROPER($entity) ->
-    *[false] the {$entityName} {$message}[/color][/italic]
-     [true] {$entityName} {$message}[/color][/italic]
+    *[false] the {$entityName}{$space}{$message}[/color][/italic]
+     [true] {$entityName}{$space}{$message}[/color][/italic]
     }
 
 chat-manager-entity-looc-wrap-message = LOOC: {$entityName}: {$message}


### PR DESCRIPTION
:cl:
- tweak: A space between your name and your message will no longer appear in subtles and emotes if you begin the message with \'s