### PR TITLE
Hardsuit Syntax Fixes + ERT Chap & BSO Hardsuit Names

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_Goobstation/store/uplink-catalog.ftl
@@ -6,11 +6,11 @@ uplink-mech-teleporter-heavy-desc = Contains a heavily armored Cybersun mech wit
 uplink-mech-teleporter-assault-name = Assault Mech teleporter
 uplink-mech-teleporter-assault-desc = Contains a lightly armored Cybersun mech with an integrated chainsword, LBX AC 10 "Scattershot", SRM-8 Light Missile Rack and P-X Tesla Cannon.
 
-uplink-hardsuit-cybersun-stealth-name = CSA-91x "Èguǐ" tacsuit
+uplink-hardsuit-cybersun-stealth-name ="Èguǐ" tacsuit
 uplink-hardsuit-cybersun-stealth-desc = A rare prototype tacsuit that features metamaterial plating which warps light around it to produce an "Invisibility cloak" effect.
 
 # Cybersun Dreadnought suit
-uplink-hardsuit-cybersun-dreadnought-name = CSA-105UA "Xíngtiān" tacsuit
+uplink-hardsuit-cybersun-dreadnought-name = "Xíngtiān" tacsuit
 uplink-hardsuit-cybersun-dreadnought-desc = A prototype tacsuit that makes an almost impenetrable wall out of the wearer. Once fastened in place, it can't be removed without killing the wearer. Its use will slowly kill the wearer, making entombment inside a one-way trip to the grave. Are you sure you want to do this?
 
 # Weapons

--- a/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
@@ -69,15 +69,9 @@ ent-ClothingHeadHelmetHardsuitSyndieElite = CSA-54UA helmet
 ent-ClothingHeadHelmetHardsuitShiweiUnpainted = CSA-54UA helmet
     .desc = An elite version of the Shanlin tacsuit's helmet, featuring improved armor and fireproofing.
     It is unpainted bare spaceship alloy.
-ent-ClothingHeadHelmetHardsuitSyndieCommander = CSA-54c helmet
-    .desc = A bulked up version of the Shanlin tacsuit's helmet, purpose-built for commanders of special operation squads. This one has been painted blood-red.
-ent-ClothingHeadHelmetHardsuitCybersun = CSA-80UA helmet
-    .desc = An incredibly sturdy looking helmet designed for the Guan Yu tacsuit.
-ent-ClothingHeadHelmetHardsuitJuggernautReverseEngineered = CSA-80UA helmet
-    .desc = An incredibly sturdy looking helmet designed for the Guan Yu tacsuit. This one has been painted blue.
-ent-ClothingHeadHelmetHardsuitCybersunStealth = CSA-91x helmet
-    .desc = A moderately protective sealed helmet designed for the èguǐ tacsuit. It features "Cloaking" metamaterials.
-ent-ClothingHeadHelmetHardsuitWizard = WZD-84 helmet
+ent-ClothingHeadHelmetHardsuitCybersunStealth = "Xíngtiān" helmet
+    .desc = A prototype helmet for the prototype "Xíngtiān" tacsuit, the helmet is heavily plated, but thankfully removable.
+    Technical identifier: CSA-105UA
     .desc = A bizarre, gem-encrusted helmet from unknown origins. It provides some protection to its wearer without restricting their movements.
 ent-ClothingHeadHelmetHardsuitLing = organic space helmet
     .desc = A spaceworthy biomass of pressure and temperature resistant tissue.

--- a/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
@@ -99,6 +99,10 @@ ent-ClothingHeadHelmetHardsuitERTJanitor = "Elymas" helmet
     .desc = A pressure resistant and fireproof hood worn by special cleanup units.
 ent-ClothingHeadHelmetHardsuitDeathsquad = NT-662ua helmet
     .desc = A highly advanced, top of the line helmet used in special operations.
+    Technical identifier: NT-662s
+ent-ClothingHeadHelmetHardsuitBlueshield = "Aegis" helmet
+    .desc = An advanced combat helmet used in defence of VIPs. 
+    Technical identifier: NT-NT-661b
 ent-ClothingHeadHelmetHardsuitClown = clown vacsuit helmet
     .desc = A colorful clown vacsuit helmet. On closer inspection, it appears to be a normal helmet painted with crayons, and a clown mask glued on top.
 ent-ClothingHeadHelmetHardsuitMime = mime vacsuit helmet

--- a/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
@@ -93,7 +93,9 @@ ent-ClothingHeadHelmetHardsuitERTSecurity = NT-444s helmet
     .desc = A special tacsuit helmet worn by members of a engineering emergency response team.
 ent-ClothingHeadHelmetHardsuitERTJanitor = NT-444j helmet
     .desc = A special hardsuit helmet worn by members of a janitorial emergency response team.
-ent-ClothingHeadHelmetCBURN = NT-444-CBRN helmet
+ent-ClothingHeadHelmetHardsuitERTJanitor = "Elymas" helmet
+    .desc = A special hardsuit helmet worn by members of a epistemological emergency response team.
+    Technical identifier: NT-444o
     .desc = A pressure resistant and fireproof hood worn by special cleanup units.
 ent-ClothingHeadHelmetHardsuitDeathsquad = NT-662ua helmet
     .desc = A highly advanced, top of the line helmet used in special operations.

--- a/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
@@ -115,7 +115,7 @@ ent-ClothingHeadHelmetHardsuitJuggernautReverseEngineered = "Guan Yu" helmet
 ent-ClothingHeadHelmetHardsuitCybersunStealth = "Èguǐ" helmet
     .desc = A moderately protective sealed helmet designed for the "Èguǐ" tacsuit. It features "Cloaking" metamaterials.
     Technical identifier: CSA-91x
-ent-ClothingHeadHelmetHardsuitCybersunStealth = "Xíngtiān" helmet
+ent-ClothingHeadHelmetHardsuitDreadnought = "Xíngtiān" helmet
     .desc = A prototype helmet for the prototype "Xíngtiān" tacsuit, the helmet is heavily plated, but thankfully removable.
     Technical identifier: CSA-105UA
 ent-ClothingHeadHelmetHardsuitWizard = "Mana" helmet

--- a/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
@@ -147,7 +147,7 @@ ent-ClothingHeadHelmetHardsuitERTSecurity = "Gabriel" helmet
 ent-ClothingHeadHelmetHardsuitERTJanitor = "Sandalphon" helmet
     .desc = A special hardsuit helmet worn by members of a janitorial emergency response team.
     Technical identifier: NT-444j
-ent-ClothingHeadHelmetHardsuitERTJanitor = "Elymas" helmet
+ent-ClothingHeadHelmetHardsuitERTChaplain = "Elymas" helmet
     .desc = A special hardsuit helmet worn by members of a epistemological emergency response team.
     Technical identifier: NT-444o
 ent-ClothingHeadHelmetCBURN = "Jophiel" helmet

--- a/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
@@ -125,7 +125,7 @@ ent-ClothingHeadHelmetHardsuitLing = organic space helmet
     .desc = A spaceworthy biomass of pressure and temperature resistant tissue.
 ent-ClothingHeadHelmetHardsuitPirateEVA = "Grunt" helmet
     .desc = A pirate vacsuit helmet, very heavy but provides good protection.
-    Technical identifier: OPR-032
+    Technical identifier: OPR-32
 ent-ClothingHeadHelmetHardsuitPirateCap = "Dragon" helmet
     .desc = A special hardsuit helmet, made for the captain of a pirate ship.
     Technical identifier: OPR-32c

--- a/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
@@ -1,103 +1,159 @@
 ent-ClothingHeadHelmetHardsuitBasic = basic vacsuit helmet
     .desc = A common vacsuit helmet that provides little more than basic protection from vacuum.
-ent-ClothingHeadHelmetHardsuitAtmos = HpI-19t helmet
-    .desc = The Fotia's standard helmet, it features the same heat protection as the suit, along with some integrated protective gear for the wearer's head.
-ent-ClothingHeadHelmetHardsuitEngineering = HpI-19r helmet
-    .desc = The Lampsi's standard helmet, it features the same radiation protection as the suit, along with some integrated protective gear for the wearer's head.
-ent-ClothingHeadHelmetHardsuitEngineeringUnpainted = HpI-19r helmet
-    .desc = { ent-ClothingHeadHelmetHardsuitEngineering.desc }
-ent-ClothingHeadHelmetHardsuitSpatio = HpI-20s helmet
-    .desc = A lightweight helmet designed for the Kriti hardsuit, it allows for better mobility, along with some protection against radiation.
-ent-ClothingHeadHelmetHardsuitSalvage = HpI-20a helmet
-    .desc = A bulky helmet designed for the Lavrion hardsuit, it has reinforced plating to protect the wearer's head in wildlife encounters.
-ent-ClothingHeadHelmetHardsuitVoidParamed = ZhP-24m helmet
-    .desc = A lightweight helmet designed for use with the Sukunabikona hardsuit. Parts of the helmet are made of hard transparent plastics, allowing for better visibility.
+ent-ClothingHeadHelmetHardsuitAtmos = "Fotia" helmet
+    .desc = The "Fotia" hardsuit's standard helmet, it features the same heat protection as the suit, along with some integrated protective gear for the wearer's head.
+    Technical identifier: HpI-19t
+ent-ClothingHeadHelmetHardsuitEngineering = "Lampsi" helmet
+    .desc = The "Lampsi" hardsuit's standard helmet, it features the same radiation protection as the suit, along with some integrated protective gear for the wearer's head.
+    Technical identifier: HpI-19r
+ent-ClothingHeadHelmetHardsuitEngineeringUnpainted = "Lampsi" helmet
+    .desc = The "Lampsi" hardsuit's standard helmet, it features the same radiation protection as the suit, along with some integrated protective gear for the wearer's head. The plasteel plating is exposed.
+    Technical identifier: HpI-19r
+ent-ClothingHeadHelmetHardsuitSpatio = "Kriti" helmet
+    .desc = A lightweight helmet designed for the "Kriti" hardsuit, it allows for better mobility, along with some protection against radiation.
+    Technical identifier: HpI-20s
+ent-ClothingHeadHelmetHardsuitSalvage = "Lavrion" helmet
+    .desc = A bulky helmet designed for the "Lavrion" hardsuit, it has reinforced plating to protect the wearer's head in wildlife encounters.
+    Technical identifier: HpI-20a
+ent-ClothingHeadHelmetHardsuitVoidParamed = "Sunkunabikona" helmet
+    .desc = A lightweight helmet designed for use with the "Sukunabikona" hardsuit. Parts of the helmet are made of hard transparent plastics, allowing for better visibility.
+    Technical identifier: ZhP-24m
 ent-ClothingHeadHelmetHardsuitMaxim = mysterious helmet
     .desc = An old looking helmet, it seems rather sturdy and lightweight. It also has an ominous red and black color scheme.
-ent-ClothingHeadHelmetHardsuitSecurity = FPA-83s helmet
-    .desc = A bulky helmet deployed with the Baghatur tacsuit. Protects its wearer against ballistics and explosive ordinance, at the cost of some mobility.
-ent-ClothingHeadHelmetHardsuitBrigmedic = FPA-84m helmet
-    .desc = A bulky helmet deployed with the Tsagaan tacsuit. Protects its wearer against ballistics and explosive ordinance, at the cost of some mobility.
-ent-ClothingHeadHelmetHardsuitCombatStandard = FPA-85 helmet
-    .desc = A bulky helmet deployed with the Baghatur Mk.II tacsuit.
+    Technical identifier: unknown
+ent-ClothingHeadHelmetHardsuitSecurity = "Baghatur" helmet
+    .desc = A bulky helmet deployed with the "Baghatur" tacsuit. Protects its wearer against ballistics and explosive ordinance, at the cost of some mobility.
+    Technical identifier: FPA-83s
+ent-ClothingHeadHelmetHardsuitBrigmedic = "Tsagaan" helmet
+    .desc = A bulky helmet deployed with the "Tsagaan" tacsuit. Protects its wearer against ballistics and explosive ordinance, at the cost of some mobility.
+    Technical identifier: "FPA-84m"
+ent-ClothingHeadHelmetHardsuitCombatStandard = "Baghatur Mk.II" helmet
+    .desc = A bulky helmet deployed with the "Baghatur Mk.II" tacsuit.
     Protects its wearer against ballistics and explosive ordinance, at the cost of some mobility.
-ent-ClothingHeadHelmetHardsuitCombatOfficer = FPA-85s helmet
-    .desc = { ent-ClothingHeadHelmetHardsuitCombatStandard.desc }
-ent-ClothingHeadHelmetHardsuitCombatMedical = FPA-86 helmet
-    .desc = A bulky helmet deployed with the Tsagaan Mk.II tacsuit.
+    Technical identifier: FPA-85
+ent-ClothingHeadHelmetHardsuitCombatOfficer = "Baghatur Mk.II" helmet
+    .desc = A bulky helmet deployed with the "Baghatur Mk.II" tacsuit, painted with the colors of station security.
     Protects its wearer against ballistics and explosive ordinance, at the cost of some mobility.
-ent-ClothingHeadHelmetHardsuitCombatCorpsman = FPA-86m helmet
-    .desc = { ent-ClothingHeadHelmetHardsuitCombatMedical.desc }
-ent-ClothingHeadHelmetHardsuitWarden = FPA-92s helmet
-    .desc = A modified riot-control helmet for use with the Sulde tacsuit. Offers better overall protection than standard tacsuits at the expense of mobility.
-ent-ClothingHeadHelmetHardsuitCombatRiot = FPA-93 helmet
-    .desc = A modified riot-control helmet for use with the Sulde Mk.II tacsuit.
+    Technical identifier: FPA-85s
+ent-ClothingHeadHelmetHardsuitCombatMedical = "Tsagaan Mk.II" helmet
+    .desc = A bulky helmet deployed with the "Tsagaan Mk.II" tacsuit.
+    Protects its wearer against ballistics and explosive ordinance, at the cost of some mobility.
+    Technical identifier: FPA-86
+ent-ClothingHeadHelmetHardsuitCombatCorpsman = "Tsagaan Mk.II" helmet
+    .desc = A bulky helmet deployed with the "Tsagaan Mk.II" tacsuit, painted with the colors of station security.
+    Protects its wearer against ballistics and explosive ordinance, at the cost of some mobility.
+    Technical identifier: FPA-86m
+ent-ClothingHeadHelmetHardsuitWarden = "Sulde" helmet
+    .desc = A modified riot-control helmet for use with the "Sulde" tacsuit. Offers better overall protection than standard tacsuits at the expense of mobility.
+    Technical identifier: FPA-92s
+ent-ClothingHeadHelmetHardsuitCombatRiot = "Sulde Mk.II" helmet
+    .desc = A modified riot-control helmet for use with the "Sulde Mk.II" tacsuit.
     Offers better overall protection than other models at the expense of mobility.
-ent-ClothingHeadHelmetHardsuitCombatWarden = FPA-93s helmet
-    .desc = { ent-ClothingHeadHelmetHardsuitCombatRiot.desc }
-ent-ClothingHeadHelmetHardsuitCap = NT-42c helmet
-    .desc = A special helmet for the Tengri tacsuit, despite its lightweight appearance, it provides good all-around protection to its wearer.
-ent-ClothingHeadHelmetHardsuitEngineeringWhite = HpI-24c helmet
-    .desc = A high-grade helmet used with the Daedalus hardsuit, it has a lighter construction than its standard counterparts, along with more radiation protection.
-ent-ClothingHeadHelmetHardsuitMedical = ZhP-25m helmet
-    .desc = An extraordinarily lightweight helmet designed for use with the Okuninushi hardsuit.
+    Technical identifier: FPA-93
+ent-ClothingHeadHelmetHardsuitCombatWarden = "Sulde Mk.II" helmet
+    .desc = A modified riot-control helmet for use with the "Sulde Mk.II" tacsuit, painted with the colors of station security.
+    Offers better overall protection than other models at the expense of mobility.
+    Technical identifier: FPA-93s
+ent-ClothingHeadHelmetHardsuitCap = "Tengri" helmet
+    .desc = A special helmet for the "Tengri" tacsuit, despite its lightweight appearance, it provides good all-around protection to its wearer.
+    Technical identifier: NT-42c 
+ent-ClothingHeadHelmetHardsuitEngineeringWhite = "Daedalus" helmet
+    .desc = A high-grade helmet used with the "Daedalus" hardsuit, it has a lighter construction than its standard counterparts, along with more radiation protection.
+    Technical identifier: HpI-24c
+ent-ClothingHeadHelmetHardsuitMedical = "Okuninushi" helmet
+    .desc = An extraordinarily lightweight helmet designed for use with the "Okuninushi" hardsuit.
     It is primarily made from transparent hard-plastics, providing complete freedom of vision.
-ent-ClothingHeadHelmetHardsuitRd = NT-45e helmet
-    .desc = A heavily armored helmet worn over the Sophia hardsuit. It boasts the same near-immunity to explosions, heat and radiation as the suit, but heavily restricts the wearer's mobility.
-ent-ClothingHeadHelmetHardsuitMystagogue = NT-45e helmet
+    Technical identifier: ZhP-25m
+ent-ClothingHeadHelmetHardsuitRd = "Sophia" helmet
+    .desc = A heavily armored helmet worn over the "Sophia" hardsuit. It boasts the same near-immunity to explosions, heat and radiation as the suit, but heavily restricts the wearer's mobility.
+    Technical identifier: NT-45e
+ent-ClothingHeadHelmetHardsuitMystagogue = "Sophia" helmet
     .desc = { ent-ClothingHeadHelmetHardsuitRd.desc }
-ent-ClothingHeadHelmetHardsuitSecurityRed = FPA-98s helmet
-    .desc = A high quality helmet for the Dayicin tacsuit. It offers better overall protection than standard tacsuits without impacting mobility as much.
-ent-ClothingHeadHelmetHardsuitCombatAdvanced = FPA-99 helmet
-    .desc = A high quality helmet for the Dayicin Mk.II tacsuit.
+ent-ClothingHeadHelmetHardsuitSecurityRed = "Dayicin" helmet
+    .desc = A high quality helmet for the "Dayicin" tacsuit. It offers better overall protection than standard tacsuits without impacting mobility as much.
+    Technical identifier: FPA-98s
+ent-ClothingHeadHelmetHardsuitCombatAdvanced = "Dayicin Mk.II" helmet
+    .desc = A high quality helmet for the "Dayicin Mk.II" tacsuit.
     Features a lightweight construction, offering the same protection as a standard tacsuit without impacting mobility as much.
-ent-ClothingHeadHelmetHardsuitCombatHoS = FPA-99s helmet
-    .desc = { ent-ClothingHeadHelmetHardsuitCombatAdvanced.desc }
-ent-ClothingHeadHelmetHardsuitLuxury = HpI-20c helmet
-    .desc = A modified helmet for the Minos hardsuit, fashioned after the Logistics Officer's colors. It's been modified for greater mobility at the expense of physical trauma protection.
-ent-ClothingHeadHelmetHardsuitSyndie = CSA-51a helmet
-    .desc = An armored helmet deployed over a Shanlin tacsuit. This one has been painted blood red.
-ent-ClothingHeadHelmetHardsuitShanlinUnpainted = CSA-51a helmet
-    .desc = An armored helmet deployed over a Shanlin tacsuit. This one is unpainted bare metal.
-ent-ClothingHeadHelmetHardsuitSyndieReverseEngineered = CSA-51a helmet
-    .desc = An armored helmet deployed over a Shanlin tacsuit. This one has been painted blue.
-ent-ClothingHeadHelmetHardsuitSyndieMedic = CSA-51m helmet
-    .desc = An armored helmet deployed over a Zhongyao tacsuit. features optic integrations for nearly every medical hud on the market.
+    Technical identifier: FPA-99
+ent-ClothingHeadHelmetHardsuitCombatHoS = "Dayicin Mk.II" helmet
+    .desc = A high quality helmet for the "Dayicin Mk.II" tacsuit, painted with the colours of station security.
+    Features a lightweight construction, offering the same protection as a standard tacsuit without impacting mobility as much.
+    Technical identifier: FPA-99s
+ent-ClothingHeadHelmetHardsuitLuxury = "Minos" helmet
+    .desc = A modified helmet for the "Minos" hardsuit, fashioned after the Logistics Officer's colors. It's been modified for greater mobility at the expense of physical trauma protection.
+    Technical identifier: HpI-20c 
+ent-ClothingHeadHelmetHardsuitSyndie = "Shanlin" helmet
+    .desc = An armored helmet deployed over a "Shanlin" tacsuit. This one has been painted blood red.
+    Technical identifier: CSA-51a 
+ent-ClothingHeadHelmetHardsuitShanlinUnpainted = "Shanlin" helmet
+    .desc = An armored helmet deployed over a "Shanlin" tacsuit. This one is unpainted bare metal.
+    Technical identifier: CSA-51a
+ent-ClothingHeadHelmetHardsuitSyndieReverseEngineered = "Shanlin" helmet
+    .desc = An armored helmet deployed over a "Shanlin" tacsuit. This one has been painted blue.
+    Technical identifier: CSA-51a
+ent-ClothingHeadHelmetHardsuitSyndieMedic = "Zhongyao" helmet
+    .desc = An armored helmet deployed over a "Zhongyao" tacsuit. features optic integrations for nearly every medical hud on the market.
     Designed to enable the survival of combat medics in the most dangerous of environments.
-ent-ClothingHeadHelmetHardsuitSyndieElite = CSA-54UA helmet
-    .desc = An elite version of the Shanlin tacsuit's helmet, featuring improved armor and fireproofing.
-ent-ClothingHeadHelmetHardsuitShiweiUnpainted = CSA-54UA helmet
-    .desc = An elite version of the Shanlin tacsuit's helmet, featuring improved armor and fireproofing.
+    Technical identifier: CSA-51m
+ent-ClothingHeadHelmetHardsuitSyndieElite = "Shiwei" helmet
+    .desc =  An armored helmet deployed over the elite "Shiwei" tacsuit, featuring improved armor and fireproofing.
+    Technical identifier: CSA-54UA 
+ent-ClothingHeadHelmetHardsuitShiweiUnpainted = "Shiwei" helmet
+    .desc = An armored helmet deployed over the elite "Shiwei" tacsuit, featuring improved armor and fireproofing.
     It is unpainted bare spaceship alloy.
+    Technical identifier: CSA-54UA
+ent-ClothingHeadHelmetHardsuitSyndieCommander = "Tianming" helmet
+    .desc = An armoured helmet for the "Tianming" tacsuit, purpose-built for commanders of special operation squads. This one has been painted blood-red.
+    Technical identifier: CSA-54c
+ent-ClothingHeadHelmetHardsuitCybersun = "Guan Yu" helmet
+    .desc = An incredibly sturdy looking helmet designed for the "Guan Yu" tacsuit.
+    Technical identifier: CSA-80UA
+ent-ClothingHeadHelmetHardsuitJuggernautReverseEngineered = "Guan Yu" helmet
+    .desc = An incredibly sturdy looking helmet designed for the "Guan Yu" tacsuit. This one has been painted blue.
+    Technical identifier: CSA-80UA
+ent-ClothingHeadHelmetHardsuitCybersunStealth = "Èguǐ" helmet
+    .desc = A moderately protective sealed helmet designed for the "Èguǐ" tacsuit. It features "Cloaking" metamaterials.
+    Technical identifier: CSA-91x
 ent-ClothingHeadHelmetHardsuitCybersunStealth = "Xíngtiān" helmet
     .desc = A prototype helmet for the prototype "Xíngtiān" tacsuit, the helmet is heavily plated, but thankfully removable.
     Technical identifier: CSA-105UA
+ent-ClothingHeadHelmetHardsuitWizard = "Mana" helmet
     .desc = A bizarre, gem-encrusted helmet from unknown origins. It provides some protection to its wearer without restricting their movements.
+    Technical identifier: WZD-84
 ent-ClothingHeadHelmetHardsuitLing = organic space helmet
     .desc = A spaceworthy biomass of pressure and temperature resistant tissue.
-ent-ClothingHeadHelmetHardsuitPirateEVA = pirate helmet
+ent-ClothingHeadHelmetHardsuitPirateEVA = "Grunt" helmet
     .desc = A pirate vacsuit helmet, very heavy but provides good protection.
-    .suffix = Pirate
-ent-ClothingHeadHelmetHardsuitPirateCap = pirate captain's tacsuit helmet
+    Technical identifier: OPR-032
+ent-ClothingHeadHelmetHardsuitPirateCap = "Dragon" helmet
     .desc = A special hardsuit helmet, made for the captain of a pirate ship.
-    .suffix = Pirate
-ent-ClothingHeadHelmetHardsuitERTCentcomm = NT-444c helmet
+    Technical identifier: OPR-32c
+ent-ClothingHeadHelmetHardsuitERTCentcomm = "Ophanim" helmet
     .desc = A special tacsuit helmet worn by Central Command Officers.
-ent-ClothingHeadHelmetHardsuitERTLeader = NT-444l helmet
+    Technical identifier: NT-444c
+ent-ClothingHeadHelmetHardsuitERTLeader = "Michael" helmet
     .desc = A special tacsuit helmet worn by leaders of an emergency response team.
-ent-ClothingHeadHelmetHardsuitERTEngineer = NT-444e helmet
+    Technical identifier: NT-444l
+ent-ClothingHeadHelmetHardsuitERTEngineer = "Uriel" helmet
     .desc = A special hardsuit helmet worn by members of an engineering emergency response team.
-ent-ClothingHeadHelmetHardsuitERTMedical = NT-444m helmet
+    Technical identifier: NT-444e
+ent-ClothingHeadHelmetHardsuitERTMedical = "Raphael" helmet
     .desc = A special hardsuit helmet worn by members of a medical emergency response team.
-ent-ClothingHeadHelmetHardsuitERTSecurity = NT-444s helmet
+    Technical identifier: NT-444m
+ent-ClothingHeadHelmetHardsuitERTSecurity = "Gabriel" helmet
     .desc = A special tacsuit helmet worn by members of a engineering emergency response team.
-ent-ClothingHeadHelmetHardsuitERTJanitor = NT-444j helmet
+    Technical identifier: NT-444s
+ent-ClothingHeadHelmetHardsuitERTJanitor = "Sandalphon" helmet
     .desc = A special hardsuit helmet worn by members of a janitorial emergency response team.
+    Technical identifier: NT-444j
 ent-ClothingHeadHelmetHardsuitERTJanitor = "Elymas" helmet
     .desc = A special hardsuit helmet worn by members of a epistemological emergency response team.
     Technical identifier: NT-444o
+ent-ClothingHeadHelmetCBURN = "Jophiel" helmet
     .desc = A pressure resistant and fireproof hood worn by special cleanup units.
-ent-ClothingHeadHelmetHardsuitDeathsquad = NT-662ua helmet
+    Technical identifier: NT-444-CBRN
+ent-ClothingHeadHelmetHardsuitDeathsquad = "Samael" helmet
     .desc = A highly advanced, top of the line helmet used in special operations.
     Technical identifier: NT-662s
 ent-ClothingHeadHelmetHardsuitBlueshield = "Aegis" helmet
@@ -107,5 +163,6 @@ ent-ClothingHeadHelmetHardsuitClown = clown vacsuit helmet
     .desc = A colorful clown vacsuit helmet. On closer inspection, it appears to be a normal helmet painted with crayons, and a clown mask glued on top.
 ent-ClothingHeadHelmetHardsuitMime = mime vacsuit helmet
     .desc = A mime vacsuit helmet. On closer inspection, it appears to be a normal helmet painted with crayons, and a mime mask glued on top.
-ent-ClothingHeadHelmetHardsuitSanta = DNK-31 helmet
+ent-ClothingHeadHelmetHardsuitSanta = "Jolly" helmet
     .desc = A festive-looking hardsuit helmet that provides the jolly gift-giver protection from low-pressure environments.
+    Technical identifier: DNK-31

--- a/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/head/hardsuit-helmets.ftl
@@ -91,7 +91,7 @@ ent-ClothingHeadHelmetHardsuitShanlinUnpainted = "Shanlin" helmet
     Technical identifier: CSA-51a
 ent-ClothingHeadHelmetHardsuitSyndieReverseEngineered = "Shanlin" helmet
     .desc = An armored helmet deployed over a "Shanlin" tacsuit. This one has been painted blue.
-    Technical identifier: CSA-51a
+    Technical identifier: CSA-51a-NT
 ent-ClothingHeadHelmetHardsuitSyndieMedic = "Zhongyao" helmet
     .desc = An armored helmet deployed over a "Zhongyao" tacsuit. features optic integrations for nearly every medical hud on the market.
     Designed to enable the survival of combat medics in the most dangerous of environments.
@@ -111,7 +111,7 @@ ent-ClothingHeadHelmetHardsuitCybersun = "Guan Yu" helmet
     Technical identifier: CSA-80UA
 ent-ClothingHeadHelmetHardsuitJuggernautReverseEngineered = "Guan Yu" helmet
     .desc = An incredibly sturdy looking helmet designed for the "Guan Yu" tacsuit. This one has been painted blue.
-    Technical identifier: CSA-80UA
+    Technical identifier: CSA-80UA-NT
 ent-ClothingHeadHelmetHardsuitCybersunStealth = "Èguǐ" helmet
     .desc = A moderately protective sealed helmet designed for the "Èguǐ" tacsuit. It features "Cloaking" metamaterials.
     Technical identifier: CSA-91x

--- a/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
@@ -39,7 +39,7 @@ ent-ClothingOuterHardsuitBrigmedic = "Tsagaan" tacsuit
 ent-ClothingOuterHardsuitCombatStandard = "Baghatur Mk.II" tacsuit
     .desc = A sturdy tactical combat hardsuit mass-produced by Five-Points-Armory.
     The tags on the suit indicate that its rated for moderate amounts of physical and explosion damage. It feels heavy.
-    Technical identifier: FPA-085
+    Technical identifier: FPA-85
 ent-ClothingOuterHardsuitCombatOfficer = "Baghatur Mk.II" tacsuit
     .desc = A sturdy tactical combat hardsuit mass-produced by Five-Points-Armory, painted with the colors of station security.
     The tags on the suit indicate that its rated for moderate amounts of physical and explosion damage. It feels heavy.
@@ -47,7 +47,7 @@ ent-ClothingOuterHardsuitCombatOfficer = "Baghatur Mk.II" tacsuit
 ent-ClothingOuterHardsuitCombatMedical = "Tsagaan Mk.II" tacsuit
     .desc = A sturdy tactical combat hardsuit mass-produced by Five-Points-Armory.
     The tags on the suit indicate that its rated for moderate amounts of physical and explosion damage. It feels heavy.
-    Technical identifier: FPA-086
+    Technical identifier: FPA-86
 ent-ClothingOuterHardsuitCombatCorpsman = "Tsagaan Mk.II" tacsuit
     .desc = A sturdy tactical combat hardsuit mass-produced by Five-Points-Armory, painted with the colors of station security & medical staff.
     The tags on the suit indicate that its rated for moderate amounts of physical and explosion damage. It feels heavy.
@@ -59,7 +59,7 @@ ent-ClothingOuterHardsuitWarden = "Sulde" tacsuit
 ent-ClothingOuterHardsuitCombatRiot = "Sulde Mk.II" tacsuit
     .desc = A specialized tactical combat hardsuit produced by Five-Points-Armory.
     The tags on the suit indicate that its rated for moderate amounts of physical and explosion damage. It feels VERY heavy.
-    Technical identifier: FPA-093
+    Technical identifier: FPA-93
 ent-ClothingOuterHardsuitCombatWarden = "Sulde Mk.II" tacsuit
     .desc = A specialized tactical combat hardsuit produced by Five-Points-Armory, painted with the colors of station security.
     The tags on the suit indicate that its rated for moderate amounts of physical and explosion damage. It feels VERY heavy.
@@ -147,13 +147,13 @@ ent-ClothingOuterHardsuitDreadnought = "Xíngtiān" tacsuit
 ent-ClothingOuterHardsuitWizard = "Mana" tacsuit
     .desc = A bizarre gem-encrusted hardsuit. Famously used by members of the Wizard Federation in their operations.
     Contrary to it's appearance, it can protect its wearer from space and considerable amounts of physical trauma, it feels somewhat light.
-    Technical identifier: WZD-084
+    Technical identifier: WZD-84
 ent-ClothingOuterHardsuitLing = organic vacsuit
     .desc = A suit made of biomass tissue that is somehow capable of resisting the hazards of low pressure and temperature in space.
 ent-ClothingOuterHardsuitPirateEVA = "Grunt" vacsuit
     .desc = A worn-out heavy space suit of unknown origin that provides some basic protection from the cold harsh realities of deep space.
     The technical identifier is nonetheless engraved crudely on the shoulder.
-    Technical identifier: OPR-032
+    Technical identifier: OPR-32
 ent-ClothingOuterHardsuitPirateCap = "Dragon" tacsuit
     .desc = An ancient armored tactical combat hardsuit of unknown origin, provides basic protections from the cold harsh realities of deep space and physical trauma.
     It doesn't seem to have any weight either. Perfect for defending against space scurvy and toolbox-wielding scallywags.

--- a/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
@@ -76,11 +76,11 @@ ent-ClothingOuterHardsuitMedical = "Okuninushi" hardsuit
     .desc = A hardsuit produced by Zeng-hu Pharmaceuticals, often purchased for use by Nanotrasen senior medical doctors.
     The labels claim it protects against damage from most chemical spills. It feels incredibly light.
     Technical identifier: ZhP-25m
-ent-ClothingOuterHardsuitRd = "Sophia" research hardsuit
+ent-ClothingOuterHardsuitRd = "Sophia" hardsuit
     .desc = The magnum opus of Nanotrasen's R&D division. The labels on this hardsuit claim that its near-immune to explosions, heat and radiation.
     Somehow it also can shrink enough to fit in a bag. It feels VERY heavy.
     Technical identifier: NT-45e
-ent-ClothingOuterHardsuitMystagogue = "Sophia" research hardsuit
+ent-ClothingOuterHardsuitMystagogue = "Sophia" hardsuit
     .desc = { ent-ClothingOuterHardsuitRd.desc }
 ent-ClothingOuterHardsuitSecurityRed = "Dayicin" tacsuit
     .desc = A top-of-the-line tactical combat hardsuit  produced by Five-Points-Armory, often purchased for use by Nanotrasen senior security officers.
@@ -89,7 +89,7 @@ ent-ClothingOuterHardsuitSecurityRed = "Dayicin" tacsuit
 ent-ClothingOuterHardsuitCombatAdvanced = "Dayicin Mk.II" tacsuit
     .desc = A top-of-the-line tactical combat hardsuit produced by Five-Points-Armory.
     The tags on the suit indicate that its rated for moderate amounts of physical and explosion damage. It feels somewhat light.
-    Technical identifier: FPA-099
+    Technical identifier: FPA-99
 ent-ClothingOuterHardsuitCombatHoS = "Dayicin Mk.II" tacsuit
     .desc = A top-of-the-line tactical combat hardsuit produced by Five-Points-Armory, painted with the colors of station security.
     The tags on the suit indicate that its rated for moderate amounts of physical and explosion damage. It feels somewhat light.
@@ -205,3 +205,4 @@ ent-ClothingOuterHardsuitMime = mime vacsuit
     .desc = A custom-made mime vacsuit. On closer inspection, it appears to be a normal vacsuit with suspenders and paint applied on top.
 ent-ClothingOuterHardsuitSanta = "Jolly" hardsuit
     .desc = A festive hardsuit produced by Donk Co. for their time-limited celebratory events, provides protection for its jolly gift-giver to sleighride safely in space without worrying about asteroid strikes.
+    Technical identifier: DNK-31

--- a/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
@@ -9,7 +9,9 @@ ent-ClothingOuterHardsuitEngineering = "Lampsi" hardsuit
     The label indicates that its rated for moderate amounts of radiation exposure. It feels a bit heavy.
     Technical identifier: HpI-19r
 ent-ClothingOuterHardsuitEngineeringUnpainted = "Lampsi" hardsuit
-    .desc = { ent-ClothingOuterHardsuitEngineering.desc }
+    .desc = A standard-issue hardsuit produced by Hephaestus Industries, used by engineers in low & high pressure environments.
+    The label indicates that its rated for moderate amounts of radiation exposure. It feels a bit heavy. The plasteel plating is exposed.
+    Technical identifier: HpI-19r
 ent-ClothingOuterHardsuitSpatio = "Kriti" hardsuit
     .desc = A standard-issue hardsuit produced by Hephaestus Industries, designed for industrial work in low pressure environments.
     The label indicates that its rated for moderate amounts of radiation exposure, and it feels somewhat light.

--- a/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
@@ -195,6 +195,10 @@ ent-ClothingOuterHardsuitCBURN = "Jophiel" tacsuit
     .desc = A tactical combat hardsuit used by the CBURN subdivision of the Emergency Response Team, it seems to be branded with the Nanotrasen logo and a strange looking series number.
     The armor appears to be lined with a rather plain, but sturdy alloy, it doesn't seem to have any weight either.
     Technical identifier: NT-444c
+ent-ClothingOuterHardsuitBlueshield = "Aegis" tacsuit
+    .desc = An advanced combat tacsuit employed by station Blue Shield officers, it appears to be branded with the Nanotrasen logo.
+    You can make out the letters "NTIA-DAP" written on it. The armour appears to be lined with a rather plain, but study alloy, effective for taking multiple gunshots.
+    Technical identifier: NT-661b
 ent-ClothingOuterHardsuitClown = clown vacsuit
     .desc = A custom-made clown vacsuit. On closer inspection, it appears to be a normal vacsuit with paint applied on top.
 ent-ClothingOuterHardsuitMime = mime vacsuit

--- a/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
@@ -138,6 +138,10 @@ ent-ClothingOuterHardsuitCybersunStealth = "Èguǐ" tacsuit
     .desc = A rare prototype tacsuit that features metamaterial plating which warps light around it to produce an "Invisibility cloak" effect.
     Unfortunately, it accomplishes this by trading a lot of protections that one would normally expect from a typical tacsuit.
     Technical identifier: CSA-91x
+ent-ClothingOuterHardsuitDreadnought = "Xíngtiān" tacsuit
+    .desc = A prototype tacsuit that makes an almost impenetrable wall out of the wearer. Once fastened in place, it can't be removed without killing the wearer.
+    Its use will slowly kill the wearer, making entombment inside a one-way trip to the grave. Are you sure you want to do this?
+    Technical identifier: CSA-105UA
 ent-ClothingOuterHardsuitWizard = "Mana" tacsuit
     .desc = A bizarre gem-encrusted hardsuit. Famously used by members of the Wizard Federation in their operations.
     Contrary to it's appearance, it can protect its wearer from space and considerable amounts of physical trauma, it feels somewhat light.

--- a/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
@@ -132,7 +132,7 @@ ent-ClothingOuterHardsuitJuggernaut = "Guan Yu" tacsuit
     Technical identifier: CSA-80UA
 ent-ClothingOuterHardsuitJuggernautReverseEngineered = "Guan Yu" tacsuit
     .desc = The pride and joy of the Cybersun-Armaments Corporation, named after an ancient Sol' War God. Commonly known throughout the galaxy as a "Juggernaut".
-    Matching its bulky appearance, it protects against all forms of damage. It feels VERY heavy.
+    Matching its bulky appearance, it protects against all forms of damage. It feels VERY heavy. This one has been painted blue.
     Technical identifier: CSA-80UA
 ent-ClothingOuterHardsuitCybersunStealth = "Èguǐ" tacsuit
     .desc = A rare prototype tacsuit that features metamaterial plating which warps light around it to produce an "Invisibility cloak" effect.

--- a/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
@@ -109,7 +109,7 @@ ent-ClothingOuterHardsuitShanlinUnpainted = "Shanlin" tacsuit
 ent-ClothingOuterHardsuitSyndieReverseEngineered = "Shanlin" tacsuit
     .desc = A tactical combat hardsuit produced by the Cybersun-Armaments Corporation, the suit's tags indicate it provides moderate protection against most forms of damage.
     This one has been painted blue. It feels incredibly light.
-    Technical identifier: CSA-51a
+    Technical identifier: CSA-51a-NT
 ent-ClothingOuterHardsuitSyndieMedic = "Zhongyao" tacsuit
     .desc = A tactical combat hardsuit produced by the Cybersun-Armaments Corporation, the suit's tags indicate it provides moderate protection against most forms of damage.
     Half of the suit is painted blood red, the rest bears galactic-standard medical markings. It feels incredibly light.
@@ -135,7 +135,7 @@ ent-ClothingOuterHardsuitJuggernaut = "Guan Yu" tacsuit
 ent-ClothingOuterHardsuitJuggernautReverseEngineered = "Guan Yu" tacsuit
     .desc = The pride and joy of the Cybersun-Armaments Corporation, named after an ancient Sol' War God. Commonly known throughout the galaxy as a "Juggernaut".
     Matching its bulky appearance, it protects against all forms of damage. It feels VERY heavy. This one has been painted blue.
-    Technical identifier: CSA-80UA
+    Technical identifier: CSA-80UA-NT
 ent-ClothingOuterHardsuitCybersunStealth = "Èguǐ" tacsuit
     .desc = A rare prototype tacsuit that features metamaterial plating which warps light around it to produce an "Invisibility cloak" effect.
     Unfortunately, it accomplishes this by trading a lot of protections that one would normally expect from a typical tacsuit.

--- a/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
+++ b/Resources/Locale/en-US/prototypes/entities/clothing/outerClothing/hardsuits.ftl
@@ -183,6 +183,10 @@ ent-ClothingOuterHardsuitERTJanitor = "Sandalphon" hardsuit
     .desc = A highly advanced hardsuit used by Janitors of the Emergency Response Team, it seems to be branded with the Nanotrasen logo and a strange looking series number.
     The armor appears to be lined with a very sturdy alloy, it doesn't seem to have any weight either.
     Technical identifier: NT-444j
+ent-ClothingOuterHardsuitERTChaplain = "Elymas" hardsuit
+    .desc = A highly advanced hardsuit used by Chaplains of the Emergency Response Team, it seems to be branded with the Nanotrasen logo and a strange looking series number.
+    The armor appears to be lined with a very sturdy alloy, it doesn't seem to have any weight either.
+    Technical identifier: NT-444o
 ent-ClothingOuterHardsuitDeathsquad = "Samael" tacsuit
     .desc = A highly advanced, top of the line tactical combat hardsuit, it seems to be branded with the Nanotrasen logo and a strange looking series number.
     You can barely make out the letters "NTIA-DAP" written on it. The armor appears to be lined with a very sturdy alloy, and doesn't seem to have any weight either.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -375,19 +375,19 @@ uplink-eva-syndie-desc = A simple EVA suit that offers no protection other than 
 uplink-hardsuit-carp-name = Carp Hardsuit
 uplink-hardsuit-carp-desc = Looks like an ordinary carp suit, except fully spaceproof and tricks space carp into thinking you are one of them.
 
-uplink-hardsuit-syndie-name = Blood-red Tacsuit
-uplink-hardsuit-syndie-desc = The calling card of pirates, outlaws, mercenaries, and deserters. The "Blood Red" Shanlin Tacsuit is an iconic piece of equipment employed by the Syndicate.
+uplink-hardsuit-syndie-name = "Shanlin" Tacsuit
+uplink-hardsuit-syndie-desc = The calling card of pirates, outlaws, mercenaries, and deserters. The "Shanlin" Tacsuit is an iconic piece of equipment employed by the Syndicate.
 
-uplink-hardsuit-syndie-medic-name = Blood-red Medic Tacsuit
-uplink-hardsuit-syndie-medic-desc = A variant of the "Blood-red" tacsuit that includes medical markings.
+uplink-hardsuit-syndie-medic-name = "Zhongyao" Tacsuit
+uplink-hardsuit-syndie-medic-desc = A variant of the "Shanlin" tacsuit that includes medical markings.
 
-uplink-hardsuit-syndie-commander-name = Blood-red "Commander" Tacsuit
-uplink-hardsuit-syndie-commander-desc = An up-armored variant of the iconic "Blood-red" tacsuit.
+uplink-hardsuit-syndie-commander-name = "Tianming" Tacsuit
+uplink-hardsuit-syndie-commander-desc = An up-armored variant of the iconic "Blood-red" tacsuit for commanders.
 
-uplink-hardsuit-syndieelite-name = Syndicate Elite Hardsuit
-uplink-hardsuit-syndieelite-desc = An elite version of the blood-red hardsuit, with improved mobility and fireproofing. Property of Gorlex Marauders.
+uplink-hardsuit-syndieelite-name = "Shiwei" Tacsuit
+uplink-hardsuit-syndieelite-desc = An elite version of the "Shanlin" hardsuit, with improved mobility and fireproofing. Property of Gorlex Marauders.
 
-uplink-clothing-outer-hardsuit-juggernaut-name = Cybersun Juggernaut Suit
+uplink-clothing-outer-hardsuit-juggernaut-name = "Guan Yu" Suit
 uplink-clothing-outer-hardsuit-juggernaut-desc = Hyper resilient armor made of materials tested in the Tau chromosphere facility. The only thing that's going to be slowing you down is this suit... and tasers.
 
 uplink-night-vision-name = Night vision goggles


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Helmets modified to match and be more clear in their descriptions
BSO renamed to Aegis
Chaplain renamed to Elymas

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Hardsuit helmet names now fit their hardsuits
- tweak: BSO tacsuit renamed to "Aegis" tacsuit
- tweak: Chaplain ERT Hardsuit renamed to "Elymas" hardsuit
- tweak: "Xíngtiān" tacsuit fits the formatting of other hardsuits now