### PR TITLE
Hardsuit Tweaks

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1755,9 +1755,9 @@
   productEntity: ClothingBackpackDuffelSyndicateHardsuitCommanderBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 25
+    Telecrystal: 30
   cost:
-    Telecrystal: 55
+    Telecrystal: 60
   categories:
   - UplinkWearables
 
@@ -1802,9 +1802,9 @@
   productEntity: CrateCybersunJuggernautBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 40
-  cost:
     Telecrystal: 60
+  cost:
+    Telecrystal: 85
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -223,8 +223,8 @@
   - type: StealTarget
     stealGroup: ClothingOuterHardsuitVoidParamed
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+    walkModifier: 0.95
+    sprintModifier: 0.95
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitVoidParamed
@@ -723,8 +723,8 @@
   - type: Item
     size: Huge
   - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite
@@ -757,8 +757,8 @@
         Radiation: 0.25
         Caustic: 0.4
   - type: ClothingSpeedModifier
-    walkModifier: 1.0
-    sprintModifier: 1.0
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieCommander
@@ -790,10 +790,10 @@
         Slash: 0.2
         Piercing: 0.2
         Heat: 0.2
-        Radiation: 0.2
+        Radiation: 0.3
         Caustic: 0.2
   - type: ClothingSpeedModifier
-    walkModifier: 0.9
+    walkModifier: 0.65
     sprintModifier: 0.65
   - type: HeldSpeedModifier
   - type: ToggleableClothing

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -24,8 +24,8 @@
         Caustic: 0.75
         Heat: 0.75
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatStandard
   - type: AllowSuitStorage
@@ -114,8 +114,8 @@
         Caustic: 0.70
         Heat: 0.40
   - type: ClothingSpeedModifier
-    walkModifier: 0.60
-    sprintModifier: 0.60
+    walkModifier: 0.7
+    sprintModifier: 0.7
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatRiot
   - type: AllowSuitStorage

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -70,8 +70,8 @@
         Radiation: 0.85
         Caustic: 0.85
   - type: ClothingSpeedModifier
-    walkModifier: 0.8
-    sprintModifier: 0.85
+    walkModifier: 0.95
+    sprintModifier: 0.95
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersunStealth
@@ -128,8 +128,8 @@
         Radiation: 0.25 # do people even know rad ammo exists? anyway making rad its weakness is kinda fair
         Caustic: 0.4
   - type: ClothingSpeedModifier
-    walkModifier: 0.7
-    sprintModifier: 0.5
+    walkModifier: 0.6
+    sprintModifier: 0.6
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototypes:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Tweaked movement speed values of Security tacsuits + Paramed hardsuit and adjusted some of the Antag hardsuits

**Station:**
--Buffs--
_Baghatur MK.II (Standard)_  -  movement speed penalty 25% > 20%
_Sulde MK.II (Riot)_                -  movement speed penalty 40% > 30%

_Sukunabikona (Paramed hardsuit)_  -  movement speed penalty 10% > 5%

**Syndicate:**
--Nerfs--
_Tianming (Commander)_  -  movement speed penalty 0% > 15%
                                           - cost 55TC > 60TC
_Guan Yu (Juggernaut)_     -  walking speed penalty 10% | running speed penalty 35% > movement speed penalty 35%
                                           -  cost 60TC > 85TC
                                           -  Radiation resistance 80% > 70%
_Shiwei (Elite)_                   -  movement speed penalty 0% > 10%
--Buffs--
_Egui (Stealth)_                  -  movement speed penalty 10% > 5%
_Xingtian (Dreadnaught)_  -  walking speed penalty 30% | running speed penalty 50% > movement speed penalty 40%

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->
Please read above in the **Description** for better details
:cl:
- tweak: Baghatur MK.II movement speed penalty decreased
- tweak: Sulde MK.II movement speed penalty decreased
- tweak: Sukunabikuna movement speed penalty decreased
- tweak: Tianming movement speed penalty increased and cost increased
- tweak: Guan Yu movement speed adjusted, cost increased and radiation armor value decreased
- tweak: Shiwei movement speed penalty increased
- tweak: Egui movement speed penalty decreased
- tweak: Xingtian movement speed penalty adjusted and decreased
