### PR TITLE
Small Drozd, C20r and FPA-90 Tweaks

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -296,7 +296,7 @@ uplink-super-surplus-bundle-name = Super Surplus Crate
 uplink-super-surplus-bundle-desc = Contains 125 telecrystals worth of completely random Syndicate items.
 
 uplink-fpa-90-bundle-name = FPA-90 Bundle
-uplink-fpa-90-bundle-desc = A cheap integrally suppressed SMG. Ammo comes separately.
+uplink-fpa-90-bundle-desc = A cheap integrally suppressed SMG. Comes loaded.
 
 # Tools
 uplink-toolbox-name = Toolbox

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -492,4 +492,4 @@
   components:
   - type: StorageFill
     contents:
-      - id: WeaponSubMachineGunFPA90Empty
+      - id: WeaponSubMachineGunFPA90

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -123,7 +123,7 @@
   - type: Wieldable
   - type: GunWieldBonus
     minAngle: -19
-    maxAngle: -16
+    maxAngle: -19
   - type: Gun
     minAngle: 21
     maxAngle: 32
@@ -202,7 +202,7 @@
     - type: Gun
       minAngle: 21
       maxAngle: 32
-      fireRate: 12
+      fireRate: 10
       burstFireRate: 12
       selectedMode: FullAuto
       soundGunshot:


### PR DESCRIPTION


<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Lowers the Drozd's rate of fire to match the C20r as it is frankly ridiculous, very slightly ups the C20r's accuracy to make it the superior choice of the two and makes the FPA-90 spawn loaded with one mag

Drozd  -  720RPM > 600RPM
C20r  -  maximum spread angle while wielded 16 > 13
FPA-90 uplink bundle  -  +1 mag loaded


---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- Done

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Drozd's fire rate
- tweak: C20r's accuracy (slightly)
- tweak: FPA-90 has a mag when bought now
