### PR TITLE
Small Shoukou Update

### DIFF
--- a/Resources/Maps/TheDen/shoukou.yml
+++ b/Resources/Maps/TheDen/shoukou.yml
@@ -175,15 +175,15 @@ entities:
           version: 6
         -4,-1:
           ind: -4,-1
-          tiles: fgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAewAAAAAAewAAAAABewAAAAACewAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAUAAAAAAAUAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAewAAAAAAewAAAAADewAAAAABewAAAAACewAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAUAAAAAAAewAAAAABewAAAAADewAAAAAAewAAAAACfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAYwAAAAAAYwAAAAAAXgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAADewAAAAACewAAAAACewAAAAABfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAYwAAAAAAXgAAAAAAXgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAYwAAAAAAEgAAAAAAEgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAbgAAAAAAbgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAXgAAAAAAEgAAAAAAEgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAbgAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAUAAAAAAAbgAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAbgAAAAAAbgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAA
+          tiles: fgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAfwAAAAAAbgAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAewAAAAAAewAAAAABewAAAAACewAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAUAAAAAAAUAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAewAAAAAAewAAAAADewAAAAABewAAAAACewAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAewAAAAABewAAAAADewAAAAAAewAAAAACfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAYwAAAAAAYwAAAAAAXgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAADewAAAAACewAAAAACewAAAAABfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAYwAAAAAAXgAAAAAAXgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAYwAAAAAAEgAAAAAAEgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAACQAAAAAACQAAAAAAfwAAAAAAbgAAAAAAbgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAXgAAAAAAEgAAAAAAEgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAACQAAAAAACQAAAAAAfwAAAAAAbgAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAewAAAAAAewAAAAAAfwAAAAAAbgAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAUAAAAAAAewAAAAAAewAAAAAAfwAAAAAAbgAAAAAAbgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAewAAAAAAewAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAUAAAAAAACQAAAAAACQAAAAAACQAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfgAAAAAAAAAAAAAAfwAAAAAACQAAAAAACQAAAAAACQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAA
           version: 6
         -4,0:
           ind: -4,0
-          tiles: fgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAewAAAAACewAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAewAAAAAAewAAAAAAewAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAUAAAAAAAewAAAAACOgAAAAAAOgAAAAABOgAAAAAAOgAAAAABOgAAAAACewAAAAADfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAewAAAAAAOgAAAAACOgAAAAADOgAAAAADOgAAAAACOgAAAAACewAAAAABewAAAAADewAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAewAAAAAAOgAAAAAAOgAAAAADOgAAAAACOgAAAAABOgAAAAADfwAAAAAAewAAAAABewAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAACewAAAAABewAAAAACewAAAAADewAAAAACfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAABLAAAAAAALAAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAewAAAAADLAAAAAAALAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAADLAAAAAAALAAAAAAAewAAAAACewAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAewAAAAADewAAAAAAewAAAAADewAAAAABfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAA
+          tiles: fgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAewAAAAACewAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAewAAAAAAewAAAAAAewAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAAAewAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAUAAAAAAAewAAAAACOgAAAAAAOgAAAAABOgAAAAAAOgAAAAABOgAAAAACewAAAAADfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAewAAAAAAOgAAAAACOgAAAAADOgAAAAADOgAAAAACOgAAAAACewAAAAABewAAAAADewAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAewAAAAAAOgAAAAAAOgAAAAADOgAAAAACOgAAAAABOgAAAAADfwAAAAAAewAAAAABewAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAewAAAAAAewAAAAACewAAAAABewAAAAACewAAAAADewAAAAACfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAABLAAAAAAALAAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAewAAAAADLAAAAAAALAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAewAAAAADLAAAAAAALAAAAAAAewAAAAACewAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAewAAAAADewAAAAAAewAAAAADewAAAAABfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAA
           version: 6
         -4,-2:
           ind: -4,-2
-          tiles: fgAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAATgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAATgAAAAACfgAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAATgAAAAADfgAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAIAAAAAADfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAKQAAAAADfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAIAAAAAADfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAIAAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAABfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAACfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAUAAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAC
+          tiles: fgAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAATgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAATgAAAAACfgAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAATgAAAAADfgAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAIAAAAAADfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAKQAAAAADfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAIAAAAAADfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAIAAAAAACfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAABfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAACfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAC
           version: 6
         1,-3:
           ind: 1,-3
@@ -303,7 +303,7 @@ entities:
           version: 6
         -5,-1:
           ind: -5,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAA
           version: 6
         4,-3:
           ind: 4,-3
@@ -2759,6 +2759,8 @@ entities:
             1082: 53,-32
             1083: 49,-33
             1208: 18,-28
+            1319: -61,-3
+            1320: -60,-3
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineS
@@ -2794,6 +2796,8 @@ entities:
             1076: 52,-37
             1077: 51,-37
             1205: 18,-31
+            1317: -60,-5
+            1318: -61,-5
         - node:
             color: '#FFFFFFFF'
             id: WoodTrimThinLineW
@@ -3691,43 +3695,47 @@ entities:
           -14,-8:
             0: 65535
           -16,-4:
-            2: 6623
+            2: 29015
           -16,-5:
             2: 53566
             0: 2048
           -17,-4:
             2: 12
           -16,-3:
-            2: 21777
+            2: 22289
           -16,-2:
-            2: 47861
+            2: 13173
+            0: 34944
+          -17,-2:
+            2: 34816
           -16,-1:
-            2: 22013
+            2: 4401
+            0: 34952
+          -17,-1:
+            2: 34952
           -16,0:
-            2: 111
+            2: 99
             0: 49152
           -15,-4:
-            2: 1879
+            0: 2032
           -15,-3:
             0: 65535
           -15,-2:
-            2: 256
-            0: 52416
+            0: 56784
           -15,-1:
-            2: 8720
-            0: 34828
+            0: 64285
           -15,-5:
             2: 12807
             0: 112
-          -15,0:
-            2: 35
-            0: 37000
           -14,-4:
             0: 28531
           -14,-2:
             0: 30310
           -14,-1:
             0: 63334
+          -15,0:
+            0: 37000
+            2: 32
           -14,-5:
             0: 48051
           -14,-3:
@@ -6466,7 +6474,7 @@ entities:
       pos: 24.5,16.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -16850.707
+      secondsUntilStateChange: -21105.62
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -6886,7 +6894,7 @@ entities:
       pos: 15.5,8.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -30509.324
+      secondsUntilStateChange: -34764.24
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -6906,6 +6914,11 @@ entities:
     - type: Transform
       pos: 33.5,11.5
       parent: 2
+  - uid: 11437
+    components:
+    - type: Transform
+      pos: -57.5,-0.5
+      parent: 2
   - uid: 15738
     components:
     - type: Transform
@@ -6915,6 +6928,12 @@ entities:
     components:
     - type: Transform
       pos: 8.5,12.5
+      parent: 2
+  - uid: 16372
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -56.5,-14.5
       parent: 2
 - proto: AirlockMaintMedLocked
   entities:
@@ -7358,7 +7377,7 @@ entities:
       pos: 18.5,-7.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -257223.5
+      secondsUntilStateChange: -261478.4
       state: Opening
     - type: DeviceLinkSink
       links:
@@ -8810,6 +8829,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -6.5,9.5
       parent: 2
+  - uid: 16417
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -58.5,-0.5
+      parent: 2
 - proto: BarricadeBlock
   entities:
   - uid: 491
@@ -8821,6 +8846,17 @@ entities:
     components:
     - type: Transform
       pos: 32.5,14.5
+      parent: 2
+  - uid: 16418
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -57.5,-0.5
+      parent: 2
+  - uid: 16453
+    components:
+    - type: Transform
+      pos: -56.5,-14.5
       parent: 2
 - proto: BarricadeDirectional
   entities:
@@ -8865,6 +8901,30 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 32.5,13.5
+      parent: 2
+  - uid: 16419
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -58.5,-1.5
+      parent: 2
+  - uid: 16420
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -59.5,-0.5
+      parent: 2
+  - uid: 16447
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -56.5,-0.5
+      parent: 2
+  - uid: 16454
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -57.5,-14.5
       parent: 2
 - proto: BarSignMaidCafe
   entities:
@@ -10138,6 +10198,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 41.553917,-15.84091
       parent: 2
+  - uid: 16449
+    components:
+    - type: Transform
+      pos: -7.31013,-24.367844
+      parent: 2
 - proto: BoxFolderRed
   entities:
   - uid: 663
@@ -10188,6 +10253,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -37.80134,-53.233833
+      parent: 2
+  - uid: 16448
+    components:
+    - type: Transform
+      pos: -7.6356506,-24.4655
       parent: 2
 - proto: BoxHolyWater
   entities:
@@ -10373,6 +10443,11 @@ entities:
     components:
     - type: Transform
       pos: 6.8557024,-39.938892
+      parent: 2
+  - uid: 16430
+    components:
+    - type: Transform
+      pos: -60.755917,-3.5740533
       parent: 2
 - proto: ButtonFrameCaution
   entities:
@@ -21571,6 +21646,71 @@ entities:
     - type: Transform
       pos: -36.5,-55.5
       parent: 2
+  - uid: 16386
+    components:
+    - type: Transform
+      pos: -55.5,-14.5
+      parent: 2
+  - uid: 16387
+    components:
+    - type: Transform
+      pos: -56.5,-14.5
+      parent: 2
+  - uid: 16388
+    components:
+    - type: Transform
+      pos: -57.5,-14.5
+      parent: 2
+  - uid: 16389
+    components:
+    - type: Transform
+      pos: -58.5,-14.5
+      parent: 2
+  - uid: 16390
+    components:
+    - type: Transform
+      pos: -58.5,-13.5
+      parent: 2
+  - uid: 16421
+    components:
+    - type: Transform
+      pos: -55.5,-0.5
+      parent: 2
+  - uid: 16422
+    components:
+    - type: Transform
+      pos: -56.5,-0.5
+      parent: 2
+  - uid: 16423
+    components:
+    - type: Transform
+      pos: -57.5,-0.5
+      parent: 2
+  - uid: 16424
+    components:
+    - type: Transform
+      pos: -58.5,-0.5
+      parent: 2
+  - uid: 16425
+    components:
+    - type: Transform
+      pos: -59.5,-0.5
+      parent: 2
+  - uid: 16426
+    components:
+    - type: Transform
+      pos: -59.5,-1.5
+      parent: 2
+  - uid: 16427
+    components:
+    - type: Transform
+      pos: -59.5,-2.5
+      parent: 2
+  - uid: 16428
+    components:
+    - type: Transform
+      pos: -59.5,-3.5
+      parent: 2
 - proto: CableApcStack1
   entities:
   - uid: 2760
@@ -29476,6 +29616,21 @@ entities:
     - type: Transform
       pos: -54.674038,-45.24756
       parent: 2
+  - uid: 16375
+    components:
+    - type: Transform
+      pos: -58.569084,-13.296244
+      parent: 2
+  - uid: 16376
+    components:
+    - type: Transform
+      pos: -58.406322,-13.100931
+      parent: 2
+  - uid: 16377
+    components:
+    - type: Transform
+      pos: -58.4226,-13.491556
+      parent: 2
 - proto: CandlePurple
   entities:
   - uid: 578
@@ -29511,6 +29666,13 @@ entities:
     components:
     - type: Transform
       pos: 21.123423,10.859423
+      parent: 2
+- proto: CannabisSeeds
+  entities:
+  - uid: 16436
+    components:
+    - type: Transform
+      pos: -59.754707,-1.8259095
       parent: 2
 - proto: CarbonDioxideCanister
   entities:
@@ -30485,6 +30647,21 @@ entities:
     components:
     - type: Transform
       pos: -30.5,-16.5
+      parent: 2
+  - uid: 16381
+    components:
+    - type: Transform
+      pos: -57.5,-13.5
+      parent: 2
+  - uid: 16382
+    components:
+    - type: Transform
+      pos: -59.5,-13.5
+      parent: 2
+  - uid: 16383
+    components:
+    - type: Transform
+      pos: -58.5,-13.5
       parent: 2
 - proto: CarpetSBlue
   entities:
@@ -33706,6 +33883,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -36.5,-54.5
       parent: 2
+  - uid: 16391
+    components:
+    - type: Transform
+      pos: -55.5,-14.5
+      parent: 2
 - proto: Chair
   entities:
   - uid: 4758
@@ -34452,6 +34634,71 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 21.376013,-10.429995
       parent: 2
+  - uid: 16366
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -51.504044,7.749718
+      parent: 2
+- proto: ChairOfficeDark
+  entities:
+  - uid: 16348
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -49.495163,-1.4366448
+      parent: 2
+  - uid: 16349
+    components:
+    - type: Transform
+      pos: -50.94373,-13.487982
+      parent: 2
+  - uid: 16350
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -41.493183,-5.3942294
+      parent: 2
+  - uid: 16351
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -29.455975,-7.348236
+      parent: 2
+  - uid: 16352
+    components:
+    - type: Transform
+      pos: -18.493418,-19.43542
+      parent: 2
+  - uid: 16353
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.45632,-25.48429
+      parent: 2
+  - uid: 16354
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -14.487569,-26.493404
+      parent: 2
+  - uid: 16355
+    components:
+    - type: Transform
+      pos: -11.4523115,-37.420704
+      parent: 2
+  - uid: 16356
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.544485,-38.394707
+      parent: 2
+  - uid: 16456
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -50.316475,1.8930948
+      parent: 2
 - proto: ChairPilotSeat
   entities:
   - uid: 4889
@@ -34573,6 +34820,18 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -50.536327,10.579609
+      parent: 2
+  - uid: 16378
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -57.47859,-13.459005
+      parent: 2
+  - uid: 16379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -59.48054,-13.442728
       parent: 2
 - proto: ChairWeb
   entities:
@@ -34910,6 +35169,13 @@ entities:
     components:
     - type: Transform
       pos: -0.67154604,-12.055826
+      parent: 2
+- proto: CigaretteFilter
+  entities:
+  - uid: 16443
+    components:
+    - type: Transform
+      pos: -59.23387,-2.9001284
       parent: 2
 - proto: CigaretteSpent
   entities:
@@ -36079,6 +36345,13 @@ entities:
     - type: Transform
       pos: 11.563249,-26.697577
       parent: 2
+- proto: ClothingHeadFishCap
+  entities:
+  - uid: 16412
+    components:
+    - type: Transform
+      pos: -60.788643,-4.7329187
+      parent: 2
 - proto: ClothingHeadHatAnimalHeadslime
   entities:
   - uid: 5147
@@ -36162,6 +36435,13 @@ entities:
     components:
     - type: Transform
       pos: -38.569164,-56.609066
+      parent: 2
+- proto: ClothingHeadHatFlowerWreath
+  entities:
+  - uid: 16384
+    components:
+    - type: Transform
+      pos: -59.270615,-13.30681
       parent: 2
 - proto: ClothingHeadHatGreensoftFlipped
   entities:
@@ -36715,6 +36995,13 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
+- proto: ClothingShoesBootsFishing
+  entities:
+  - uid: 16411
+    components:
+    - type: Transform
+      pos: -60.658432,-4.3260174
+      parent: 2
 - proto: ClothingShoesLeather
   entities:
   - uid: 5211
@@ -38767,6 +39054,24 @@ entities:
     - type: Transform
       pos: 9.158765,-7.760074
       parent: 2
+- proto: DecorFloorPaper
+  entities:
+  - uid: 16441
+    components:
+    - type: Transform
+      pos: -60.5,-0.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+- proto: DecorFloorPaper1
+  entities:
+  - uid: 16440
+    components:
+    - type: Transform
+      pos: -60.5,-2.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
 - proto: DecorFloorPaper3
   entities:
   - uid: 16053
@@ -38774,6 +39079,13 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -44.5,9.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 16439
+    components:
+    - type: Transform
+      pos: -59.5,-2.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -43020,6 +43332,11 @@ entities:
     - type: Transform
       pos: 33.709957,-34.81473
       parent: 2
+  - uid: 16451
+    components:
+    - type: Transform
+      pos: -13.915666,-24.47033
+      parent: 2
 - proto: DrinkLithiumFlask
   entities:
   - uid: 15030
@@ -43089,6 +43406,11 @@ entities:
     components:
     - type: Transform
       pos: 50.310936,-29.301607
+      parent: 2
+  - uid: 16385
+    components:
+    - type: Transform
+      pos: -57.88715,-13.534674
       parent: 2
 - proto: DrinkRootBeerCan
   entities:
@@ -43430,6 +43752,13 @@ entities:
     components:
     - type: Transform
       pos: 41.444542,-16.55966
+      parent: 2
+- proto: DrinkWatermelonJuice
+  entities:
+  - uid: 16438
+    components:
+    - type: Transform
+      pos: -59.20132,-3.274477
       parent: 2
 - proto: DrinkWhiskeyBottleFull
   entities:
@@ -44402,6 +44731,13 @@ entities:
     components:
     - type: Transform
       pos: -16.51364,-8.393126
+      parent: 2
+- proto: FancyTableSpawner
+  entities:
+  - uid: 16373
+    components:
+    - type: Transform
+      pos: -58.5,-13.5
       parent: 2
 - proto: FaxMachineBase
   entities:
@@ -46382,7 +46718,7 @@ entities:
       pos: 24.5,16.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -16857.006
+      secondsUntilStateChange: -21111.918
       state: Closing
     - type: DeviceNetwork
       deviceLists:
@@ -46468,6 +46804,21 @@ entities:
     components:
     - type: Transform
       pos: -57.5,-48.5
+      parent: 2
+- proto: FishingRodMakeshift
+  entities:
+  - uid: 16413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -60.446846,-4.618986
+      parent: 2
+- proto: FishLabeler
+  entities:
+  - uid: 16404
+    components:
+    - type: Transform
+      pos: -59.552128,-3.4964485
       parent: 2
 - proto: Floodlight
   entities:
@@ -46615,6 +46966,28 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
+- proto: FloorWaterEntity
+  entities:
+  - uid: 16405
+    components:
+    - type: Transform
+      pos: -59.5,-5.5
+      parent: 2
+  - uid: 16406
+    components:
+    - type: Transform
+      pos: -60.5,-5.5
+      parent: 2
+  - uid: 16407
+    components:
+    - type: Transform
+      pos: -60.5,-6.5
+      parent: 2
+  - uid: 16408
+    components:
+    - type: Transform
+      pos: -59.5,-6.5
+      parent: 2
 - proto: FoodApple
   entities:
   - uid: 6490
@@ -46649,6 +47022,13 @@ entities:
       parent: 2
     missingComponents:
     - SpaceGarbage
+- proto: FoodBoxDonkpocket
+  entities:
+  - uid: 16450
+    components:
+    - type: Transform
+      pos: -13.606421,-24.34012
+      parent: 2
 - proto: FoodBoxDonkpocketPizza
   entities:
   - uid: 6495
@@ -68831,16 +69211,6 @@ entities:
     - type: Transform
       pos: -49.5,-38.5
       parent: 2
-  - uid: 9317
-    components:
-    - type: Transform
-      pos: -57.5,0.5
-      parent: 2
-  - uid: 9318
-    components:
-    - type: Transform
-      pos: -57.5,-0.5
-      parent: 2
   - uid: 9319
     components:
     - type: Transform
@@ -69619,16 +69989,6 @@ entities:
     - type: Transform
       pos: 14.5,12.5
       parent: 2
-  - uid: 9492
-    components:
-    - type: Transform
-      pos: -58.5,-4.5
-      parent: 2
-  - uid: 9493
-    components:
-    - type: Transform
-      pos: -58.5,-5.5
-      parent: 2
   - uid: 9494
     components:
     - type: Transform
@@ -69785,6 +70145,11 @@ entities:
     - type: Transform
       pos: -40.5,16.5
       parent: 2
+  - uid: 9526
+    components:
+    - type: Transform
+      pos: -63.5,0.5
+      parent: 2
   - uid: 9529
     components:
     - type: Transform
@@ -69855,40 +70220,10 @@ entities:
     - type: Transform
       pos: -44.5,14.5
       parent: 2
-  - uid: 9550
-    components:
-    - type: Transform
-      pos: -63.5,0.5
-      parent: 2
-  - uid: 9551
-    components:
-    - type: Transform
-      pos: -63.5,-0.5
-      parent: 2
-  - uid: 9552
-    components:
-    - type: Transform
-      pos: -63.5,-1.5
-      parent: 2
   - uid: 9553
     components:
     - type: Transform
-      pos: -63.5,-2.5
-      parent: 2
-  - uid: 9554
-    components:
-    - type: Transform
-      pos: -63.5,-3.5
-      parent: 2
-  - uid: 9555
-    components:
-    - type: Transform
-      pos: -63.5,-4.5
-      parent: 2
-  - uid: 9556
-    components:
-    - type: Transform
-      pos: -62.5,-4.5
+      pos: -64.5,-5.5
       parent: 2
   - uid: 9557
     components:
@@ -70392,11 +70727,6 @@ entities:
     - type: Transform
       pos: -65.5,-17.5
       parent: 2
-  - uid: 9684
-    components:
-    - type: Transform
-      pos: -56.5,-14.5
-      parent: 2
   - uid: 9685
     components:
     - type: Transform
@@ -70512,11 +70842,6 @@ entities:
     - type: Transform
       pos: 43.5,-14.5
       parent: 2
-  - uid: 9712
-    components:
-    - type: Transform
-      pos: -56.5,-16.5
-      parent: 2
   - uid: 9713
     components:
     - type: Transform
@@ -70526,11 +70851,6 @@ entities:
     components:
     - type: Transform
       pos: -8.5,12.5
-      parent: 2
-  - uid: 9715
-    components:
-    - type: Transform
-      pos: -56.5,-17.5
       parent: 2
   - uid: 9716
     components:
@@ -70571,7 +70891,7 @@ entities:
   - uid: 9724
     components:
     - type: Transform
-      pos: -56.5,-15.5
+      pos: -62.5,1.5
       parent: 2
   - uid: 9725
     components:
@@ -71227,6 +71547,11 @@ entities:
     - type: Transform
       pos: 54.5,-13.5
       parent: 2
+  - uid: 11145
+    components:
+    - type: Transform
+      pos: -64.5,-0.5
+      parent: 2
   - uid: 11147
     components:
     - type: Transform
@@ -71243,6 +71568,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 63.5,-43.5
+      parent: 2
+  - uid: 11425
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -60.5,-13.5
       parent: 2
   - uid: 11529
     components:
@@ -71746,18 +72077,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -60.5,9.5
       parent: 2
-  - uid: 15958
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -62.5,1.5
-      parent: 2
-  - uid: 15959
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -61.5,1.5
-      parent: 2
   - uid: 16166
     components:
     - type: Transform
@@ -71798,6 +72117,27 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,21.5
+      parent: 2
+  - uid: 16369
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -60.5,-14.5
+      parent: 2
+  - uid: 16398
+    components:
+    - type: Transform
+      pos: -61.5,-2.5
+      parent: 2
+  - uid: 16399
+    components:
+    - type: Transform
+      pos: -61.5,-1.5
+      parent: 2
+  - uid: 16400
+    components:
+    - type: Transform
+      pos: -61.5,-3.5
       parent: 2
 - proto: GrilleBroken
   entities:
@@ -71953,10 +72293,30 @@ entities:
       parent: 2
 - proto: GrilleSpawner
   entities:
+  - uid: 9550
+    components:
+    - type: Transform
+      pos: -64.5,-1.5
+      parent: 2
+  - uid: 9551
+    components:
+    - type: Transform
+      pos: -64.5,-2.5
+      parent: 2
+  - uid: 9552
+    components:
+    - type: Transform
+      pos: -64.5,-3.5
+      parent: 2
   - uid: 9562
     components:
     - type: Transform
       pos: -58.5,-53.5
+      parent: 2
+  - uid: 9715
+    components:
+    - type: Transform
+      pos: -64.5,-4.5
       parent: 2
   - uid: 9879
     components:
@@ -72903,6 +73263,18 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-37.5
+      parent: 2
+- proto: hydroponicsSoil
+  entities:
+  - uid: 16434
+    components:
+    - type: Transform
+      pos: -58.5,-1.5
+      parent: 2
+  - uid: 16435
+    components:
+    - type: Transform
+      pos: -59.5,-1.5
       parent: 2
 - proto: HydroponicsToolClippers
   entities:
@@ -74543,6 +74915,11 @@ entities:
       parent: 2
 - proto: MaintenanceToolSpawner
   entities:
+  - uid: 9317
+    components:
+    - type: Transform
+      pos: -63.5,-2.5
+      parent: 2
   - uid: 10152
     components:
     - type: Transform
@@ -74655,11 +75032,6 @@ entities:
     - type: Transform
       pos: -10.5,13.5
       parent: 2
-  - uid: 10174
-    components:
-    - type: Transform
-      pos: -61.5,-7.5
-      parent: 2
   - uid: 14910
     components:
     - type: Transform
@@ -74669,6 +75041,11 @@ entities:
     components:
     - type: Transform
       pos: 52.5,-15.5
+      parent: 2
+  - uid: 16457
+    components:
+    - type: Transform
+      pos: -62.5,-5.5
       parent: 2
 - proto: Matchbox
   entities:
@@ -74738,6 +75115,11 @@ entities:
     components:
     - type: Transform
       pos: -50.489002,5.089605
+      parent: 2
+  - uid: 16445
+    components:
+    - type: Transform
+      pos: -59.59052,-0.45417333
       parent: 2
 - proto: MedicalBed
   entities:
@@ -75102,6 +75484,37 @@ entities:
     - type: Transform
       pos: 54.97876,-44.508137
       parent: 2
+  - uid: 16358
+    components:
+    - type: Transform
+      pos: 26.974833,-37.565342
+      parent: 2
+  - uid: 16365
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -21.514534,2.6045995
+      parent: 2
+  - uid: 16367
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -47.585827,-31.377005
+      parent: 2
+  - uid: 16368
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -25.641972,-30.421293
+      parent: 2
+- proto: N14ChairOfficeGreen
+  entities:
+  - uid: 16357
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.521545,-38.43193
+      parent: 2
 - proto: N14ChairOfficeRed
   entities:
   - uid: 615
@@ -75121,6 +75534,42 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 22.30076,11.252563
+      parent: 2
+  - uid: 16359
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.44864,-13.460699
+      parent: 2
+  - uid: 16360
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 34.566223,0.5485635
+      parent: 2
+  - uid: 16361
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.473679,-16.456837
+      parent: 2
+  - uid: 16362
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.431055,-19.451628
+      parent: 2
+  - uid: 16363
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 40.506397,-16.334291
+      parent: 2
+  - uid: 16364
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.547474,2.5557714
       parent: 2
 - proto: N14DecorFloorPaper1
   entities:
@@ -76076,6 +76525,13 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 21.514048,10.875698
       parent: 2
+- proto: PaperRolling
+  entities:
+  - uid: 16442
+    components:
+    - type: Transform
+      pos: -59.478012,-3.0954409
+      parent: 2
 - proto: PaperScrap
   entities:
   - uid: 5998
@@ -76376,6 +76832,13 @@ entities:
     - type: Transform
       pos: 34.720486,17.9614
       parent: 2
+- proto: PlushieCarp
+  entities:
+  - uid: 16431
+    components:
+    - type: Transform
+      pos: -59.24288,-6.5888963
+      parent: 2
 - proto: PlushieCatBlack
   entities:
   - uid: 16244
@@ -76443,6 +76906,11 @@ entities:
     - type: Transform
       pos: 72.70667,-23.536297
       parent: 2
+  - uid: 16433
+    components:
+    - type: Transform
+      pos: -59.633507,-5.4007454
+      parent: 2
 - proto: PlushieHuman
   entities:
   - uid: 9982
@@ -76505,6 +76973,11 @@ entities:
     - type: Transform
       pos: 23.496122,11.813873
       parent: 2
+  - uid: 16432
+    components:
+    - type: Transform
+      pos: -60.49614,-6.1331673
+      parent: 2
 - proto: PlushieMort
   entities:
   - uid: 6858
@@ -76544,6 +77017,16 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 23.653599,10.398014
+      parent: 2
+- proto: PlushieOni
+  entities:
+  - uid: 16452
+    components:
+    - type: MetaData
+      desc: They're a certified fisherman, why are they out in space?
+      name: Puddles
+    - type: Transform
+      pos: -62.37487,-2.4167185
       parent: 2
 - proto: PlushieOrangeFox
   entities:
@@ -76602,9 +77085,12 @@ entities:
   - uid: 15596
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -58.357563,-15.695623
+      rot: -4.71238898038469 rad
+      pos: -59.453217,-13.49691
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: PlushieSharkBlue
   entities:
   - uid: 7215
@@ -76698,8 +77184,11 @@ entities:
   - uid: 10385
     components:
     - type: Transform
-      pos: -57.49212,-15.477257
+      pos: -57.50048,-13.482857
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: PortableGeneratorJrPacman
   entities:
   - uid: 15873
@@ -77380,6 +77869,11 @@ entities:
     components:
     - type: Transform
       pos: 46.5,-27.5
+      parent: 2
+  - uid: 16374
+    components:
+    - type: Transform
+      pos: -55.5,-13.5
       parent: 2
 - proto: PottedPlantRandom
   entities:
@@ -79338,6 +79832,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 37.5,0.5
       parent: 2
+  - uid: 16429
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -59.5,-3.5
+      parent: 2
 - proto: PoweredSmallLightEmpty
   entities:
   - uid: 10776
@@ -79427,6 +79927,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 47.5,-41.5
+      parent: 2
+  - uid: 16380
+    components:
+    - type: Transform
+      pos: -58.5,-13.5
       parent: 2
 - proto: PoweredSmallLightMaintenanceRed
   entities:
@@ -79550,6 +80055,18 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 31.5,17.5
+      parent: 2
+- proto: PrinterDoc
+  entities:
+  - uid: 16346
+    components:
+    - type: Transform
+      pos: 17.5,-38.5
+      parent: 2
+  - uid: 16347
+    components:
+    - type: Transform
+      pos: 28.5,-38.5
       parent: 2
 - proto: PrizeCounter
   entities:
@@ -80190,6 +80707,16 @@ entities:
     - type: Transform
       pos: -36.5,-57.5
       parent: 2
+  - uid: 16409
+    components:
+    - type: Transform
+      pos: -59.5,-4.5
+      parent: 2
+  - uid: 16410
+    components:
+    - type: Transform
+      pos: -60.5,-4.5
+      parent: 2
 - proto: RailingCorner
   entities:
   - uid: 10922
@@ -80817,6 +81344,11 @@ entities:
     - type: Transform
       pos: -59.5,8.5
       parent: 2
+  - uid: 16393
+    components:
+    - type: Transform
+      pos: -58.5,-15.5
+      parent: 2
 - proto: RandomPosterContraband
   entities:
   - uid: 11016
@@ -80859,6 +81391,11 @@ entities:
     components:
     - type: Transform
       pos: -48.5,8.5
+      parent: 2
+  - uid: 16446
+    components:
+    - type: Transform
+      pos: -58.5,-2.5
       parent: 2
 - proto: RandomPosterLegit
   entities:
@@ -81414,17 +81951,16 @@ entities:
     - type: Transform
       pos: -41.5,-59.5
       parent: 2
-  - uid: 9526
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -62.5,0.5
-      parent: 2
   - uid: 9527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -60.5,11.5
+      parent: 2
+  - uid: 9554
+    components:
+    - type: Transform
+      pos: -63.5,-0.5
       parent: 2
   - uid: 9560
     components:
@@ -81521,11 +82057,6 @@ entities:
     - type: Transform
       pos: -62.5,-43.5
       parent: 2
-  - uid: 11145
-    components:
-    - type: Transform
-      pos: -62.5,-5.5
-      parent: 2
   - uid: 11148
     components:
     - type: Transform
@@ -81610,6 +82141,11 @@ entities:
     components:
     - type: Transform
       pos: -61.5,-50.5
+      parent: 2
+  - uid: 11408
+    components:
+    - type: Transform
+      pos: -63.5,-5.5
       parent: 2
   - uid: 11454
     components:
@@ -81704,6 +82240,11 @@ entities:
     components:
     - type: Transform
       pos: 40.5,-50.5
+      parent: 2
+  - uid: 15959
+    components:
+    - type: Transform
+      pos: -62.5,0.5
       parent: 2
 - proto: ReinforcedPlasmaWindow
   entities:
@@ -83020,16 +83561,6 @@ entities:
     - type: Transform
       pos: -35.5,0.5
       parent: 2
-  - uid: 11408
-    components:
-    - type: Transform
-      pos: -57.5,0.5
-      parent: 2
-  - uid: 11409
-    components:
-    - type: Transform
-      pos: -57.5,-0.5
-      parent: 2
   - uid: 11410
     components:
     - type: Transform
@@ -83039,11 +83570,6 @@ entities:
     components:
     - type: Transform
       pos: -49.5,-27.5
-      parent: 2
-  - uid: 11412
-    components:
-    - type: Transform
-      pos: -56.5,-14.5
       parent: 2
   - uid: 11413
     components:
@@ -83065,16 +83591,6 @@ entities:
     - type: Transform
       pos: -56.5,-22.5
       parent: 2
-  - uid: 11420
-    components:
-    - type: Transform
-      pos: -56.5,-16.5
-      parent: 2
-  - uid: 11421
-    components:
-    - type: Transform
-      pos: -56.5,-17.5
-      parent: 2
   - uid: 11422
     components:
     - type: Transform
@@ -83089,11 +83605,6 @@ entities:
     components:
     - type: Transform
       pos: -56.5,-20.5
-      parent: 2
-  - uid: 11425
-    components:
-    - type: Transform
-      pos: -56.5,-15.5
       parent: 2
   - uid: 11426
     components:
@@ -83145,16 +83656,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -35.5,-24.5
-      parent: 2
-  - uid: 11436
-    components:
-    - type: Transform
-      pos: -58.5,-4.5
-      parent: 2
-  - uid: 11437
-    components:
-    - type: Transform
-      pos: -58.5,-5.5
       parent: 2
   - uid: 11438
     components:
@@ -83616,6 +84117,33 @@ entities:
       rot: 3.141592653589793 rad
       pos: 10.5,21.5
       parent: 2
+  - uid: 16370
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -60.5,-13.5
+      parent: 2
+  - uid: 16371
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -60.5,-14.5
+      parent: 2
+  - uid: 16401
+    components:
+    - type: Transform
+      pos: -61.5,-1.5
+      parent: 2
+  - uid: 16402
+    components:
+    - type: Transform
+      pos: -61.5,-2.5
+      parent: 2
+  - uid: 16403
+    components:
+    - type: Transform
+      pos: -61.5,-3.5
+      parent: 2
 - proto: ResearchAndDevelopmentServer
   entities:
   - uid: 11530
@@ -83736,6 +84264,13 @@ entities:
     components:
     - type: Transform
       pos: -42.5,-31.5
+      parent: 2
+- proto: ScrapBucket
+  entities:
+  - uid: 16444
+    components:
+    - type: Transform
+      pos: -60.518253,-0.34024096
       parent: 2
 - proto: Screen
   entities:
@@ -84232,6 +84767,12 @@ entities:
           - 15317
           - 15319
           - 15318
+  - uid: 16455
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -56.5,-13.5
+      parent: 2
 - proto: ShellShotgun
   entities:
   - uid: 16020
@@ -86968,6 +87509,13 @@ entities:
     - type: Transform
       pos: 25.5,-45.5
       parent: 2
+- proto: SolidSecretDoor
+  entities:
+  - uid: 15958
+    components:
+    - type: Transform
+      pos: -53.5,9.5
+      parent: 2
 - proto: SophicScribeSpawner
   entities:
   - uid: 12088
@@ -88561,6 +89109,11 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 18.5,5.5
+      parent: 2
+  - uid: 16414
+    components:
+    - type: Transform
+      pos: -59.476517,-4.0758247
       parent: 2
 - proto: StoolBar
   entities:
@@ -92176,6 +92729,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -45.5,10.5
       parent: 2
+  - uid: 16415
+    components:
+    - type: Transform
+      pos: -59.5,-3.5
+      parent: 2
+  - uid: 16416
+    components:
+    - type: Transform
+      pos: -59.5,-2.5
+      parent: 2
 - proto: TableWoodReinforced
   entities:
   - uid: 1449
@@ -94393,10 +94956,25 @@ entities:
     - type: Transform
       pos: -53.5,-47.5
       parent: 2
+  - uid: 9318
+    components:
+    - type: Transform
+      pos: -57.5,0.5
+      parent: 2
   - uid: 9423
     components:
     - type: Transform
       pos: 57.5,-48.5
+      parent: 2
+  - uid: 9492
+    components:
+    - type: Transform
+      pos: -61.5,0.5
+      parent: 2
+  - uid: 9493
+    components:
+    - type: Transform
+      pos: -59.5,0.5
       parent: 2
   - uid: 9530
     components:
@@ -94408,6 +94986,18 @@ entities:
     components:
     - type: Transform
       pos: 34.5,-43.5
+      parent: 2
+  - uid: 9555
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -57.5,-15.5
+      parent: 2
+  - uid: 9556
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -56.5,-16.5
       parent: 2
   - uid: 9576
     components:
@@ -94421,11 +95011,23 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -39.5,-54.5
       parent: 2
+  - uid: 9684
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -56.5,-17.5
+      parent: 2
   - uid: 9707
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -39.5,-55.5
+      parent: 2
+  - uid: 9712
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -56.5,-15.5
       parent: 2
   - uid: 9750
     components:
@@ -94521,6 +95123,11 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -17.5,-36.5
+      parent: 2
+  - uid: 10174
+    components:
+    - type: Transform
+      pos: -61.5,-6.5
       parent: 2
   - uid: 10237
     components:
@@ -94650,11 +95257,39 @@ entities:
     - type: Transform
       pos: -59.5,-48.5
       parent: 2
+  - uid: 11409
+    components:
+    - type: Transform
+      pos: -58.5,0.5
+      parent: 2
+  - uid: 11412
+    components:
+    - type: Transform
+      pos: -60.5,0.5
+      parent: 2
   - uid: 11414
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -34.5,-51.5
+      parent: 2
+  - uid: 11420
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -58.5,-15.5
+      parent: 2
+  - uid: 11421
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -60.5,-15.5
+      parent: 2
+  - uid: 11436
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -59.5,-15.5
       parent: 2
   - uid: 11486
     components:
@@ -100643,6 +101278,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -61.5,8.5
       parent: 2
+  - uid: 15887
+    components:
+    - type: Transform
+      pos: -58.5,-5.5
+      parent: 2
   - uid: 15905
     components:
     - type: Transform
@@ -100688,6 +101328,31 @@ entities:
     components:
     - type: Transform
       pos: -44.5,-61.5
+      parent: 2
+  - uid: 16392
+    components:
+    - type: Transform
+      pos: -61.5,-5.5
+      parent: 2
+  - uid: 16394
+    components:
+    - type: Transform
+      pos: -61.5,-7.5
+      parent: 2
+  - uid: 16395
+    components:
+    - type: Transform
+      pos: -58.5,-4.5
+      parent: 2
+  - uid: 16396
+    components:
+    - type: Transform
+      pos: -61.5,-4.5
+      parent: 2
+  - uid: 16397
+    components:
+    - type: Transform
+      pos: -61.5,-0.5
       parent: 2
 - proto: WallReinforcedDiagonal
   entities:
@@ -102978,11 +103643,6 @@ entities:
     - type: Transform
       pos: -52.5,9.5
       parent: 2
-  - uid: 15887
-    components:
-    - type: Transform
-      pos: -53.5,9.5
-      parent: 2
   - uid: 15888
     components:
     - type: Transform
@@ -103451,6 +104111,13 @@ entities:
     components:
     - type: Transform
       pos: 50.5,-31.5
+      parent: 2
+- proto: WatermelonSeeds
+  entities:
+  - uid: 16437
+    components:
+    - type: Transform
+      pos: -58.79442,-1.8259095
       parent: 2
 - proto: WaterTankFull
   entities:

--- a/Resources/Prototypes/Maps/shoukou.yml
+++ b/Resources/Prototypes/Maps/shoukou.yml
@@ -70,6 +70,7 @@
             ForensicMantis: [ 1, 1 ]
             Roboticist: [ 2, 2 ]
             Borg: [ 2, 2 ]
+            Librarian: [ 1, 1 ]
           #Logistics
             Quartermaster: [ 1, 1 ]
             SalvageSpecialist: [ 2, 4 ]


### PR DESCRIPTION
I added two maints rooms (a fishing hole and a small room where you can have a date.) No, they aren't piped properly, because it's maints, but they do have lighting.

I also fixed an astonishing lack of office chairs, and the Cataloguer had spawns but wasn't in the map prototype.

Fishing hole:
![image](https://github.com/user-attachments/assets/ae134e05-548e-4589-b094-2a163893cf14)


# Changelog
:cl:
- tweak: Gave Shoukou some new maints rooms.
- fix: Fixed chair migration problems (On Shoukou.)
- remove: Removed Gregg's whimsy >:(((( 