### PR TITLE
Feat: Basic Dynamic Power Draw for IPCs Based on Movement Speed

### DIFF
--- a/Content.Server/Silicon/Charge/Systems/SiliconChargeSystem.cs
+++ b/Content.Server/Silicon/Charge/Systems/SiliconChargeSystem.cs
@@ -203,8 +203,6 @@ public sealed class SiliconChargeSystem : EntitySystem
 
     private float SiliconMovementEffects(EntityUid silicon, SiliconComponent siliconComp)
     {
-        const float maxReductionAmount = 0.6f;
-
         // Calculate dynamic power draw.
         if (!TryComp(silicon, out MovementSpeedModifierComponent? movement) ||
             !TryComp(silicon, out PhysicsComponent? physics) || !TryComp(silicon, out InputMoverComponent? input))
@@ -212,13 +210,13 @@ public sealed class SiliconChargeSystem : EntitySystem
 
         if (input.HeldMoveButtons == 0x0 || _jetpack.IsUserFlying(silicon)) // If nothing is being held or jet packing
         {
-            return siliconComp.DrainPerSecond * maxReductionAmount; // Reduces draw by max reduction amount
+            return siliconComp.DrainPerSecond * siliconComp.IdleDrainReduction; // Reduces draw by idle drain reduction
         }
 
         // LinearVelocity is relative to the parent
         return Math.Clamp(
             siliconComp.DrainPerSecond * (1 - (physics.LinearVelocity.Length() / movement.CurrentSprintSpeed)), // Power draw changes as a percentage of the movement
             0f, // Minimum is no change to power draw
-            siliconComp.DrainPerSecond * maxReductionAmount); // Should be a maximum of the max reduction amount
+            siliconComp.DrainPerSecond * siliconComp.IdleDrainReduction); // Should be a maximum of the idle drain reduction
     }
 }

--- a/Content.Server/Silicon/Charge/Systems/SiliconChargeSystem.cs
+++ b/Content.Server/Silicon/Charge/Systems/SiliconChargeSystem.cs
@@ -202,7 +202,7 @@ public sealed class SiliconChargeSystem : EntitySystem
 
     private float SiliconMovementEffects(EntityUid silicon, SiliconComponent siliconComp)
     {
-        const float maxReductionAmount = 0.7f;
+        const float maxReductionAmount = 0.6f;
 
         // Calculate dynamic power draw.
         if (!TryComp(silicon, out MovementSpeedModifierComponent? movement) ||

--- a/Content.Shared/Silicon/Components/SiliconComponent.cs
+++ b/Content.Shared/Silicon/Components/SiliconComponent.cs
@@ -69,6 +69,16 @@ public sealed partial class SiliconComponent : Component
     [DataField]
     public float DrainPerSecond = 50f;
 
+    /// <summary>
+    ///     How much less power is used while being idle.
+    /// </summary>
+    /// <remarks>
+    ///     Relative to the DrainPerSecond.
+    ///     0 is no reduction. 1 is 100% reduction. 0.5 is 50% reduction.
+    ///     Currently, 90% reduction is as high as we can go without changing code in C#
+    /// </remarks>
+    [DataField]
+    public float IdleDrainReduction = 0.6f;
 
     /// <summary>
     ///     The percentages at which the silicon will enter each state.

--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -74,7 +74,7 @@
   - type: Silicon
     entityType: enum.SiliconType.Player
     batteryPowered: true
-    drainPerSecond: 1.5
+    drainPerSecond: 2.25
     idleDrainReduction: 0.9
     chargeThresholdMid: 0.80
     chargeThresholdLow: 0.35

--- a/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/ipc.yml
@@ -75,6 +75,7 @@
     entityType: enum.SiliconType.Player
     batteryPowered: true
     drainPerSecond: 1.5
+    idleDrainReduction: 0.9
     chargeThresholdMid: 0.80
     chargeThresholdLow: 0.35
     chargeThresholdCritical: 0.10


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Made the power draw on IPCs relative to their velocity and if they are actively inputting commands.
I.e. standing still would be a 90% reduction of base power draw, and full sprint would be no reduction. 

Based off [this](https://discord.com/channels/1301753657024319488/1378818845438902522) discussion

I've tested dragging someone with moon boots in a moving shuttle to make sure it wasn't drawing more than it was supposed to. 

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

N/A

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: IPCs now use significantly less power when standing still
