### PR TITLE
Added the Dropper to the Botanical Belt Whitelist

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -372,6 +372,7 @@
         - Bottle
         - Syringe
         - CigPack
+        - Dropper
       components:
         - Seed
         - Smokable

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -290,6 +290,9 @@
     toggleState: 1 # draw
   - type: ExaminableSolution
     solution: dropper
+  - type: Tag
+    tags:
+    - Dropper
   - type: UserInterface
     interfaces:
       enum.TransferAmountUiKey.Key:

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -619,6 +619,9 @@
   id: DrinkBottle
 
 - type: Tag
+  id: Dropper
+
+- type: Tag
   id: Duck
 
 - type: Tag


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Added the Dropper item to the whitelist for the Botanical belt (also added a "Dropper" tag for future use)

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked dropper into botanical belt whitelist
