### PR TITLE
Suit Sensors Tweaks

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml
@@ -15,6 +15,9 @@
                     </PanelContainer>
                 </controls:StripeBack>
 
+                <LineEdit Name="SearchLineEdit" HorizontalExpand="True"
+                          PlaceHolder="{Loc crew-monitor-filter-line-placeholder}" />
+
                 <ScrollContainer Name="SensorScroller"
                                  VerticalExpand="True"
                                  SetWidth="520"

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -156,6 +156,11 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
         // Populate departments
         foreach (var sensor in departmentSensors)
         {
+            if (!string.IsNullOrEmpty(SearchLineEdit.Text)
+                && !sensor.Name.Contains(SearchLineEdit.Text, StringComparison.CurrentCultureIgnoreCase)
+                && !sensor.Job.Contains(SearchLineEdit.Text, StringComparison.CurrentCultureIgnoreCase))
+                continue;
+
             var coordinates = _entManager.GetCoordinates(sensor.Coordinates);
 
             // Add a button that will hold a username and other details

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -78,10 +78,28 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
 
         NoServerLabel.Visible = false;
 
+        // Collect one status per user, using the sensor with the most data available.
+        Dictionary<NetEntity, SuitSensorStatus> uniqueSensorsMap = new();
+        foreach (var sensor in sensors)
+        {
+            if (uniqueSensorsMap.TryGetValue(sensor.OwnerUid, out var existingSensor))
+            {
+                // Skip if we already have a sensor with more data for this mob.
+                if (existingSensor.Coordinates != null && sensor.Coordinates == null)
+                    continue;
+
+                if (existingSensor.DamagePercentage != null && sensor.DamagePercentage == null)
+                    continue;
+            }
+
+            uniqueSensorsMap[sensor.OwnerUid] = sensor;
+        }
+        var uniqueSensors = uniqueSensorsMap.Values.ToList();
+
         // Order sensor data
-        var orderedSensors = sensors.OrderBy(n => n.Name).OrderBy(j => j.Job);
+        var orderedSensors = uniqueSensors.OrderBy(n => n.Name).OrderBy(j => j.Job);
         var assignedSensors = new HashSet<SuitSensorStatus>();
-        var departments = sensors.SelectMany(d => d.JobDepartments).Distinct().OrderBy(n => n);
+        var departments = uniqueSensors.SelectMany(d => d.JobDepartments).Distinct().OrderBy(n => n);
 
         // Create department labels and populate lists
         foreach (var department in departments)

--- a/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorComponent.cs
@@ -14,43 +14,43 @@ public sealed partial class SuitSensorComponent : Component
     /// <summary>
     ///     Choose a random sensor mode when item is spawned.
     /// </summary>
-    [DataField]
+    [DataField("randomMode")]
     public bool RandomMode = true;
 
     /// <summary>
     ///     If true user can't change suit sensor mode
     /// </summary>
-    [DataField]
+    [DataField("controlsLocked")]
     public bool ControlsLocked = false;
 
     /// <summary>
     ///  How much time it takes to change another player's sensors
     /// </summary>
-    [DataField]
+    [DataField("sensorsTime")]
     public float SensorsTime = 1.75f;
 
     /// <summary>
     ///     Current sensor mode. Can be switched by user verbs.
     /// </summary>
-    [DataField]
+    [DataField("mode")]
     public SuitSensorMode Mode = SuitSensorMode.SensorOff;
 
     /// <summary>
     ///     Activate sensor if user wear it in this slot.
     /// </summary>
-    [DataField]
+    [DataField("activationSlot")]
     public string ActivationSlot = "jumpsuit";
 
     /// <summary>
     /// Activate sensor if user has this in a sensor-compatible container.
     /// </summary>
-    [DataField]
+    [DataField("activationContainer")]
     public string? ActivationContainer;
 
     /// <summary>
     ///     How often does sensor update its owners status (in seconds). Limited by the system update rate.
     /// </summary>
-    [DataField]
+    [DataField("updateRate")]
     public TimeSpan UpdateRate = TimeSpan.FromSeconds(2f);
 
     /// <summary>
@@ -62,7 +62,7 @@ public sealed partial class SuitSensorComponent : Component
     /// <summary>
     ///     Next time when sensor updated owners status
     /// </summary>
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [DataField("nextUpdate", customTypeSerializer: typeof(TimeOffsetSerializer))]
     [AutoPausedField]
     public TimeSpan NextUpdate = TimeSpan.Zero;
 

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -237,8 +237,9 @@ public sealed class SuitSensorSystem : EntitySystem
             return;
 
         // check if target is incapacitated (cuffed, dead, etc)
-        if (component.User != null && args.User != component.User && _actionBlocker.CanInteract(component.User.Value, null))
-            return;
+        // ignore above, check commented out due to player requests
+        //if (component.User != null && args.User != component.User && _actionBlocker.CanInteract(component.User.Value, null))
+        //    return;
 
         args.Verbs.UnionWith(new[]
         {

--- a/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
+++ b/Content.Server/Medical/SuitSensors/SuitSensorSystem.cs
@@ -408,7 +408,7 @@ public sealed class SuitSensorSystem : EntitySystem
             totalDamageThreshold = critThreshold.Value.Int();
 
         // finally, form suit sensor status
-        var status = new SuitSensorStatus(GetNetEntity(uid), userName, userJob, userJobIcon, userJobDepartments);
+        var status = new SuitSensorStatus(GetNetEntity(sensor.User.Value), GetNetEntity(uid), userName, userJob, userJobIcon, userJobDepartments);
         switch (sensor.Mode)
         {
             case SuitSensorMode.SensorBinary:
@@ -463,6 +463,7 @@ public sealed class SuitSensorSystem : EntitySystem
             [SuitSensorConstants.NET_JOB_DEPARTMENTS] = status.JobDepartments,
             [SuitSensorConstants.NET_IS_ALIVE] = status.IsAlive,
             [SuitSensorConstants.NET_SUIT_SENSOR_UID] = status.SuitSensorUid,
+            [SuitSensorConstants.NET_OWNER_UID] = status.OwnerUid,
         };
 
         if (status.TotalDamage != null)
@@ -493,13 +494,14 @@ public sealed class SuitSensorSystem : EntitySystem
         if (!payload.TryGetValue(SuitSensorConstants.NET_JOB_DEPARTMENTS, out List<string>? jobDepartments)) return null;
         if (!payload.TryGetValue(SuitSensorConstants.NET_IS_ALIVE, out bool? isAlive)) return null;
         if (!payload.TryGetValue(SuitSensorConstants.NET_SUIT_SENSOR_UID, out NetEntity suitSensorUid)) return null;
+        if (!payload.TryGetValue(SuitSensorConstants.NET_OWNER_UID, out NetEntity ownerUid)) return null;
 
         // try get total damage and cords (optionals)
         payload.TryGetValue(SuitSensorConstants.NET_TOTAL_DAMAGE, out int? totalDamage);
         payload.TryGetValue(SuitSensorConstants.NET_TOTAL_DAMAGE_THRESHOLD, out int? totalDamageThreshold);
         payload.TryGetValue(SuitSensorConstants.NET_COORDINATES, out NetCoordinates? coords);
 
-        var status = new SuitSensorStatus(suitSensorUid, name, job, jobIcon, jobDepartments)
+        var status = new SuitSensorStatus(ownerUid, suitSensorUid, name, job, jobIcon, jobDepartments)
         {
             IsAlive = isAlive.Value,
             TotalDamage = totalDamage,

--- a/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
+++ b/Content.Shared/Medical/SuitSensor/SharedSuitSensor.cs
@@ -7,8 +7,9 @@ namespace Content.Shared.Medical.SuitSensor;
 [Serializable, NetSerializable]
 public sealed class SuitSensorStatus
 {
-    public SuitSensorStatus(NetEntity suitSensorUid, string name, string job, string jobIcon, List<string> jobDepartments)
+    public SuitSensorStatus(NetEntity ownerUid, NetEntity suitSensorUid, string name, string job, string jobIcon, List<string> jobDepartments)
     {
+        OwnerUid = ownerUid;
         SuitSensorUid = suitSensorUid;
         Name = name;
         Job = job;
@@ -18,6 +19,7 @@ public sealed class SuitSensorStatus
 
     public TimeSpan Timestamp;
     public NetEntity SuitSensorUid;
+    public NetEntity OwnerUid;
     public string Name;
     public string Job;
     public string JobIcon;
@@ -55,6 +57,7 @@ public enum SuitSensorMode : byte
 
 public static class SuitSensorConstants
 {
+    public const string NET_OWNER_UID = "ownerUid";
     public const string NET_NAME = "name";
     public const string NET_JOB = "job";
     public const string NET_JOB_ICON = "jobIcon";

--- a/Resources/Locale/en-US/medical/components/crew-monitoring-component.ftl
+++ b/Resources/Locale/en-US/medical/components/crew-monitoring-component.ftl
@@ -2,6 +2,8 @@
 
 crew-monitoring-user-interface-title = Crew Monitoring Console
 
+crew-monitor-filter-line-placeholder = Filter
+
 crew-monitoring-user-interface-name = Name
 crew-monitoring-user-interface-job = Job
 crew-monitoring-user-interface-status = Status


### PR DESCRIPTION
# Description

- ported https://github.com/space-wizards/space-station-14/pull/35918
Suit sensors will no longer duplicate on the crew console when you have multiple "sources" of sensors, like an implanter and suit sensors. What will show up in the console will now be whatever gives the most information.
e.g. having coords disabled, but being implanted with a tracker will make you show up with coords turned up to max on the console, ONCE. 
There is a way to show up twice still - if your paradox anomaly turns their coords up, it's still going to show two entries for one person. 

- ported https://github.com/space-wizards/space-station-14/pull/31659

- removed the check for incapacitation on changing another person's coords

---

# Changelog

:cl:
- add: Added a filter, such that you can search people on the crew console by name or job.
- fix: Suit sensors will no longer duplicate on the crew console when you have multiple "sources" of sensors. See PR for details.
- remove: Removed the check for incapacitation on changing another person's coords. You're now free to come up to people and force their coords on. (or off, you rascal) 