### PR TITLE
Add .38 Moon Clips to Sec Loadout

### DIFF
--- a/Resources/Locale/en-US/loadouts/jobs/security.ftl
+++ b/Resources/Locale/en-US/loadouts/jobs/security.ftl
@@ -8,6 +8,8 @@ loadout-name-LoadoutSpeedLoaderMagnumSpare = speed loader (.45 magnum, spare)
 loadout-name-LoadoutSpeedLoaderMagnumRubberSpare = speed loader (.45 magnum rubber, spare)
 loadout-name-LoadoutMagazineMagnumSpare = pistol magazine (.45 magnum, spare)
 loadout-name-LoadoutMagazineMagnumRubberSpare = pistol magazine (.45 magnum rubber, spare)
+loadout-name-LoadoutSpeedLoaderSpecialSpare = speed loader (.38 special, spare)
+loadout-name-LoadoutSpeedLoaderSpecialRubberSpare = speed loader (.38 special rubber, spare)
 
 # Duty Weapons
 loadout-name-LoadoutSecurityMk58 = Mk58 (lethal)

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/uncategorized.yml
@@ -51,6 +51,14 @@
     - type: loadout
       id: LoadoutSpeedLoaderMagnumRubberSpare
     - type: loadout
+      id: LoadoutSpeedLoaderSpecial
+    - type: loadout
+      id: LoadoutSpeedLoaderSpecialSpare
+    - type: loadout
+      id: LoadoutSpeedLoaderSpecialRubber
+    - type: loadout
+      id: LoadoutSpeedLoaderSpecialRubberSpare
+    - type: loadout
       id: LoadoutMagazineMagnum
     - type: loadout
       id: LoadoutMagazineMagnumRubber

--- a/Resources/Prototypes/Loadouts/Jobs/Security/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/uncategorized.yml
@@ -288,6 +288,88 @@
     - SpeedLoaderMagnumRubber
 
 - type: loadout
+  id: LoadoutSpeedLoaderSpecial
+  category: JobsSecurityAUncategorized
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Security
+      min: 3600 # 1 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityEquipment
+    - !type:CharacterLogicOrRequirement
+      requirements:
+      - !type:CharacterDepartmentRequirement
+        departments:
+          - Security
+      - !type:CharacterJobRequirement
+        jobs:
+          - BlueshieldOfficer
+  items:
+    - SpeedLoaderSpecial
+
+- type: loadout
+  id: LoadoutSpeedLoaderSpecialSpare
+  category: JobsSecurityAUncategorized
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Security
+      min: 3600 # 1 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityEquipment
+    - !type:CharacterLogicOrRequirement
+      requirements:
+      - !type:CharacterDepartmentRequirement
+        departments:
+          - Security
+      - !type:CharacterJobRequirement
+        jobs:
+          - BlueshieldOfficer
+  items:
+    - SpeedLoaderSpecial
+
+- type: loadout
+  id: LoadoutSpeedLoaderSpecialRubber
+  category: JobsSecurityAUncategorized
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityEquipment
+    - !type:CharacterLogicOrRequirement
+      requirements:
+      - !type:CharacterDepartmentRequirement
+        departments:
+          - Security
+      - !type:CharacterJobRequirement
+        jobs:
+          - BlueshieldOfficer
+  items:
+    - SpeedLoaderSpecialRubber
+
+- type: loadout
+  id: LoadoutSpeedLoaderSpecialRubberSpare
+  category: JobsSecurityAUncategorized
+  cost: 4
+  exclusive: true
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutSecurityEquipment
+    - !type:CharacterLogicOrRequirement
+      requirements:
+      - !type:CharacterDepartmentRequirement
+        departments:
+          - Security
+      - !type:CharacterJobRequirement
+        jobs:
+          - BlueshieldOfficer
+  items:
+    - SpeedLoaderSpecialRubber
+
+- type: loadout
   id: LoadoutMagazineMagnum
   category: JobsSecurityAUncategorized
   cost: 4


### PR DESCRIPTION
# Description
adds .38 to sec loadout (was missing)

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] add .38 special and .38 special rubber clips and spares
- [x] add localisation

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<h1>Media</h1>
n/a

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: TJohnson
- add: .38 special moon clips to Security loadouts. Revolver enthusiasts rejoice!