### PR TITLE
Removing the HandHeld Power/Atmos Monitors from Loadouts

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/atmosphericTechnician.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/atmosphericTechnician.yml
@@ -28,8 +28,6 @@
   maxItems: 1
   items:
     - type: loadout
-      id: LoadoutAtmosphericTechnicianEquipmentHandHeldAtmosMonitor
-    - type: loadout
       id: LoadoutAtmosphericTechnicianEquipmentBoxInflatable
     - type: loadout
       id: LoadoutAtmosphericTechnicianEquipmentMedkitOxygen

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/chiefEngineer.yml
@@ -30,6 +30,8 @@
     - type: loadout
       id: LoadoutChiefEngineerEquipmentHandHeldAtmosMonitor
     - type: loadout
+      id: LoadoutChiefEngineerEquipmentHandHeldPowerMonitor
+    - type: loadout
       id: LoadoutChiefEngineerEquipmentBoxInflatable
     - type: loadout
       id: LoadoutChiefEngineerEquipmentMedkitOxygen

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/engineeringUncategorized.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/engineeringUncategorized.yml
@@ -25,12 +25,6 @@
 #  maxItems: 1
 #  items:
 #
-- type: characterItemGroup
-  id: LoadoutEngineeringEquipment
-  maxItems: 1
-  items:
-  - type: loadout
-    id: LoadoutHandHeldPowerMonitor
 
 - type: characterItemGroup
   id: LoadoutEngineeringEyes

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/atmosphericTechnician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/atmosphericTechnician.yml
@@ -74,18 +74,6 @@
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutAtmosphericTechnicianEquipmentHandHeldAtmosMonitor
-  category: JobsEngineeringAtmosphericTechnician
-  cost: 2
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutAtmosphericTechnicianEquipment
-  - !type:CharacterJobRequirement
-    jobs:
-    - AtmosphericTechnician
-  items:
-  - HandHeldAtmosMonitor
 
 - type: loadout
   id: LoadoutAtmosphericTechnicianEquipmentBoxInflatable

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/chiefEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/chiefEngineer.yml
@@ -88,6 +88,19 @@
   - HandHeldAtmosMonitor
 
 - type: loadout
+  id: LoadoutChiefEngineerEquipmentHandHeldPowerMonitor
+  category: JobsEngineeringChiefEngineer
+  cost: 2
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutChiefEngineerEquipment
+  - !type:CharacterJobRequirement
+    jobs:
+    - ChiefEngineer
+  items:
+  - HandHeldPowerMonitor
+
+- type: loadout
   id: LoadoutChiefEngineerEquipmentBoxInflatable
   category: JobsEngineeringChiefEngineer
   cost: 0

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/uncategorized.yml
@@ -46,19 +46,6 @@
 # Ears
 
 # Equipment
-- type: loadout
-  id: LoadoutHandHeldPowerMonitor
-  category: JobsEngineeringAAUncategorized
-  cost: 2
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutEngineeringEquipment
-  - !type:CharacterDepartmentRequirement
-    departments:
-    - Engineering
-  items:
-  - HandHeldPowerMonitor
 
 # Eyes
 - type: loadout


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

What the title says. Only the CE can now have either/both

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Blew up someone's bowl of cereal

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Removed the Handheld Power Monitor from All Engineering loadouts
- tweak: Removed the Handheld Atmos Monitor from the Atmospheric Technician loadout
- tweak: Added the Handheld Power Monitor to the Chief Engineer's loadout (CE now has both)
