### PR TITLE
Silly April

### DIFF
--- a/Resources/Locale/en-US/_DEN/traits/speech.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/speech.ftl
@@ -1,3 +1,5 @@
+character-item-group-TraitRaceSounds = Race Sounds
+
 trait-name-VulpkaninSounds = Vulpkanin Sounds
 trait-description-VulpkaninSounds =
     Allows you to use the sounds Vulpkanins have.

--- a/Resources/Prototypes/CharacterItemGroups/Generic/miscTraitGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/miscTraitGroups.yml
@@ -1,5 +1,6 @@
 - type: characterItemGroup
   id: TraitsRaceSounds
+  maxItems: 1
   items:
     - type: loadout
       id: VulpkaninSounds

--- a/Resources/Prototypes/CharacterItemGroups/Generic/miscTraitGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/miscTraitGroups.yml
@@ -7,8 +7,6 @@
     - type: loadout
       id: FelinidSounds
     - type: loadout
-      id: HarpySounds
-    - type: loadout
       id: OniSounds
     - type: loadout
       id: ShadowkinSounds

--- a/Resources/Prototypes/Traits/speech.yml
+++ b/Resources/Prototypes/Traits/speech.yml
@@ -1,7 +1,7 @@
 - type: trait
   id: VulpkaninSounds
   category: TraitsSpeechSounds
-  points: 2
+  points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsRaceSounds
@@ -20,7 +20,7 @@
 - type: trait
   id: FelinidSounds
   category: TraitsSpeechSounds
-  points: 2
+  points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsRaceSounds
@@ -37,28 +37,9 @@
       useSex: true
 
 - type: trait
-  id: HarpySounds
-  category: TraitsSpeechSounds
-  points: 2
-  requirements:
-    - !type:CharacterItemGroupRequirement
-      group: TraitsRaceSounds
-    - !type:CharacterSpeciesRequirement
-      inverted: true
-      species:
-        - Harpy
-  functions:
-    - !type:TraitAddTag
-      tags:
-      - HarpyEmotes
-    - !type:TraitSetAdditionalEmoteSound
-      emoteSound: SoundsHarpy
-      useSex: false
-
-- type: trait
   id: OniSounds
   category: TraitsSpeechSounds
-  points: 2
+  points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsRaceSounds
@@ -77,7 +58,7 @@
 - type: trait
   id: ShadowkinSounds
   category: TraitsSpeechSounds
-  points: 2
+  points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsRaceSounds
@@ -96,7 +77,7 @@
 - type: trait
   id: SiliconSounds
   category: TraitsSpeechSounds
-  points: 2
+  points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsRaceSounds
@@ -115,7 +96,7 @@
 - type: trait
   id: ReptilianSounds
   category: TraitsSpeechSounds
-  points: 2
+  points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsRaceSounds
@@ -134,7 +115,7 @@
 - type: trait
   id: OviniaSounds
   category: TraitsSpeechSounds
-  points: 2
+  points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsRaceSounds
@@ -153,7 +134,7 @@
 - type: trait
   id: FeroxiSounds
   category: TraitsSpeechSounds
-  points: 2
+  points: -2
   requirements:
     - !type:CharacterItemGroupRequirement
       group: TraitsRaceSounds


### PR DESCRIPTION
:cl:
- tweak: Race Sounds no longer give you points. Silly april.
- fix: Fixed Race Sounds not having a localization.
- remove: Remove Harpy Sounds as a trait, pending separation from EVERY RACE SOUND IN THE GAME.