### PR TITLE
Emote Sounds Trait Bugfix + Fix Test Fails

### DIFF
--- a/Content.IntegrationTests/Tests/StoreTests.cs
+++ b/Content.IntegrationTests/Tests/StoreTests.cs
@@ -77,7 +77,8 @@ public sealed class StoreTests
             var mind = mindSystem.CreateMind(null);
             mindSystem.TransferTo(mind, human, mind: mind);
 
-            FixedPoint2 originalBalance = 20;
+            // Ensure this is higher than the cost of the most expensive TC item
+            FixedPoint2 originalBalance = 1000;
             uplinkSystem.AddUplink(human, originalBalance, null, true);
 
             var storeComponent = entManager.GetComponent<StoreComponent>(pda);

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -440,8 +440,8 @@ public sealed partial class HumanoidCharacterProfile : ICharacterProfile
             && LoadoutPreferences.SequenceEqual(other.LoadoutPreferences)
             && Appearance.MemberwiseEquals(other.Appearance)
             && FlavorText == other.FlavorText
-            && CDCharacterRecords != null && other.CDCharacterRecords != null &&
-                CDCharacterRecords.MemberwiseEquals(other.CDCharacterRecords);
+            && (CDCharacterRecords == null || other.CDCharacterRecords == null
+                || CDCharacterRecords.MemberwiseEquals(other.CDCharacterRecords));
     }
 
     public void EnsureValid(ICommonSession session, IDependencyCollection collection)

--- a/Resources/Locale/en-US/_DEN/loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/_DEN/loadouts/itemgroups.ftl
@@ -1,0 +1,2 @@
+# Traits
+character-item-group-TraitsRaceSounds = Species Sounds

--- a/Resources/Locale/en-US/_DEN/markings/reptilianandvulpkanin.ftl
+++ b/Resources/Locale/en-US/_DEN/markings/reptilianandvulpkanin.ftl
@@ -2,7 +2,7 @@
 marking-ReptilianSharpCobraHood-sharp_cobra_hood = Base
 marking-ReptilianSharpCobraHood-sharp_cobra_hood_overlay = Inner
 
-#New Sergal
+# New Sergal
 marking-EarsCheesegal=  Sergal Ears
 marking-EarsCheesegal-sergears-1=  External
 marking-EarsCheesegal-sergears-2=  Internal
@@ -13,7 +13,7 @@ marking-TailCheesegal =  Sergal Tail
 marking-TailCheesegal-sergtail-1 =  Primary
 marking-TailCheesegal-sergtail-2 =  Secondary
 
-#These ones are for the chestfluff and tail
+# These ones are for the chestfluff and tail
 marking-TailBrushtip =  Brushed tip tail
 marking-TailBrushtip-brushtiptail =  Primary
 marking-TailBrushtip-brushtiptail2 =  Tail Tip

--- a/Resources/Locale/en-US/_DEN/traits/categories.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/categories.ftl
@@ -1,0 +1,1 @@
+trait-category-TraitsSpeechSounds = Voice

--- a/Resources/Locale/en-US/_DV/datasets/names/oni.ftl
+++ b/Resources/Locale/en-US/_DV/datasets/names/oni.ftl
@@ -1,16 +1,16 @@
 ## Male, First
-#陽
+# 陽
 names-oni-last-male-dataset-1 = Kiyoshi
-#明
+# 明
 names-oni-last-male-dataset-2 = Satoshi
-#光
+# 光
 names-oni-last-male-dataset-3 = Teru
 names-oni-last-male-dataset-4 = Hiroshi
-#天
+# 天
 names-oni-last-male-dataset-5 = Takashi
-#永一
+# 永一
 names-oni-last-male-dataset-6 = Eeichi
-#永一朗
+# 永一朗
 names-oni-last-male-dataset-7 = Eeichirou
 names-oni-last-male-dataset-8 = Kyousaburou
 names-oni-last-male-dataset-9 = Tsutomu
@@ -20,35 +20,35 @@ names-oni-last-male-dataset-12 = Kenji
 names-oni-last-male-dataset-13 = Kenichi
 names-oni-last-male-dataset-14 = Susumu
 names-oni-last-male-dataset-15 = Kyounosuke
-#Mars
+# Mars
 names-oni-last-male-dataset-16 = Suisei
-#Reference
+# Reference
 names-oni-last-male-dataset-17 = Shuten
 
 ## Female, First
-#星
+# 星
 names-oni-last-female-dataset-1 = Akari
 names-oni-last-female-dataset-2 = Kira
 names-oni-last-female-dataset-3 = Kirameki
-#陽
+# 陽
 names-oni-last-female-dataset-4 = Aki
 names-oni-last-female-dataset-5 = Akiho
 names-oni-last-female-dataset-6 = Akimi
-#明
+# 明
 names-oni-last-female-dataset-7 = Akashi
 names-oni-last-female-dataset-8 = Saya
-#月
+# 月
 names-oni-last-female-dataset-9 = Aporo
 names-oni-last-female-dataset-10 = Arute
 names-oni-last-female-dataset-11 = Meguru
-#天
+# 天
 names-oni-last-female-dataset-12 = Tiara
 names-oni-last-female-dataset-13 = Suisei
-#水
+# 水
 names-oni-last-female-dataset-14 = Io
 names-oni-last-female-dataset-15 = Aoi
 names-oni-last-female-dataset-16 = Mizu
-#epic references
+# epic references
 names-oni-last-female-dataset-17 = Shuten
 names-oni-last-female-dataset-18 = Suika
 

--- a/Resources/Locale/en-US/markings/anthro.ftl
+++ b/Resources/Locale/en-US/markings/anthro.ftl
@@ -49,6 +49,10 @@ marking-SnoutFWolfAlt-snout_fwolfalt = Wolf Snout Alt F
 marking-SnoutWolfAlt = Wolf Snout Alt
 marking-SnoutWolfAlt-snout_wolfalt = Wolf Snout Alt
 
+marking-SnoutSCanid = Canid Snout S
+marking-SnoutSCanid-snout_scanid_primary = Primary
+marking-SnoutSCanid-snout_scanid_secondary = Secondary
+
 marking-SnoutFSCanid = Canid Snout FS
 marking-SnoutFSCanid-snout_fscanid_primary = Canid Snout FS (Primary)
 marking-SnoutFSCanid-snout_fscanid_secondary = Canid Snout FS (Secondary)
@@ -533,8 +537,15 @@ marking-TailSevenKitsune-m_tail_sevenkitsune_FRONT_primary = Kitsune, 7 Tail (Pr
 marking-TailSevenKitsune-m_tail_sevenkitsune_FRONT_secondary = Kitsune, 7 Tail (Secondary)
 marking-TailSevenKitsune = Kitsune, 7 Tail
 
-marking-TailSharkNoFin_tail_sharknofin_BEHIND_primary = Shark Tail w/o Fin
-marking-TailSharkNoFin_tail_sharknofin_FRONT_primary = Shark Tail w/o Fin
+marking-TailSharkADT-shark_tail = Tail
+marking-TailSharkADT-shark_fin = Fin
+marking-TailSharkADT = Shark Tail Alt
+
+marking-TailShark-m_tail_shark_FRONT_primary = Tail
+marking-TailShark = Shark Tail
+
+marking-TailSharkNoFin-tail_sharknofin_BEHIND_primary = Shark Tail w/o Fin
+marking-TailSharkNoFin-tail_sharknofin_FRONT_primary = Shark Tail w/o Fin
 marking-TailSharkNoFin = Shark Tail w/o Fin
 
 marking-TailShepherd-m_tail_sheperd_BEHIND_secondary = German Shepherd (Primary)

--- a/Resources/Prototypes/CharacterItemGroups/Generic/miscTraitGroups.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/miscTraitGroups.yml
@@ -1,21 +1,21 @@
 - type: characterItemGroup
   id: TraitsRaceSounds
   items:
-    - type: loadout
+    - type: trait
       id: VulpkaninSounds
-    - type: loadout
+    - type: trait
       id: FelinidSounds
-    - type: loadout
+    - type: trait
       id: HarpySounds
-    - type: loadout
+    - type: trait
       id: OniSounds
-    - type: loadout
+    - type: trait
       id: ShadowkinSounds
-    - type: loadout
+    - type: trait
       id: SiliconSounds
-    - type: loadout
+    - type: trait
       id: ReptilianSounds
-    - type: loadout
+    - type: trait
       id: OviniaSounds
-    - type: loadout
+    - type: trait
       id: FeroxiSounds

--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -29,6 +29,7 @@
     - TraitsSpeechUncategorized
     - TraitsSpeechAccents
     - TraitsSpeechLanguages
+    - TraitsSpeechSounds
 
 - type: traitCategory
   id: TraitsSpeechUncategorized


### PR DESCRIPTION
# Description

fixes errors in a few tests as well as the group exclusivity in emote sound traits

---

# Changelog

:cl:
- fix: Localization fixes for a few markings and the emote sound trait group.
- fix: You can now only choose one species emote sound trait.
- tweak: Moved emote sound traits to the Speech trait category.