### PR TITLE
Fix Saving Prefered Quick Store Item Locations (space-wizards/space-station-14#32480)

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -736,7 +736,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
     private void OnSaveItemLocation(StorageSaveItemLocationEvent msg, EntitySessionEventArgs args)
     {
-        if (!ValidateInput(args, msg.Storage, msg.Item, out var player, out var storage, out var item, held: true))
+        if (!ValidateInput(args, msg.Storage, msg.Item, out var player, out var storage, out var item))
             return;
 
         SaveItemLocation(storage!, item.Owner);


### PR DESCRIPTION
# Description
Comes from: space-wizards/space-station-14#32480

Upstream/downstream cherry-pick that fixes item saving. Sometimes bound to Ctrl+I, pressing it over an item in an inventory saves that location for when the item is placed into the bag by clicking on it or quick equipped (Shift+E), but it was broken for a while.

_This was also submitted to upstream (Simple-Station/Einstein-Engines#2484) but I'm an impatient one and I use this a lot._

# Changelog

:cl:
- fix: Saving item locations are working again