### PR TITLE
Minor Ftl Fix

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -379,10 +379,6 @@
         key: KnockedDown
         time: 0.75
         type: Remove
-      - !type:GenericStatusEffect
-        key: Adrenaline # Guess what epinephrine is...
-        component: IgnoreSlowOnDamage
-        time: 5 # lingers less than hivemind reagent to give it a niche
       - !type:MovespeedModifier # Goob edit
         walkSpeedModifier: 1.1
         sprintSpeedModifier: 1.1

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -48,10 +48,6 @@
         key: Drowsiness
         time: 10
         type: Remove
-      - !type:GenericStatusEffect # goob edit
-        key: Adrenaline
-        component: IgnoreSlowOnDamage
-        time: 5
       - !type:ChemAddMoodlet # Floof - Add mood-system addiction
         moodPrototype: AmphetamineBenefit
         guidebookShowEffectName: true
@@ -120,10 +116,6 @@
         messages: ["ephedrine-effect-tight-pain", "ephedrine-effect-heart-pounds"]
         type: Local
         probability: 0.05
-      - !type:GenericStatusEffect # goob edit
-        key: Adrenaline
-        component: IgnoreSlowOnDamage
-        time: 5
     Medicine:
       effects:
       - !type:ResetNarcolepsy
@@ -187,10 +179,6 @@
         key: Drowsiness
         time: 10
         type: Remove
-      - !type:GenericStatusEffect # goob edit
-        key: Adrenaline
-        component: IgnoreSlowOnDamage
-        time: 5
     Medicine:
       metabolismRate: 1.0
       effects:


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

This removes the GenericStatusEffect Adrenaline from a few chemicals because that effect doesn't actually exist here, it apparently was leftover from this [commit](https://github.com/TheDenSS14/TheDen/commit/9bae47bc6d3e44fba8b86e18c78e6b0f3fe00ed6) and just was left unaddressed

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Remove the Stuff


# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: SleepyScarecrow
- fix: Removed the empty adrenaline status effect from a few chems
