### PR TITLE
New Hunger and Thirst Rates

### DIFF
--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -27,6 +27,13 @@ public sealed partial class HungerComponent : Component
     public float BaseDecayRate = 0.003f;
 
     /// <summary>
+    /// A flat multiplier applied to BaseDecayRate.
+    /// This shouldn't change, ideally; this is supposed to make species hunger rates more intuitive to code.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float DecayRateMultiplier = 1.0f;
+
+    /// <summary>
     /// The actual amount at which <see cref="CurrentHunger"/> decays.
     /// Affected by <seealso cref="CurrentThreshold"/>
     /// </summary>

--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class HungerComponent : Component
     /// The base amount at which <see cref="CurrentHunger"/> decays.
     /// </summary>
     [DataField("baseDecayRate"), ViewVariables(VVAccess.ReadWrite)]
-    public float BaseDecayRate = 0.003f;
+    public float BaseDecayRate = 50.0f / (45 * 60); // One tier every 45 minutes
 
     /// <summary>
     /// A flat multiplier applied to BaseDecayRate.

--- a/Content.Shared/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Shared/Nutrition/Components/ThirstComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class ThirstComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("baseDecayRate")]
     [AutoNetworkedField]
-    public float BaseDecayRate = 0.015f;
+    public float BaseDecayRate = 150.0f / (35 * 60); // One tier every 35 minutes
 
     /// <summary>
     /// A flat multiplier applied to BaseDecayRate.

--- a/Content.Shared/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Shared/Nutrition/Components/ThirstComponent.cs
@@ -3,6 +3,7 @@ using Content.Shared.Nutrition.EntitySystems;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
 
 namespace Content.Shared.Nutrition.Components;
 
@@ -15,6 +16,13 @@ public sealed partial class ThirstComponent : Component
     [DataField("baseDecayRate")]
     [AutoNetworkedField]
     public float BaseDecayRate = 0.015f;
+
+    /// <summary>
+    /// A flat multiplier applied to BaseDecayRate.
+    /// This shouldn't change, ideally; this is supposed to make species hunger rates more intuitive to code.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float DecayRateMultiplier = 1.0f;
 
     [ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]
@@ -65,6 +73,20 @@ public sealed partial class ThirstComponent : Component
         {ThirstThreshold.Thirsty, "Thirsty"},
         {ThirstThreshold.Parched, "Parched"},
         {ThirstThreshold.Dead, "Parched"},
+    };
+
+    /// <summary>
+    /// A dictionary relating ThirstThreshold to how much they modify <see cref="BaseDecayRate"/>.
+    /// </summary>
+    [DataField("hungerThresholdDecayModifiers", customTypeSerializer: typeof(DictionarySerializer<ThirstThreshold, float>))]
+    [AutoNetworkedField]
+    public Dictionary<ThirstThreshold, float> ThirstThresholdDecayModifiers = new()
+    {
+        {ThirstThreshold.OverHydrated, 1.2f},
+        {ThirstThreshold.Okay, 1.0f },
+        {ThirstThreshold.Thirsty, 0.8f },
+        {ThirstThreshold.Parched, 0.6f},
+        {ThirstThreshold.Dead, 0f}
     };
 }
 

--- a/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
@@ -158,7 +158,7 @@ public sealed class HungerSystem : EntitySystem
 
         if (component.HungerThresholdDecayModifiers.TryGetValue(component.CurrentThreshold, out var modifier))
         {
-            component.ActualDecayRate = component.BaseDecayRate * modifier;
+            component.ActualDecayRate = component.BaseDecayRate * component.DecayRateMultiplier * modifier;
         }
 
         component.LastThreshold = component.CurrentThreshold;

--- a/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
@@ -177,36 +177,18 @@ public sealed class ThirstSystem : EntitySystem
         var ev = new MoodEffectEvent("Thirst" + component.CurrentThirstThreshold);
         RaiseLocalEvent(uid, ev);
 
-        switch (component.CurrentThirstThreshold)
+        if (component.CurrentThirstThreshold == ThirstThreshold.Dead)
+            return;
+
+        component.ActualDecayRate = component.BaseDecayRate * component.DecayRateMultiplier;
+        if (!component.ThirstThresholdDecayModifiers.TryGetValue(component.CurrentThirstThreshold,
+            out var decayRateModifier))
         {
-            case ThirstThreshold.OverHydrated:
-                component.LastThirstThreshold = component.CurrentThirstThreshold;
-                component.ActualDecayRate = component.BaseDecayRate * 1.2f;
-                return;
-
-            case ThirstThreshold.Okay:
-                component.LastThirstThreshold = component.CurrentThirstThreshold;
-                component.ActualDecayRate = component.BaseDecayRate;
-                return;
-
-            case ThirstThreshold.Thirsty:
-                // Same as okay except with UI icon saying drink soon.
-                component.LastThirstThreshold = component.CurrentThirstThreshold;
-                component.ActualDecayRate = component.BaseDecayRate * 0.8f;
-                return;
-            case ThirstThreshold.Parched:
-                _movement.RefreshMovementSpeedModifiers(uid);
-                component.LastThirstThreshold = component.CurrentThirstThreshold;
-                component.ActualDecayRate = component.BaseDecayRate * 0.6f;
-                return;
-
-            case ThirstThreshold.Dead:
-                return;
-
-            default:
-                Log.Error($"No thirst threshold found for {component.CurrentThirstThreshold}");
-                throw new ArgumentOutOfRangeException($"No thirst threshold found for {component.CurrentThirstThreshold}");
+            Log.Error($"No thirst threshold found for {component.CurrentThirstThreshold}");
+            throw new ArgumentOutOfRangeException($"No thirst threshold found for {component.CurrentThirstThreshold}");
         }
+
+        component.ActualDecayRate *= decayRateModifier;
     }
 
     public override void Update(float frameTime)

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -11,7 +11,7 @@
   - type: HumanoidAppearance
     species: Arachnid
   - type: Hunger
-    baseDecayRate: 0.00125 # Spiders have slow metabolisms all things considered, so I decided to just make their hunger drain slower.
+    decayRateMultiplier: 0.8 # Spiders have slow metabolisms all things considered, so I decided to just make their hunger drain slower.
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Thirst
   - type: Sericulture

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -8,9 +8,9 @@
   - type: HumanoidAppearance
     species: Diona
   - type: Hunger
-    baseDecayRate: 0.001
+    decayRateMultiplier: 0.75
   - type: Thirst
-    baseDecayRate: 0.0075
+    decayRateMultiplier: 0.75
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Icon
     sprite: Mobs/Species/Diona/parts.rsi

--- a/Resources/Prototypes/_DEN/Entities/Mobs/Species/ovinia.yml
+++ b/Resources/Prototypes/_DEN/Entities/Mobs/Species/ovinia.yml
@@ -127,9 +127,9 @@
   - type: Flammable
     fireStackIncreaseMultiplier: .75 #wool isnt flammable
   - type: Hunger
-    baseDecayRate: 0.00075 #25% slower than normal (chewin they cud)
+    decayRateMultiplier: 0.75 #25% slower than normal (chewin they cud)
   - type: Thirst
-    baseDecayRate: 0.01125 # 25% slower than normal
+    decayRateMultiplier: 0.75 # 25% slower than normal
   - type: Carriable
 
 

--- a/Resources/Prototypes/_DEN/Traits/disabilities.yml
+++ b/Resources/Prototypes/_DEN/Traits/disabilities.yml
@@ -20,4 +20,4 @@
     - !type:TraitReplaceComponent
       components:
         - type: Hunger
-          baseDecayRate: 0.005
+          decayRateMultiplier: 1.33

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -11,7 +11,7 @@
     - HeadTop
 
   - type: Hunger
-    baseDecayRate: 0.005 # Floofstation, changed from 0.0467 so it's actually 33% faster. Original number came from DeltaV, which has a much higher base hunger rate. Original comment: needs to eat more to survive
+    decayRateMultiplier: 1.33
   - type: Thirst
 
   - type: Carriable

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
@@ -12,7 +12,7 @@
   - type: Inventory
     speciesId: feroxi
   - type: Thirst
-    baseDecayRate: 0.03
+    decayRateMultiplier: 2.0
   - type: Icon
     sprite: _DV/Mobs/Species/Feroxi/parts.rsi
     state: full

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -9,7 +9,7 @@
     species: Rodentia
   - type: Thirst
   - type: Hunger
-    baseDecayRate: 0.005 # Floofstation, changed from 0.0467 so it's actually 33% faster. Original number came from DeltaV, which has a much higher base hunger rate
+    decayRateMultiplier: 1.33
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Inventory
     speciesId: rodentia

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
@@ -8,7 +8,7 @@
   - type: HumanoidAppearance
     species: Vulpkanin
   - type: Hunger
-    baseDecayRate: 0.00375 # 25% more than default
+    decayRateMultiplier: 1.25
   - type: Carriable # Carrying system from nyanotrasen.
   - type: Inventory # Allows vulps to wear properly shaped helmets
     speciesId: vulpkanin

--- a/Resources/Prototypes/_EE/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Species/tajaran.yml
@@ -5,7 +5,7 @@
   abstract: true
   components:
   - type: Hunger
-    baseDecayRate: 0.00375 # 25% more than default
+    decayRateMultiplier: 1.25
   - type: Thirst
   - type: Sprite
     scale: 0.8, 0.8


### PR DESCRIPTION
# Description

hunger drops at the rate of approx. 1 tier every 45 minutes, though this will be skewed by the fact most furry species have increased hunger rate

thirst drops at the rate of approx. 1 tier every 35 minutes

made hunger/thirst adjustment more intuitive on the back end

animal hunger rates untouched idgaf

---

# Changelog

:cl:
- tweak: Hunger and thirst rates adjusted again. Expect to visit the kitchen or bar at least once per hour.