### PR TITLE
Various Kitsune Fixes

### DIFF
--- a/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
+++ b/Content.Server/Humanoid/Systems/HumanoidAppearanceSystem.cs
@@ -20,43 +20,6 @@ public sealed partial class HumanoidAppearanceSystem : SharedHumanoidAppearanceS
         SubscribeLocalEvent<HumanoidAppearanceComponent, GetVerbsEvent<Verb>>(OnVerbsRequest);
     }
 
-    // this was done enough times that it only made sense to do it here
-
-    /// <summary>
-    ///     Clones a humanoid's appearance to a target mob, provided they both have humanoid components.
-    /// </summary>
-    /// <param name="source">Source entity to fetch the original appearance from.</param>
-    /// <param name="target">Target entity to apply the source entity's appearance to.</param>
-    /// <param name="sourceHumanoid">Source entity's humanoid component.</param>
-    /// <param name="targetHumanoid">Target entity's humanoid component.</param>
-    public void CloneAppearance(EntityUid source, EntityUid target, HumanoidAppearanceComponent? sourceHumanoid = null,
-        HumanoidAppearanceComponent? targetHumanoid = null)
-    {
-        if (!Resolve(source, ref sourceHumanoid) || !Resolve(target, ref targetHumanoid))
-        {
-            return;
-        }
-
-        targetHumanoid.Species = sourceHumanoid.Species;
-        targetHumanoid.SkinColor = sourceHumanoid.SkinColor;
-        targetHumanoid.EyeColor = sourceHumanoid.EyeColor;
-        targetHumanoid.Age = sourceHumanoid.Age;
-        targetHumanoid.Height = sourceHumanoid.Height;
-        targetHumanoid.Width = sourceHumanoid.Width;
-        SetSex(target, sourceHumanoid.Sex, false, targetHumanoid);
-        targetHumanoid.CustomBaseLayers = new(sourceHumanoid.CustomBaseLayers);
-        targetHumanoid.MarkingSet = new(sourceHumanoid.MarkingSet);
-
-        targetHumanoid.Gender = sourceHumanoid.Gender;
-        if (TryComp<GrammarComponent>(target, out var grammar))
-        {
-            grammar.Gender = sourceHumanoid.Gender;
-        }
-
-        targetHumanoid.LastProfileLoaded = sourceHumanoid.LastProfileLoaded;
-        Dirty(target, targetHumanoid);
-    }
-
     /// <summary>
     ///     Removes a marking from a humanoid by ID.
     /// </summary>

--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -61,7 +61,7 @@ public sealed class VocalSystem : EntitySystem
 
     private void OnSexChanged(EntityUid uid, VocalComponent component, SexChangedEvent args)
     {
-        LoadSounds(uid, component);
+        LoadSounds(uid, component, args.NewSex);
     }
 
     private void OnEmote(EntityUid uid, VocalComponent component, ref EmoteEvent args)

--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -6,9 +6,11 @@ using Content.Shared._DV.Abilities.Kitsune;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Damage.Components;
+using Content.Shared.Humanoid;
 using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Systems;
 using Content.Shared.Polymorph;
+using Content.Shared.Speech.Components;
 using Robust.Shared.Player;
 
 namespace Content.Server._DV.Abilities.Kitsune;
@@ -38,6 +40,7 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
             return;
 
         newKitsune.Color = oldKitsune.Color;
+        newKitsune.ColorLight = oldKitsune.ColorLight;
         _appearance.SetData(newEntity, KitsuneColorVisuals.Color, newKitsune.Color ?? Color.Orange);
 
         // Ensure that the fox fire action state is transferred properly.
@@ -52,6 +55,9 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
             foxfire.Kitsune = newEntity;
             Dirty(fireUid, foxfire);
         }
+
+        if (TryComp<HumanoidAppearanceComponent>(oldEntity, out var humanoidAppearance))
+            RaiseLocalEvent(newEntity, new SexChangedEvent(Sex.Unsexed, humanoidAppearance.Sex));
 
         // Code after this point will not run when reverting to human form.
         if (HasComp<KitsuneFoxComponent>(oldEntity))

--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -76,7 +76,7 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
             _faction.AddFactions(newEntity, factions.Factions);
         }
 
-        _popup.PopupEntity(Loc.GetString("kitsune-popup-morph-message-others", ("entity", args.NewEntity)), args.NewEntity, Filter.PvsExcept(args.NewEntity), true);
+        _popup.PopupEntity(Loc.GetString("kitsune-popup-morph-message-others", ("target", args.NewEntity)), args.NewEntity, Filter.PvsExcept(args.NewEntity), true); // Floof - M3739 - #1030
         _popup.PopupEntity(Loc.GetString("kitsune-popup-morph-message-user"), args.NewEntity, args.NewEntity);
     }
 

--- a/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
+++ b/Content.Shared/Humanoid/SharedHumanoidAppearanceSystem.cs
@@ -151,6 +151,36 @@ public abstract class SharedHumanoidAppearanceSystem : EntitySystem
     }
 
     /// <summary>
+    ///     Clones a humanoid's appearance to a target mob, provided they both have humanoid components.
+    /// </summary>
+    /// <param name="source">Source entity to fetch the original appearance from.</param>
+    /// <param name="target">Target entity to apply the source entity's appearance to.</param>
+    /// <param name="sourceHumanoid">Source entity's humanoid component.</param>
+    /// <param name="targetHumanoid">Target entity's humanoid component.</param>
+    public void CloneAppearance(EntityUid source, EntityUid target, HumanoidAppearanceComponent? sourceHumanoid = null,
+        HumanoidAppearanceComponent? targetHumanoid = null)
+    {
+        if (!Resolve(source, ref sourceHumanoid) || !Resolve(target, ref targetHumanoid))
+            return;
+
+        targetHumanoid.Species = sourceHumanoid.Species;
+        targetHumanoid.SkinColor = sourceHumanoid.SkinColor;
+        targetHumanoid.EyeColor = sourceHumanoid.EyeColor;
+        targetHumanoid.Age = sourceHumanoid.Age;
+        SetSex(target, sourceHumanoid.Sex, false, targetHumanoid);
+        targetHumanoid.CustomBaseLayers = new(sourceHumanoid.CustomBaseLayers);
+        targetHumanoid.MarkingSet = new(sourceHumanoid.MarkingSet);
+
+        targetHumanoid.Gender = sourceHumanoid.Gender;
+        if (TryComp<GrammarComponent>(target, out var grammar))
+            grammar.Gender = sourceHumanoid.Gender;
+
+        targetHumanoid.LastProfileLoaded = sourceHumanoid.LastProfileLoaded; // DeltaV - let paradox anomaly be cloned
+
+        Dirty(target, targetHumanoid);
+    }
+
+    /// <summary>
     ///     Sets the visibility for multiple layers at once on a humanoid's sprite.
     /// </summary>
     /// <param name="uid">Humanoid mob's UID</param>

--- a/Content.Shared/_DV/Abilities/Kitsune/KitsuneComponent.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/KitsuneComponent.cs
@@ -30,6 +30,12 @@ public sealed partial class KitsuneComponent : Component
     [DataField, AutoNetworkedField] public List<EntityUid> ActiveFoxFires = [];
 
     [DataField, AutoNetworkedField] public Color? Color;
+
+    /// <summary>
+    /// Represents a light coming from a light source.
+    /// As such it has its value maximised while not touching hue or saturation.
+    /// </summary>
+    [DataField, AutoNetworkedField] public Color? ColorLight;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
@@ -28,6 +28,22 @@ public abstract class SharedKitsuneSystem : EntitySystem
         if (TryComp<HumanoidAppearanceComponent>(ent, out var humanComp))
         {
             ent.Comp.Color = humanComp.EyeColor;
+
+            var lightColor = ent.Comp.Color.Value;
+            var max = MathF.Max(lightColor.R, MathF.Max(lightColor.G, lightColor.B));
+            // Don't let it divide by 0
+            if (max == 0)
+            {
+                lightColor = new Color(1, 1, 1, lightColor.A);
+            }
+            else
+            {
+                var factor = 1 / max;
+                lightColor.R *= factor;
+                lightColor.G *= factor;
+                lightColor.B *= factor;
+            }
+            ent.Comp.ColorLight = lightColor;
         }
     }
 
@@ -62,9 +78,7 @@ public abstract class SharedKitsuneSystem : EntitySystem
         Dirty(fireEnt, fireComp);
         Dirty(ent);
 
-        _light.SetColor(fireEnt, ent.Comp.Color ?? Color.Purple);
-
-        args.Handled = true;
+        _light.SetColor(fireEnt, ent.Comp.ColorLight ?? Color.Purple);
     }
 
     private void OnFoxfireShutdown(Entity<FoxfireComponent> ent, ref ComponentShutdown args)

--- a/Resources/Locale/en-US/deltav/actions/kitsune.ftl
+++ b/Resources/Locale/en-US/deltav/actions/kitsune.ftl
@@ -1,5 +1,7 @@
 petting-success-soft-floofy-kitsune = You gently pat {THE($target)}
-kitsune-popup-morph-message-other = {$target} shifts their form
+kitsune-popup-morph-message-others = {$target} shifts their form
 kitsune-popup-morph-message-user = You shift your form
 kitsune-popup-cant-morph-stamina = You are too exhausted!
 fox-no-hands = You can't make a wisp without a hand
+# Floof - M3739 - #1030 - fox-no-charges
+fox-no-charges = You can't make another wisp!

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -88,6 +88,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       types:
         Slash: -0.5

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -31,6 +31,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       types:
         Heat: -7.5
@@ -82,6 +83,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       types:
         Heat: -15
@@ -122,6 +124,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       groups:
         Brute: -22.5 # 7.5 for each type in the group
@@ -171,6 +174,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       groups:
         Brute: -45 # 15 for each type in the group
@@ -209,6 +213,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       types:
         Bloodloss: -2.5 #lowers bloodloss damage, was .5, buffed due to Limb Damage Changes
@@ -245,6 +250,7 @@
     - type: Healing
       damageContainers:
         - Biological
+        - BiologicalMetaphysical # Floof - M3739 - #1006
       damage:
         groups:
           Brute: 5 # Tourniquets HURT!
@@ -275,6 +281,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # Floof - M3739 - #1006
     damage:
       types:
         Slash: -7.5

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -729,9 +729,11 @@
         - type: ShowHealthBars
           damageContainers:
           - Biological
+          - BiologicalMetaphysical # Floof - M3739 - #1006
         - type: ShowHealthIcons
           damageContainers:
           - Biological
+          - BiologicalMetaphysical # Floof - M3739 - #1006
 
 - type: trait
   id: CyberEyesDiagnostic
@@ -794,9 +796,11 @@
         - type: ShowHealthIcons
           damageContainers:
           - Biological
+          - BiologicalMetaphysical # Floof - M3739 - #1006
         - type: ShowHealthBars
           damageContainers:
           - Biological
+          - BiologicalMetaphysical # Floof - M3739 - #1006
           - Inorganic
           - Silicon
 

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/kitsune.yml
@@ -10,7 +10,7 @@
       fix1:
         shape: !type:PhysShapeCircle
           radius: 0.35
-        density: 50
+        density: 140 # Floof - M3739 - #981 - Was originally 50. Later found out from SolStar that this was unintended. Given the same density as the Felinids.
         restitution: 0.0
         mask:
         - MobMask

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Species/kitsune.yml
@@ -41,4 +41,6 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+  - type: TimedDespawn # Floof - M3739 - #1030 - poor man's cooldown, sadge. Maybe someday I'll do this a better way.
+    lifetime: 120
   - type: InteractionOutline


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Merge of a handful of Kitsune fixes from Floof (plus another that was also a part of kitsune fixes), all linked below:
- https://github.com/Fansana/floofstation1/pull/981
- https://github.com/Fansana/floofstation1/pull/1006
- https://github.com/Fansana/floofstation1/pull/1030

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: Various Floof Contributions
- fix: Cloning should now properly replicate the original body's appearance.
- fix: Female kitsune should now no longer laugh like a man when in fox form.
- fix: Kitsune foxfire will now emit light, regardless of how dark the color is.
- fix: Kitsune should now no longer weigh as much as a feather.
- fix: Kitsune can now be healed by topicals.
- fix: Kitsune can no longer place infinite foxfires.
- fix: You will now see the proper message when a kitsune shifts into fox form.