### PR TITLE
Small Tweaks and Fixes

### DIFF
--- a/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.KravMaga.cs
+++ b/Content.Shared/_Goobstation/MartialArts/SharedMartialArtsSystem.KravMaga.cs
@@ -81,7 +81,7 @@ public abstract partial class SharedMartialArtsSystem
             case KravMagaMoves.LegSweep:
                 if(_netManager.IsClient)
                     return;
-                _stun.TryParalyze(hitEntity, TimeSpan.FromSeconds(4), true);
+                _stun.TryKnockdown(hitEntity, TimeSpan.FromSeconds(4), true);
                 break;
             case KravMagaMoves.NeckChop:
                 var comp = EnsureComp<KravMagaSilencedComponent>(hitEntity);

--- a/Resources/Locale/en-US/_DEN/paradox-anomaly/paradox-anomaly.ftl
+++ b/Resources/Locale/en-US/_DEN/paradox-anomaly/paradox-anomaly.ftl
@@ -1,1 +1,1 @@
-examine-paradox-anomaly-message = [color=purple]{CAPITALIZE(SUBJECT($entity))} feel off.[/color]
+examine-paradox-anomaly-message = [color=purple]{CAPITALIZE(SUBJECT($entity))} feels off.[/color]

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon_base.yml
@@ -331,6 +331,8 @@
     - type: FootPrints
     - type: Carriable
     - type: LayingDown
+    - type: RMCSetPose
+    - type: ModifyUndies  # FLOOF Add
 
 
 - type: damageModifierSet

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -385,6 +385,9 @@
   - type: PhysicalComposition
     materialComposition:
       Diamond: 100
+  - type: Tag
+    tags:
+     - Diamond
 
 - type: entity
   parent: MaterialDiamond

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -363,7 +363,7 @@
     damage:
       types:
         Shock: 3
-    heavyRateModifier: 3
+    heavyRateModifier: 1.5
     heavyRangeModifier: 1.25
     heavyDamageBaseModifier: 3
     maxTargets: 1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -91,10 +91,10 @@
     damage:
       types:
         Slash: 12
-    heavyRateModifier: 4
+    heavyRateModifier: 1
     heavyRangeModifier: 2.75 #Superior Japanese folded steel
     heavyDamageBaseModifier: 2
-    heavyStaminaCost: 10
+    heavyStaminaCost: 8.5
     maxTargets: 1
     angle: 20
   - type: DamageOtherOnHit
@@ -197,7 +197,7 @@
         Slash: 19
         Blunt: 1
     bluntStaminaDamageFactor: 25.0
-    heavyRateModifier: 4
+    heavyRateModifier: 1
     heavyRangeModifier: 1.85
     heavyDamageBaseModifier: 1
     heavyStaminaCost: 10

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -44,6 +44,10 @@
       - Sheet
       - RawMaterial
       - Ingot
+      - Wooden
+      - ClothMade
+      - Gauze
+      - Metal
   - type: AmbientSound
     enabled: false
     volume: 5

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -857,6 +857,7 @@
       - ClothMade
       - Gauze
       - Metal
+      - Diamond
   - type: GuideHelp
     guides:
     - Robotics
@@ -1214,6 +1215,7 @@
       - ClothMade
       - Gauze
       - Metal
+      - Diamond
 
 - type: entity
   id: AmmoTechFab

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -319,6 +319,7 @@
       - ClothMade
       - Gauze
       - Metal
+      - Diamond
   - type: Lathe
     idleState: icon
     runningState: building

--- a/Resources/Prototypes/_DEN/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Weapons/Melee/sword.yml
@@ -26,7 +26,7 @@
     soundHit:
       collection: MetalThud
   - type: DamageOtherOnHit
-    staminaCost: 30
+    staminaCost: 20
   - type: MeleeRequiresWield
   - type: EmbeddableProjectile
   - type: EmbedPassiveDamage

--- a/Resources/Prototypes/_Goobstation/MartialArts/kravmaga.yml
+++ b/Resources/Prototypes/_Goobstation/MartialArts/kravmaga.yml
@@ -8,7 +8,7 @@
     icon:
       sprite: _Goobstation/Actions/kravmaga.rsi
       state: legsweep
-      useDelay: 3
+      useDelay: 5 # allows a window of escape and prevents looping
     event: !type:KravMagaActionEvent { }
   - type: KravMagaAction
     configuration: LegSweep

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -571,6 +571,9 @@
   id: Debug
 
 - type: Tag
+  id: Diamond
+
+- type: Tag
   id: Dice
 
 - type: Tag


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Krav Maga's Leg Sweep adjusted to only do knockdown instead of paralysis, as well as a 5 second use delay on it to prevent potential looping, Fixes text for the paradox anomaly examine text to be more grammatically correct, Fixes IPCS not being able to set poses or take off underwear, Makes it so Diamonds should only be able to be inserted in the respective lathes that can use them, Attack speed fixes for katanas and claymores after an old PR fucked them up, Stamina cost for greatsword lowered to 20 from 30.

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Tweaked Krav Maga's leg sweep to have a 5 second use delay instead of 3 and to do a knockdown instead of a complete paralysis.
- tweak: Diamonds should now only be able to be inserted into the respective lathes that use them, security techfab and exosuit fabricator.
- tweak: Stamina cost for heavy swings on Greatsword lowered from 30 to 20.
- fix: Fixed the heavy swing speed for katanas and claymores to be more sensible.
- fix: Fixed IPCs not being able to set poses.
