### PR TITLE
Add Randomize Body Button

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -21,8 +21,12 @@
                                     <LineEdit Name="NameEdit" MinSize="270 0" VerticalAlignment="Center" Margin="5 0 0 0" />
                                     <Button Name="NameRandomize" Text="{Loc 'humanoid-profile-editor-name-random-button'}" />
                                 </BoxContainer>
-                                <Button Name="RandomizeEverything" HorizontalAlignment="Center" HorizontalExpand="False"
+                                <BoxContainer Orientation="Horizontal" Align="Center">
+                                    <Button Name="RandomizeEverything" HorizontalExpand="False"
                                     MaxWidth="256" Text="{Loc 'humanoid-profile-editor-randomize-everything-button'}" />
+                                    <Button Name="RandomizeBodyButton" HorizontalExpand="False"
+                                    MaxWidth="256" Text="{Loc 'humanoid-profile-editor-randomize-body-button'}" />
+                                </BoxContainer>
                                 <RichTextLabel Name="WarningLabel" HorizontalExpand="False" VerticalExpand="True"
                                     MaxWidth="425" HorizontalAlignment="Left" />
                             </BoxContainer>

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -159,6 +159,7 @@ namespace Content.Client.Lobby.UI
             NameEdit.OnTextChanged += args => { SetName(args.Text); };
             NameRandomize.OnPressed += _ => RandomizeName();
             RandomizeEverything.OnPressed += _ => { RandomizeProfile(); };
+            RandomizeBodyButton.OnPressed += _ => { RandomizeBody(); };
             WarningLabel.SetMarkup($"[color=red]{Loc.GetString("humanoid-profile-editor-naming-rules-warning")}[/color]");
 
             #endregion Name
@@ -2048,6 +2049,18 @@ namespace Content.Client.Lobby.UI
         private void SetPreviewRotation(Direction direction)
         {
             SpriteView.OverrideDirection = (Direction) ((int) direction % 4 * 2);
+        }
+
+        private void RandomizeBody()
+        {
+            if (Profile == null)
+            {
+                return;
+            }
+
+            Profile = HumanoidCharacterProfile.RandomBody(Profile);
+            SetProfile(Profile, CharacterSlot);
+            SetDirty();
         }
 
         private void RandomizeName()

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -319,6 +319,22 @@ public sealed partial class HumanoidCharacterProfile : ICharacterProfile
         };
     }
 
+    public static HumanoidCharacterProfile RandomBody(HumanoidCharacterProfile profile)
+    {
+        return new HumanoidCharacterProfile()
+        {
+            Name = profile.Name,
+            Sex = profile.Sex,
+            Age = profile.Age,
+            Gender = profile.Gender,
+            Species = profile.Species,
+            Appearance = HumanoidCharacterAppearance.Random(profile.Species, profile.Sex),
+            Nationality = profile.Nationality,
+            Employer = profile.Employer,
+            Lifepath = profile.Lifepath,
+        };
+    }
+
     public HumanoidCharacterProfile WithName(string name) => new(this) { Name = name };
     public HumanoidCharacterProfile WithFlavorText(string flavorText) => new(this) { FlavorText = flavorText };
     public HumanoidCharacterProfile WithAge(int age) => new(this) { Age = age };

--- a/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/preferences/ui/humanoid-profile-editor.ftl
@@ -1,4 +1,5 @@
 humanoid-profile-editor-randomize-everything-button = Randomize everything
+humanoid-profile-editor-randomize-body-button = Randomize body
 humanoid-profile-editor-name-label = Name:
 humanoid-profile-editor-name-random-button = Randomize
 humanoid-profile-editor-appearance-tab = Appearance


### PR DESCRIPTION
## About the PR
adds a "randomize body" button to the character creator screen, which randomizes your appearance (skin hair eyes etc) and NOTHING ELSE

## Why / Balance
- developer QOL
- kick start a character design if you already have a species in mind

## How to test
- start game in lobby
- click the "randomize body" button to receive a new appearance
- optional: change the name, sex/gender, age, and "lore" settings (nationality/lifepath/employer) and try the button, see that they do not change

## Media
![image](https://github.com/user-attachments/assets/3fe0191c-bd74-4ddf-b6f4-9b4f7c3845e6)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
none

**Changelog**
:cl:
- add: Added a "randomize body" button to the character creator, which will randomize your character's appearance and nothing else.