### PR TITLE
Adding Admin Tools and Changing Aghost Starting Gear

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/satchel.yml
@@ -276,6 +276,9 @@
   components:
   - type: StorageFill
     contents:
-    - id: GasAnalyzer
-    - id: trayScanner
-  - type: Unremoveable
+    - id: DrinkGlass
+    - id: AdminMaterialBox
+    - id: TrashBananaPeel
+    - id: PowerCellMicroreactor
+      amount: 2
+  #- type: Unremoveable # why? makes testing some things pretty annoying, and the PDA is removable

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -84,8 +84,10 @@
 # SPDX-FileCopyrightText: 2025 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 John Willis <143434770+CerberusWolfie@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 KekaniCreates <87507256+KekaniCreates@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Rosycup <178287475+Rosycup@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 MajorMoth <61519600+MajorMoth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Rosycup <***>
+# SPDX-FileCopyrightText: 2025 Rosycup <178287475+Rosycup@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Rosycup <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>
 # SPDX-FileCopyrightText: 2025 Tobias Berger <toby@tobot.dev>
 # SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 sleepyyapril <flyingkarii@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1198,7 +1198,7 @@
   description: If you are not an admin please return this PDA to the nearest admin.
   components:
   - type: Pda
-    id: PassengerIDCard
+    id: CentcomIDCard
   - type: HealthAnalyzer
     scanDelay: 0
   - type: CartridgeLoader
@@ -1206,14 +1206,15 @@
     notificationsEnabled: false
     diskSpace: 10 # DeltaV
     preinstalled:
-      - CrewManifestCartridge
-      - NotekeeperCartridge
-      - NewsReaderCartridge
-      - LogProbeCartridge
-      - SecWatchCartridge # DeltaV: SecWatch replaces WantedList
-      - StockTradingCartridge # Delta-V
-      - NanoChatCartridge # DeltaV
-      - PsiWatchCartridge
+    # den - every cartridge alphabetically
+     - AstroNavCartridge
+     - CrewManifestCartridge
+     - LogProbeCartridge
+     #- MedTekCartridge  # not needed, already has HealthAnalyzer component
+     - NetProbeCartridge
+     - NewsReaderCartridge
+     - NotekeeperCartridge
+     - PsiWatchCartridge
 
 - type: entity
   parent: CentcomPDA

--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -9,23 +9,36 @@
 - type: inventoryTemplate
   id: aghost
   slots:
-    - name: back
-      slotTexture: back
-      slotFlags: BACK
-      slotGroup: SecondHotbar
-      stripTime: 6
-      uiWindowPos: 2,1
-      strippingWindowPos: 2,4
-      displayName: ID
     - name: id
       slotTexture: id
       fullTextureName: template_small
       slotFlags: IDCARD
       slotGroup: SecondHotbar
       stripTime: 6
-      uiWindowPos: 2,2
-      strippingWindowPos: 2,3
+      uiWindowPos: 2,1
+      strippingWindowPos: 2,4
       displayName: ID
+      stripHidden: true
+    - name: belt
+      slotTexture: belt
+      fullTextureName: template_small
+      slotFlags: BELT
+      slotGroup: SecondHotbar
+      stripTime: 6
+      uiWindowPos: 3,1
+      strippingWindowPos: 1,5
+      displayName: Belt
+      stripHidden: true
+    - name: back
+      slotTexture: back
+      fullTextureName: template_small
+      slotFlags: BACK
+      slotGroup: SecondHotbar
+      stripTime: 6
+      uiWindowPos: 3,0
+      strippingWindowPos: 0,5
+      displayName: Back
+      stripHidden: true
 
     # For Pockets to hold stuffs.
     - name: pocket1

--- a/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/aghost_inventory_template.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2024 Sphiral <145869023+SphiraI@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
 # SPDX-FileCopyrightText: 2025 John Willis <143434770+CerberusWolfie@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 MajorMoth <61519600+MajorMoth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -343,8 +343,9 @@
   equipment:
     back: ClothingBackpackSatchelHoldingAdmin
     id: AdminPDA
+    belt: AdminToolbelt
     pocket1: BoxFolderAdmin
-    pocket2: AdminToolbelt
+    #pocket2: 
     #pocket3: 
     #pocket4: 
 

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -343,6 +343,10 @@
   equipment:
     back: ClothingBackpackSatchelHoldingAdmin
     id: AdminPDA
+    pocket1: BoxFolderAdmin
+    pocket2: AdminToolbelt
+    #pocket3: 
+    #pocket4: 
 
 #Head Rev Gear
 - type: startingGear

--- a/Resources/Prototypes/_DEN/Entities/Objects/Misc/admin.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Misc/admin.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 MajorMoth <61519600+MajorMoth@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   id: BoxFolderAdmin
   parent: BoxBase

--- a/Resources/Prototypes/_DEN/Entities/Objects/Misc/admin.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Misc/admin.yml
@@ -1,0 +1,103 @@
+- type: entity
+  id: BoxFolderAdmin
+  parent: BoxBase
+  name: admin folder
+  description: A special folder for more than just paper.
+  suffix: Admin
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/bureaucracy.rsi
+    layers:
+    - state: folder-colormap
+      color: "#702963"
+    - state: folder-base
+  - type: Item
+    sprite: Objects/Misc/bureaucracy.rsi
+    size: Small
+    shape: null
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,9,3
+  - type: ItemMapper
+    mapLayers:
+      folder-overlay-paper:
+        whitelist:
+          tags:
+          - Document
+  - type: Appearance
+  - type: Tag
+    tags:
+    - Folder
+  - type: StorageFill
+    contents:
+      - id: Paper
+        amount: 6
+      - id: FoodLollipop
+
+- type: entity
+  id: AdminToolbelt
+  parent: ClothingBeltChiefEngineer
+  name: admin toolbelt
+  description: A magical toolbelt that is NOT a shrunken chief engineer's toolbelt.
+  suffix: Admin
+  components:
+  - type: Item
+    size: Small
+    shape: null
+  - type: StorageFill
+    contents:
+      - id: ToolDebug
+      - id: WelderExperimental
+      - id: Multitool
+      - id: HolofanProjector
+      - id: GasAnalyzer
+      - id: trayScanner
+      - id: OmnimedTool
+      - id: BaseUplinkRadioDebug
+      - id: LightReplacer
+      - id: SprayPainter
+      - id: GeigerCounter
+      - id: AccessConfigurator
+      - id: AdminRCD
+  - type: Storage
+    grid:
+    - 0,0,6,3
+    whitelist: null
+
+- type: entity
+  id: AdminMaterialBox
+  parent: BoxCardboard
+  name: admin material box
+  description: A box of basic materials.
+  suffix: Admin
+  components:
+  - type: Item
+    size: Normal
+    shape: 
+    - 0,0,1,1
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,5,3
+  - type: StorageFill
+    contents:
+    - id: SheetSteel
+    - id: SheetGlass
+    - id: SheetPlastic
+    - id: MaterialWoodPlank
+    - id: MaterialCloth
+    - id: PartRodMetal
+
+- type: entity
+  id: AdminRCD
+  parent: RCD
+  name: admin RCD
+  description: An RCD with a never-ending supply of compressed matter.
+  suffix: Admin
+  components:
+  - type: LimitedCharges
+    maxCharges: 100
+    charges: 100
+  - type: AutoRecharge
+    rechargeDuration: 0


### PR DESCRIPTION
## About the PR
- Added the admin folder, which can hold up to any normal item. Prefilled with paper and a tasty treat.
- Added the admin toolbelt, which can hold up to any normal item. Prefilled with various tools.
- Changed the admin satchel to be removable and added a few things to its fill.
- Added the Admin RCD, an infinite RCD.
- Added an admin material box which contains 6 of the most basic materials. 
- The ID card in the admin PDA is now a CC ID card.

## Why / Balance
People were complaining about a lack of basic tools on the aghost.

## Technical details
Simple yml changes.

## Media
![image](https://github.com/user-attachments/assets/a65b145b-41d8-41e8-b48f-0ed567febe29)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
None afaik.

**Changelog**
:cl:
- add: A bunch of new admin tools and things in the aghost starting gear.