### PR TITLE
Fix Changelog Workflows

### DIFF
--- a/.github/workflows/discord-changelog.yml
+++ b/.github/workflows/discord-changelog.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT <77995199+DEATHB4DEFEAT@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Evgencheg <73418250+Evgencheg@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 FoxxoTrystan <45297731+FoxxoTrystan@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/.github/workflows/discord-changelog.yml
+++ b/.github/workflows/discord-changelog.yml
@@ -22,8 +22,13 @@ jobs:
       with:
         ref: master
 
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
     - name: Publish changelog
-      run: Tools/actions_changelogs_since_last_run.py
+      run: python Tools/actions_changelogs_since_last_run.py
       env:
         CHANGELOG_DIR: ${{ vars.CHANGELOG_DIR }}
         CHANGELOG_WEBHOOK: ${{ secrets.CHANGELOG_WEBHOOK }}

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -22,8 +22,13 @@ jobs:
         token: ${{secrets.GITHUB_TOKEN}}
         ref: master
 
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
     - name: Publish changelog
-      run: Tools/actions_changelogs_since_last_run.py
+      run: python Tools/actions_changelogs_since_last_run.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CHANGELOG_DIR: ${{ vars.CHANGELOG_DIR }}

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 FoxxoTrystan <45297731+FoxxoTrystan@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 FoxxoTrystan <trystan.garnierhein@gmail.com>
+# SPDX-FileCopyrightText: 2025 portfiend <109661617+portfiend@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT


### PR DESCRIPTION
explicitly run changelogs via python instead of trying to infer the script type from that one execution header that is now broken
