### PR TITLE
Fix SqueakySmileyBallRandom Entity Prototype Id

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/fun.yml
@@ -166,7 +166,7 @@
       - !type:EntSelector
         id: SqueakySmileyBall
       - !type:EntSelector
-        id: PlushieSmileyBallRandom
+        id: SqueakySmileyBallRandom
         weight: 0.3 # rare color variant...
     - !type:GroupSelector
       children:

--- a/Resources/Prototypes/_DEN/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Fun/toys.yml
@@ -46,7 +46,7 @@
 
 - type: entity
   parent: SqueakySmileyBall
-  id: PlushieSmileyBallRandom
+  id: SqueakySmileyBallRandom
   suffix: random appearance
   components:
     - type: RandomSprite


### PR DESCRIPTION
## About the PR
changed id for the randomized smiley ball to be squeaky and not plushie

## Why / Balance
1. we just added it so nothing relies on it yet
2. annoyed me when i saw it

## Technical details
chaos shadow dragon technique

## Breaking changes
if an entity ID was changed in the woods and nobody was around to hear it did it really change at all