### PR TITLE
Thigh High Socks Actually Work Like Socks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Under/under.yml
+++ b/Resources/Prototypes/Entities/Clothing/Under/under.yml
@@ -7,7 +7,7 @@
 # I would cry if we didn't have them. -swept
 
 - type: entity
-  parent: ClothingShoesBaseSocks
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksBee
   name: bee socks
   description: Make them loins buzz!
@@ -18,7 +18,7 @@
     sprite: Clothing/Under/Socks/bee.rsi
 
 - type: entity
-  parent: ClothingShoesBaseSocks
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksCoder
   name: coder socks
   description: It's time to code sisters!!11!

--- a/Resources/Prototypes/Entities/Clothing/Under/under.yml
+++ b/Resources/Prototypes/Entities/Clothing/Under/under.yml
@@ -7,7 +7,7 @@
 # I would cry if we didn't have them. -swept
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks
   id: ClothingUnderSocksBee
   name: bee socks
   description: Make them loins buzz!
@@ -18,7 +18,7 @@
     sprite: Clothing/Under/Socks/bee.rsi
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks
   id: ClothingUnderSocksCoder
   name: coder socks
   description: It's time to code sisters!!11!

--- a/Resources/Prototypes/_DEN/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/_DEN/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -1,0 +1,12 @@
+- type: entity
+  abstract: true
+  parent: ClothingShoesBaseButcherable
+  id: ClothingShoesBaseSocks
+  components:
+  - type: Clothing
+    renderLayer: jumpsuit
+  - type: HideLayerClothing
+    force: true
+    slots:
+    - LFoot
+    - RFoot

--- a/Resources/Prototypes/_Floof/Entities/Clothing/Under/under.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/Under/under.yml
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksCoderValid
   name: blood-red coder socks
   description: "It's time to code maliciously while petting a syndicat!!! :3 :3"
@@ -17,7 +17,7 @@
     sprite: _Floof/Clothing/Under/Socks/codervalid.rsi
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksPlain
   name: plain thigh-high socks
   description: Just a plain pair of thigh-high socks.
@@ -28,7 +28,7 @@
     sprite: _Floof/Clothing/Under/Socks/plainsocks.rsi
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksStripedWhite
   name: striped white thigh-high socks
   description: Just a plain pair of thigh-high socks.
@@ -39,7 +39,7 @@
     sprite: _Floof/Clothing/Under/Socks/stripesockswhite.rsi
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksStripedPurple
   name: striped purple thigh-high socks
   description: Just a plain pair of thigh-high socks.
@@ -50,7 +50,7 @@
     sprite: _Floof/Clothing/Under/Socks/stripesockspurple.rsi
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksStripedRainbow
   name: striped rainbow thigh-high socks
   description: Just a plain pair of thigh-high socks.

--- a/Resources/Prototypes/_Floof/Entities/Clothing/departmental_clothes.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/departmental_clothes.yml
@@ -30,7 +30,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksCaptain
   name: captain's thigh-high socks
   description: A pair of thigh-high socks, styled for a captain.
@@ -72,7 +72,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksCommand
   name: head of personel's thigh-high socks
   description: A pair of thigh-high socks, styled for the head of personel.
@@ -115,7 +115,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksEngi
   name: engineering thigh-high socks
   description: A pair of thigh-high socks, styled for Engineering roles.
@@ -156,7 +156,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksChiefEngi
   name: chief engineer's thigh-high socks
   description: A pair of thigh-high socks, styled for Logistic roles.
@@ -203,7 +203,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksEpi
   name: epistemics thigh-high socks
   description: A pair of thigh-high socks, styled for Epistemic roles.
@@ -244,7 +244,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksChaplain
   name: chaplain thigh-high socks
   description: A pair of thigh-high socks, oddly, styled for a Chaplain.
@@ -308,7 +308,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksEpiHead
   name: research director's thigh-high socks
   description: A pair of thigh-high socks, styled for the research director.
@@ -349,7 +349,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesMilitaryBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksMantisEpi
   name: psionic mantis' thigh-high socks
   description: A pair of thigh-high socks, styled for a Psionic Mantis.
@@ -392,7 +392,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksLogis
   name: logistics thigh-high socks
   description: A pair of thigh-high socks, styled for Logistic roles.
@@ -433,7 +433,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksLOLogis
   name: logistics officer thigh-high socks
   description: A pair of thigh-high socks, styled for Logistic roles.
@@ -474,7 +474,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksCourier
   name: courier thigh-high socks
   description: A pair of thigh-high socks, styled for Couriers.
@@ -517,7 +517,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksMedic
   name: medical thigh-high socks
   description: A pair of thigh-high socks, styled for Medic roles.
@@ -558,7 +558,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksChemists
   name: chemist thigh-high socks
   description: A pair of thigh-high socks, styled for Chemists.
@@ -599,7 +599,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksParaMedic
   name: paramedic thigh-high socks
   description: A pair of thigh-high socks, styled for Paramedic roles.
@@ -640,7 +640,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksCMO
   name: chief med officer's thigh-high socks
   description: A pair of thigh-high socks, styled for the CMO.
@@ -683,7 +683,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesMilitaryBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksSecurity
   name: security thigh-high socks
   description: A pair of thigh-high socks, styled for Security roles.
@@ -724,7 +724,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesMilitaryBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksHeadSecurity
   name: HoS thigh-high socks
   description: A pair of thigh-high socks, styled for the HoS.
@@ -765,7 +765,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesMilitaryBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksDetective
   name: detective's thigh-high socks
   description: A pair of thigh-high socks, styled for a Detective.
@@ -808,7 +808,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksService
   name: service thigh-high socks
   description: A pair of thigh-high socks, styled for Service workers.
@@ -860,7 +860,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksJanitor
   name: rubber thigh-high socks
   description: A pair of thigh-high socks, styled for Janitorial.
@@ -902,7 +902,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksBartender
   name: bartender thigh-high socks
   description: A pair of thigh-high socks, styled for Bartenders.
@@ -943,7 +943,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksMusician
   name: musician thigh-high socks
   description: A pair of thigh-high socks, styled for musicians.
@@ -984,7 +984,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBase
+  parent: ClothingShoesBaseSocks #TheDen
   id: ClothingUnderSocksChef
   name: chef thigh-high socks
   description: A pair of thigh-high socks, styled for a Chef.


### PR DESCRIPTION
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
This PR creates the parent "ClothingShoesBaseSocks" which makes every under sock actually render UNDER jumpsuits (most of the time), hides the feet layer and changes all the under socks to use that parent. I did it this way because it is easily revertable should a better solution come about, something goes wrong, etc etc.

## Why / Balance
All the socks were originally supposed to go under the jumpsuit in the first place (according to the comments found in the Bee and Coder socks code)

## Technical details
ClothingShoesBaseSocks created in the designated Den folders, it renders on the same layer as jumpsuits/skirts (which for some reason makes them render under the jumpsuits by default unless the jumpsuit is taken off and put back on in render distance) and just changed the parent for all the under socks that I know.

## Media
[https://cdn.discordapp.com/attachments/1302263137902530704/1386296877405831169/2025-06-22_06-47-55.mp4?ex=6859d9d3&is=68588853&hm=6bd8847ffba8642037c19fb4a7e775bce6b0c1dc3a3695de3fafe1bebe0245ec&](HERE)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
All the parents have changed for all the under socks, although this should not affect loadouts at all

**Changelog**
:cl:
- fix: Coder socks now appear under jumpsuits, jumpskirts, basically any clothes
- add: All the under sucks are now butcherable (into one cloth)
