### PR TITLE
Set Pose Changes

### DIFF
--- a/Content.Server/_RMC14/Examine/RMCSetPoseSystem.cs
+++ b/Content.Server/_RMC14/Examine/RMCSetPoseSystem.cs
@@ -25,8 +25,10 @@ public sealed class RMCSetPoseSystem : SharedRMCSetPoseSystem
 
     private void OnSetPoseGetVerbs(Entity<RMCSetPoseComponent> ent, ref GetVerbsEvent<Verb> args)
     {
-        if (!args.CanInteract)
-            return;
+        // The Den: removed interact check, it does make sense to be able to pose without being able to interact with the world.
+        // yes, this will allow you to pose while dead which is very much intended.
+        //if (!args.CanInteract)
+        //    return;
 
         if (args.User != args.Target)
             return;

--- a/Content.Server/_RMC14/Examine/RMCSetPoseSystem.cs
+++ b/Content.Server/_RMC14/Examine/RMCSetPoseSystem.cs
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 MajorMoth <61519600+MajorMoth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 MajorMoth
+// SPDX-FileCopyrightText: 2025 sleepyyapril
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Locale/en-US/_RMC14/pose/set-pose.ftl
+++ b/Resources/Locale/en-US/_RMC14/pose/set-pose.ftl
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
-rmc-set-pose-examined = [color=lightblue][bold]{ CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } {$pose}[/bold][/color]
-rmc-set-pose-dialog = This is {$ent}. { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) }...
+# den: removed "is"
+rmc-set-pose-examined = [color=lightblue][bold]{ CAPITALIZE(SUBJECT($ent)) } {$pose}[/bold][/color] 
+rmc-set-pose-dialog = This is {$ent}. { CAPITALIZE(SUBJECT($ent)) }... 
+
 rmc-set-pose-title = Set Pose


### PR DESCRIPTION
## About the PR
- Removes "is" from set pose.
- Removes the interaction check from set pose.

## Why / Balance
People asked

## Technical details
- Removed conjugate be from the set pose loc string
- Commented out the interaction check from set pose. Due to the fact being alive is a prerequisite to being able to interact with stuff, with the check removed you can now set pose when dead. In a server like Den I feel like it's not going to get abused, and if it is, it can always be ahelped. If it becomes an issue it can be swapped to `args.Dead`

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**
:cl:
- remove: Removed "is" from set pose for more grammatical freedom.
- remove: Removed the interaction check from set pose. You can now set pose when cuffed, dead, etc. Do not abuse it, or it will be changed.