### PR TITLE
Remove Consent Requiring Reagents Being Spawned In

### DIFF
--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -62,8 +62,10 @@ public sealed class VentClogRule : StationEventSystem<VentClogRuleComponent>
             if (!RobustRandom.Prob(0.33f))
                 continue;
 
-            var pickAny = RobustRandom.Prob(0.05f);
-            var reagent = RobustRandom.Pick(pickAny ? allReagents : component.SafeishVentChemicals);
+            // The Den start
+            // var pickAny = RobustRandom.Prob(0.05f);
+            var reagent = RobustRandom.Pick(component.SafeishVentChemicals); // removed the random chance of it being a completely random reagent as it would sometimes include consent-breaking ones
+            // The Den end
 
             var weak = component.WeakReagents.Contains(reagent);
             var quantity = weak ? component.WeakReagentQuantity : component.ReagentQuantity;

--- a/Content.Server/StationEvents/Events/VentClogRule.cs
+++ b/Content.Server/StationEvents/Events/VentClogRule.cs
@@ -1,21 +1,20 @@
-// SPDX-FileCopyrightText: 2022 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Moony <moonheart08@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Pancake <Pangogie@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Rane <60792108+Elijahrane@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 T-Stalker <43253663+DogZeroX@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 metalgearsloth <comedian_vs_clown@hotmail.com>
-// SPDX-FileCopyrightText: 2022 moonheart08 <moonheart08@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 wrexbe <81056464+wrexbe@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Debug <49997488+DebugOk@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Emisse <99158783+Emisse@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Moony <moony@hellomouse.net>
-// SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Slava0135 <40753025+Slava0135@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Kara <lunarautomaton6@gmail.com>
-// SPDX-FileCopyrightText: 2024 VMSolidus <evilexecutive@gmail.com>
-// SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 Leon Friedrich
+// SPDX-FileCopyrightText: 2022 Pancake
+// SPDX-FileCopyrightText: 2022 Rane
+// SPDX-FileCopyrightText: 2022 T-Stalker
+// SPDX-FileCopyrightText: 2022 moonheart08
+// SPDX-FileCopyrightText: 2022 wrexbe
+// SPDX-FileCopyrightText: 2023 Debug
+// SPDX-FileCopyrightText: 2023 Emisse
+// SPDX-FileCopyrightText: 2023 Moony
+// SPDX-FileCopyrightText: 2023 Nemanja
+// SPDX-FileCopyrightText: 2023 Slava0135
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2024 Kara
+// SPDX-FileCopyrightText: 2024 VMSolidus
+// SPDX-FileCopyrightText: 2024 deltanedas
+// SPDX-FileCopyrightText: 2025 MajorMoth
+// SPDX-FileCopyrightText: 2025 sleepyyapril
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -372,10 +372,13 @@
         - ReagentSlimeNorepinephricAcid
         - ReagentSlimeEphedrine
         - ReagentSlimeRobustHarvest
-        - ReagentSlimeCum # Floofstation
-        - ReagentSlimePomelustine # Floofstation
-        - ReagentSlimePhilterex # Floofstation
-        - ReagentSlimeLibidozenithizine # Floofstation
+#       The Den start
+#       These often end up breaking consent. Removed.
+#       - ReagentSlimeCum # Floofstation
+#       - ReagentSlimePomelustine # Floofstation
+#       - ReagentSlimePhilterex # Floofstation
+#       - ReagentSlimeLibidozenithizine # Floofstation
+#       The Den end
         - ReagentSlimeIchor
         - ReagentSlimeBleach
         - ReagentSlimeSoap

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -1,24 +1,24 @@
-# SPDX-FileCopyrightText: 2023 Alex <129697969+Lomcastar@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Ed <96445749+TheShuEd@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 I.K <45953835+notquitehadouken@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2023 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Alex
+# SPDX-FileCopyrightText: 2023 Ed
+# SPDX-FileCopyrightText: 2023 I.K
+# SPDX-FileCopyrightText: 2023 Kara
+# SPDX-FileCopyrightText: 2023 brainfood1183
 # SPDX-FileCopyrightText: 2023 notquitehadouken <1isthisameme>
-# SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT <77995199+DEATHB4DEFEAT@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Fansana <fansana95@googlemail.com>
-# SPDX-FileCopyrightText: 2024 Nairod <110078045+Nairodian@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 ShatteredSwords <135023515+ShatteredSwords@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Tonydatguy <154929293+Tonydatguy@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Whisper <121047731+QuietlyWhisper@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 fenndragon <fenndragon@gmail.com>
-# SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 liltenhead <104418166+liltenhead@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 sleepyyapril <flyingkarii@gmail.com>
-# SPDX-FileCopyrightText: 2025 Blitz <73762869+BlitzTheSquishy@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Eris <eris@erisws.com>
-# SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>
-# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT
+# SPDX-FileCopyrightText: 2024 Fansana
+# SPDX-FileCopyrightText: 2024 Nairod
+# SPDX-FileCopyrightText: 2024 Nemanja
+# SPDX-FileCopyrightText: 2024 ShatteredSwords
+# SPDX-FileCopyrightText: 2024 Tonydatguy
+# SPDX-FileCopyrightText: 2024 Whisper
+# SPDX-FileCopyrightText: 2024 fenndragon
+# SPDX-FileCopyrightText: 2024 gluesniffler
+# SPDX-FileCopyrightText: 2024 liltenhead
+# SPDX-FileCopyrightText: 2025 Blitz
+# SPDX-FileCopyrightText: 2025 Eris
+# SPDX-FileCopyrightText: 2025 MajorMoth
+# SPDX-FileCopyrightText: 2025 VMSolidus
+# SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
@@ -1,13 +1,14 @@
-# SPDX-FileCopyrightText: 2023 CrigCrag <137215465+CrigCrag@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 MisterMecky <mrmecky@hotmail.com>
-# SPDX-FileCopyrightText: 2023 Moomoobeef <62638182+Moomoobeef@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Ubaser <134914314+UbaserB@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 forthbridge <79264743+forthbridge@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 lzk <124214523+lzk228@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 metalgearsloth <comedian_vs_clown@hotmail.com>
-# SPDX-FileCopyrightText: 2024 deathride58 <deathride58@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 KekaniCreates <87507256+KekaniCreates@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 CrigCrag
+# SPDX-FileCopyrightText: 2023 MisterMecky
+# SPDX-FileCopyrightText: 2023 Moomoobeef
+# SPDX-FileCopyrightText: 2023 Ubaser
+# SPDX-FileCopyrightText: 2023 forthbridge
+# SPDX-FileCopyrightText: 2023 lzk
+# SPDX-FileCopyrightText: 2023 metalgearsloth
+# SPDX-FileCopyrightText: 2024 deathride58
+# SPDX-FileCopyrightText: 2025 KekaniCreates
+# SPDX-FileCopyrightText: 2025 MajorMoth
+# SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
@@ -90,7 +90,8 @@
       - Rhigoxane # funky
       - Spewium # funky
       - Pestiline # funky
-      - Philterex # VASH
+#     this might break consent
+#     - Philterex # VASH
     - quantity: 5
       weight: 2.5
       reagents:

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -1,21 +1,25 @@
-# SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
-# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Nim <128169402+Nimfar11@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Slava0135 <40753025+Slava0135@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 brainfood1183 <113240905+brainfood1183@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Aiden <aiden@djkraz.com>
-# SPDX-FileCopyrightText: 2024 Alzore <140123969+Blackern5000@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT <77995199+DEATHB4DEFEAT@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Ed <96445749+TheShuEd@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Emisse <99158783+emisse@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Memeji <greyalphawolf7@gmail.com>
-# SPDX-FileCopyrightText: 2024 VMSolidus <evilexecutive@gmail.com>
-# SPDX-FileCopyrightText: 2024 Whisper <121047731+QuietlyWhisper@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 icekot8 <93311212+icekot8@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 Rosycup <178287475+Rosycup@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Kara
+# SPDX-FileCopyrightText: 2023 Nemanja
+# SPDX-FileCopyrightText: 2023 Nim
+# SPDX-FileCopyrightText: 2023 Slava0135
+# SPDX-FileCopyrightText: 2023 brainfood1183
+# SPDX-FileCopyrightText: 2023 metalgearsloth
+# SPDX-FileCopyrightText: 2024 AJCM-git
+# SPDX-FileCopyrightText: 2024 Aiden
+# SPDX-FileCopyrightText: 2024 Alzore
+# SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT
+# SPDX-FileCopyrightText: 2024 Ed
+# SPDX-FileCopyrightText: 2024 Emisse
+# SPDX-FileCopyrightText: 2024 Memeji
+# SPDX-FileCopyrightText: 2024 VMSolidus
+# SPDX-FileCopyrightText: 2024 Whisper
+# SPDX-FileCopyrightText: 2024 coderabbitai[bot]
+# SPDX-FileCopyrightText: 2024 icekot8
+# SPDX-FileCopyrightText: 2025 MajorMoth
+# SPDX-FileCopyrightText: 2025 Rosycup
+# SPDX-FileCopyrightText: 2025 Steve
+# SPDX-FileCopyrightText: 2025 marc-pelletier
+# SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -203,8 +203,11 @@
     - Water
     - Sulfur
     - Blood # Floof - Artifact tweaks
-    - Cum # Floof - Artifact tweaks
-    - Pomelustine # Floof - Artifact tweaks
+#   The Den start
+#   These often end up breaking consent. Removed.
+#   - Cum # Floof - Artifact tweaks
+#   - Pomelustine # Floof - Artifact tweaks
+#   The Den end
 
 - type: artifactEffect
   id: EffectCold
@@ -539,8 +542,11 @@
     - Desoxyephedrine
     - Pax
     - Siderlac
-    - Libidozenithizine # Floof - Artifact tweaks
-    - Philterex # Floof - Artifact tweaks
+#   The Den start
+#   These often end up breaking consent. Removed.
+#   - Libidozenithizine # Floof - Artifact tweaks
+#   - Philterex # Floof - Artifact tweaks
+#   The Den end
 
 - type: artifactEffect
   id: EffectEmp

--- a/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/slimes.yml
@@ -5,73 +5,76 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
-- type: entity
-  id: ReagentSlimeCum
-  parent: ReagentSlime
-  suffix: Cum
-  components:
-  - type: Bloodstream
-    bloodReagent: Cum
-  - type: PointLight
-    color: "#FFFDFB"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#FFFDFB"
+# The Den start
+# These often end up breaking consent. Removed.
+# - type: entity
+#   id: ReagentSlimeCum
+#   parent: ReagentSlime
+#   suffix: Cum
+#   components:
+#   - type: Bloodstream
+#     bloodReagent: Cum
+#   - type: PointLight
+#     color: "#FFFDFB"
+#   - type: Sprite
+#     drawdepth: Mobs
+#     sprite: Mobs/Aliens/elemental.rsi
+#     layers:
+#       - map: [ "enum.DamageStateVisualLayers.Base" ]
+#         state: alive
+#         color: "#FFFDFB"
 
-- type: entity
-  id: ReagentSlimePomelustine
-  parent: ReagentSlime
-  suffix: Pomelustine
-  components:
-  - type: Bloodstream
-    bloodReagent: Pomelustine
-  - type: PointLight
-    color: "#45072f"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#45072f"
+# - type: entity
+#   id: ReagentSlimePomelustine
+#   parent: ReagentSlime
+#   suffix: Pomelustine
+#   components:
+#   - type: Bloodstream
+#     bloodReagent: Pomelustine
+#   - type: PointLight
+#     color: "#45072f"
+#   - type: Sprite
+#     drawdepth: Mobs
+#     sprite: Mobs/Aliens/elemental.rsi
+#     layers:
+#       - map: [ "enum.DamageStateVisualLayers.Base" ]
+#         state: alive
+#         color: "#45072f"
 
-- type: entity
-  id: ReagentSlimePhilterex
-  parent: ReagentSlime
-  suffix: Philterex
-  components:
-  - type: Bloodstream
-    bloodReagent: Philterex
-  - type: PointLight
-    color: "#ae0072"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#ae0072"
+# - type: entity
+#   id: ReagentSlimePhilterex
+#   parent: ReagentSlime
+#   suffix: Philterex
+#   components:
+#   - type: Bloodstream
+#     bloodReagent: Philterex
+#   - type: PointLight
+#     color: "#ae0072"
+#   - type: Sprite
+#     drawdepth: Mobs
+#     sprite: Mobs/Aliens/elemental.rsi
+#     layers:
+#       - map: [ "enum.DamageStateVisualLayers.Base" ]
+#         state: alive
+#         color: "#ae0072"
 
-- type: entity
-  id: ReagentSlimeLibidozenithizine
-  parent: ReagentSlime
-  suffix: Libidozenithizine
-  components:
-  - type: Bloodstream
-    bloodReagent: Libidozenithizine
-  - type: PointLight
-    color: "#c90084"
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/elemental.rsi
-    layers:
-      - map: [ "enum.DamageStateVisualLayers.Base" ]
-        state: alive
-        color: "#c90084"
+# - type: entity
+#   id: ReagentSlimeLibidozenithizine
+#   parent: ReagentSlime
+#   suffix: Libidozenithizine
+#   components:
+#   - type: Bloodstream
+#     bloodReagent: Libidozenithizine
+#   - type: PointLight
+#     color: "#c90084"
+#   - type: Sprite
+#     drawdepth: Mobs
+#     sprite: Mobs/Aliens/elemental.rsi
+#     layers:
+#       - map: [ "enum.DamageStateVisualLayers.Base" ]
+#         state: alive
+#         color: "#c90084"
+# The Den end
 
 - type: entity
   id: ReagentSlimeOpporozidone

--- a/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/slimes.yml
@@ -1,7 +1,8 @@
-# SPDX-FileCopyrightText: 2024 fenndragon <fenndragon@gmail.com>
-# SPDX-FileCopyrightText: 2024 fox <daytimer253@gmail.com>
-# SPDX-FileCopyrightText: 2025 Rosycup <178287475+Rosycup@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 fenndragon
+# SPDX-FileCopyrightText: 2024 fox
+# SPDX-FileCopyrightText: 2025 MajorMoth
+# SPDX-FileCopyrightText: 2025 Rosycup
+# SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 


### PR DESCRIPTION
## About the PR
What it says on the tin.

## Why / Balance
Consent breaches.

## Technical details
- Removed a bunch of stuff from yml definitions
- Changed the way the `VentClog` rule runs to avoid the possible roll from a collection of *all* reagents.

## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
Removed a few prototypes from floof.

**Changelog**
:cl:
- remove: Removed consent-breaking reagents from spawning in through artifacts, random pills, vent clogs, and reagent slimes. Please report any other mechanics that might've been missed if you see them. Anomalies did not need changing as they did not have any NSFW reagents in them.