### PR TITLE
tweak: move lewd traits into new category

### DIFF
--- a/Resources/Locale/en-US/_DEN/traits/categories.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/categories.ftl
@@ -4,3 +4,4 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 trait-category-TraitsSpeechSounds = Voice
+trait-category-Lewd = Lewd

--- a/Resources/Prototypes/Traits/categories.yml
+++ b/Resources/Prototypes/Traits/categories.yml
@@ -31,6 +31,10 @@
     - TraitsPhysicalAugmentations
 
 - type: traitCategory
+  id: Lewd
+  root: true
+
+- type: traitCategory
   id: Speech
   root: true
   subCategories:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1289,7 +1289,7 @@
 # Commented out upon request for the time being
 #- type: trait
 #  id: EggLaying
-#  category: TraitsPhysicalBiological
+#  category: Lewd
 #  points: 0
 #  requirements:
 #  - !type:CharacterJobRequirement

--- a/Resources/Prototypes/_Floof/Traits/lewd.yml
+++ b/Resources/Prototypes/_Floof/Traits/lewd.yml
@@ -9,7 +9,7 @@
 
 - type: trait
   id: CumProducer
-  category: TraitsPhysicalBiological
+  category: Lewd
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -42,7 +42,7 @@
 
 - type: trait
   id: MilkProducer
-  category: TraitsPhysicalBiological
+  category: Lewd
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -75,7 +75,7 @@
 
 - type: trait
   id: SquirtProducer
-  category: TraitsPhysicalBiological
+  category: Lewd
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -108,7 +108,7 @@
 
 - type: trait
   id: HoneyProducer
-  category: TraitsPhysicalBiological
+  category: Lewd
   points: -1 # Point cost added to balance with removal of species restriction
   requirements:
     - !type:CharacterJobRequirement


### PR DESCRIPTION
## About the PR
title.

## Why / Balance
some people would rather not be penis jumpscared.

honey stomach is in there too, i figure it's lewd trait-shaped enough.

## Technical details
ancestral chaos blast technique

## Media
![image](https://github.com/user-attachments/assets/5654e9aa-7eb1-4501-9a9b-225e631834b6)

## Requirements
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
none

**Changelog**
:cl:
- tweak: Lewd traits have been moved out of Physical and into a new category.
