### PR TITLE
Fix: Make Character Editor Buttons Vertical

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -62,13 +62,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
             <!-- Import/Export -->
             <BoxContainer Orientation="Vertical">
                 <prefUi:HighlightedContainer>
-                    <BoxContainer Orientation="Horizontal" SeparationOverride="5">
+                    <BoxContainer Orientation="Vertical" SeparationOverride="5">
                         <Button Name="ImportButton" Text="{Loc 'humanoid-profile-editor-import-button'}"/>
                         <Button Name="ExportButton" Text="{Loc 'humanoid-profile-editor-export-button'}"/>
-                        <Button Name="ExportImageButton" Text="{Loc 'humanoid-profile-editor-export-image-button'}"/>
-                        <Button Name="OpenImagesButton" Text="{Loc 'humanoid-profile-editor-open-image-button'}"/>
                         <Button Name="SaveButton" Text="{Loc 'humanoid-profile-editor-save-button'}" />
                         <Button Name="ResetButton" Disabled="True" Text="{Loc 'humanoid-profile-editor-reset-button'}"/>
+                        <Button Name="ExportImageButton" Text="{Loc 'humanoid-profile-editor-export-image-button'}"/>
+                        <Button Name="OpenImagesButton" Text="{Loc 'humanoid-profile-editor-open-image-button'}"/>
                     </BoxContainer>
                 </prefUi:HighlightedContainer>
             </BoxContainer>


### PR DESCRIPTION
## About the PR
title

## Why / Balance
was stretching the UI and making the character preview small and everything ugly as hell

## Technical details
ultra god power ray technique

## Media
![image](https://github.com/user-attachments/assets/971280df-8d8e-48c8-b716-2ba76f137583)

**Changelog**
:cl:
- fix: Made the top buttons (save, import, export, reset) in the character editor vertical.