### PR TITLE
Fix: Give Skeletons "Offer Item" Capability

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -362,6 +362,7 @@
   - type: FootPrints
   - type: RMCSetPose
   - type: ModifyUndies  # FLOOF Add
+  - type: OfferItem
 
 - type: entity
   save: false
@@ -452,7 +453,6 @@
         Asphyxiation: -1.0
   - type: FireVisuals
     alternateState: Standing
-  - type: OfferItem
   - type: LayingDown
   - type: BloodstreamAffectedByMass
     power: 0.6 # A minimum size felinid will have 30% blood, a minimum size vulp will have 60%, a maximum size oni will have ~200%


### PR DESCRIPTION
## About the PR
allows skeletons to offer/receive items

## Why / Balance
no reason they should not

## Technical details
i actually just moved the OfferItem component from BaseMobSpeciesOrganic to BaseMobSpecies. skeletons are the only species prototype that inherit from BaseMobSpecies, so it should be fine. no reason why that should be locked to organics

## Media
idgaf

## Requirements
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
hope not

**Changelog**
:cl:
- fix: Skeletons can now offer and receive items.