### PR TITLE
Bionic Arm and Leg No Arm Resprite Trait

### DIFF
--- a/Resources/Changelog/Den.yml
+++ b/Resources/Changelog/Den.yml
@@ -6827,3 +6827,24 @@ Entries:
   id: 646
   time: '2025-06-30T16:05:54.0000000+00:00'
   url: https://github.com/TheDenSS14/TheDen/pull/938
+- author: KyuPolaris
+  changes:
+    - type: Fix
+      message: >-
+        Fixed Arachne inventory to not be jank (sorry voters, easier to fix than
+        to replace funnily enough)
+    - type: Tweak
+      message: >-
+        Arachne now start with Arachnic as their default language instead of Sol
+        Common
+    - type: Tweak
+      message: >-
+        Removed restriction on some suits so Arachne can wear them (will look a
+        little silly for the time being, but all suits on them do)
+    - type: Fix
+      message: >-
+        Gave the arachnic language it's [Arachnic] prefix tag like other
+        languages. 
+  id: 647
+  time: '2025-06-30T22:52:25.0000000+00:00'
+  url: https://github.com/TheDenSS14/TheDen/pull/878

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -677,6 +677,11 @@ trait-description-BionicLeg =
     One or more of your limbs have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
     or a more obvious metal limb. This limb provides enhanced speed to it's user, allowing you to run away from situations faster or get to a place faster.
 
+trait-name-BionicLegNoVisuals = Bionic Legs (No Leg Resprite)
+trait-description-BionicLeg =
+    One or more of your limbs have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
+    or a more obvious metal limb. This limb provides enhanced speed to it's user, allowing you to run away from situations faster or get to a place faster.
+
 trait-name-FlareShieldingModule = I.P.C Eye Module: Flare Shielding
 trait-description-FlareShieldingModule =
    Your eyes have been fitted with a photochromic lens that automatically darkens in response to intense stimuli.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -555,6 +555,11 @@ trait-description-BionicArm =
     One or more of your limbs have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
     or a more obvious metal limb. This limb provides enhanced strength to its user, allowing one to pry open barriers with their bare hands.
 
+trait-name-BionicArmNoVisuals = Bionic Arm (No Arm Resprite)
+trait-description-BionicArmNoVisuals =
+    One or more of your limbs have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
+    or a more obvious metal limb. This limb provides enhanced strength to its user, allowing one to pry open barriers with their bare hands.
+
 trait-name-PlateletFactories = Platelet Factories
 trait-description-PlateletFactories =
     Your body has been augmented with a series of biotailored organs that enhance the owner's long term survivability. These organs will attempt

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -678,7 +678,7 @@ trait-description-BionicLeg =
     or a more obvious metal limb. This limb provides enhanced speed to it's user, allowing you to run away from situations faster or get to a place faster.
 
 trait-name-BionicLegNoVisuals = Bionic Legs (No Leg Resprite)
-trait-description-BionicLeg =
+trait-description-BionicLegNoVisuals =
     One or more of your limbs have been replaced with an expensive, state of the art bionic. It could be either one made of highly realistic synthflesh,
     or a more obvious metal limb. This limb provides enhanced speed to it's user, allowing you to run away from situations faster or get to a place faster.
 

--- a/Resources/Prototypes/CharacterItemGroups/Generic/mindormachine.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/mindormachine.yml
@@ -45,6 +45,8 @@
     - type: trait
       id: BionicArm
     - type: trait
+      id: BionicArmNoVisuals
+    - type: trait
       id: PlateletFactories
     - type: trait
       id: DermalArmor

--- a/Resources/Prototypes/CharacterItemGroups/Generic/mindormachine.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/mindormachine.yml
@@ -57,6 +57,8 @@
     - type: trait
       id: BionicLeg
     - type: trait
+      id: BionicLegNoVisuals
+    - type: trait
       id: FlareShieldingModule
     - type: trait
       id: SecurityEyesModule

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -587,6 +587,10 @@
   category: TraitsPhysicalAugmentations
   points: -6
   requirements:
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - BionicArmNoVisuals
     - !type:CharacterJobRequirement
       inverted: true
       jobs:
@@ -614,6 +618,10 @@
   category: TraitsPhysicalAugmentations
   points: -6
   requirements:
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - BionicArm
     - !type:CharacterJobRequirement
       inverted: true
       jobs:
@@ -978,6 +986,7 @@
       inverted: true
       traits:
         - WheelchairBound
+        - BionicLegNoVisuals
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:
@@ -1012,6 +1021,7 @@
       inverted: true
       traits:
         - WheelchairBound
+        - BionicLeg
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1000,6 +1000,30 @@
       slotId: "right leg"
 
 - type: trait
+  id: BionicLegNoVisuals
+  category: TraitsPhysicalAugmentations
+  points: -8
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - WheelchairBound
+    - !type:CharacterSpeciesRequirement
+      inverted: true
+      species:
+        - Arachne
+  functions:
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-bionic-leg-message
+          fontSize: 12
+          requireDetailRange: true
+
+- type: trait
   id: FlareShieldingModule
   category: TraitsPhysicalAugmentations
   points: -4

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -610,6 +610,23 @@
           requireDetailRange: true
 
 - type: trait
+  id: BionicArmNoVisuals
+  category: TraitsPhysicalAugmentations
+  points: -6
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - Prisoner # Bionics should be "Confiscated" from long term prisoners.
+        - Gladiator
+  functions:
+    - !type:TraitPushDescription
+      descriptionExtensions:
+        - description: examine-bionic-arm-message
+          fontSize: 12
+          requireDetailRange: true
+
+- type: trait
   id: PlateletFactories
   category: TraitsPhysicalAugmentations
   points: -10


### PR DESCRIPTION
:cl:
- add: Added a trait that lets you have a bionic arm without the forced arm resprite. This should be roleplayed as you do have a bionic arm, but it's more organic or hidden.
- add: Added a trait that lets you have a bionic leg without the forced leg resprite. This should be roleplayed as you do have a bionic leg, but it's more organic or hidden.