### PR TITLE
Map population adjustment

### DIFF
--- a/Resources/Prototypes/Maps/barrier.yml
+++ b/Resources/Prototypes/Maps/barrier.yml
@@ -22,7 +22,7 @@
   mapName: 'Barrier Hospital'
   mapPath: /Maps/TheDen/barrier.yml
   minPlayers: 0
-  maxPlayers: 50
+  maxPlayers: 35
   stations:
     Barrier:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/edge.yml
+++ b/Resources/Prototypes/Maps/edge.yml
@@ -21,7 +21,7 @@
   id: Edge
   mapName: 'Edge'
   mapPath: /Maps/TheDen/edge.yml
-  minPlayers: 0
+  minPlayers: 5
   maxPlayers: 80
   stations:
     Edge:

--- a/Resources/Prototypes/Maps/gravel.yml
+++ b/Resources/Prototypes/Maps/gravel.yml
@@ -32,7 +32,7 @@
   mapName: 'Gravel'
   mapPath: /Maps/TheDen/gravel.yml
   minPlayers: 0
-  maxPlayers: 45
+  maxPlayers: 35
   stations:
     Gravel:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Gravel maxpop 45 -> 35
Edge minpop 0 -> 5
Barrier maxpop 50 -> 35

## Why / Balance
Maps have existed for a bit, we've felt out the scope of what population levels they can handle

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Fox
- tweak: Various maps have had their population limits adjusted, see PR for details


