### PR TITLE
Fix Microwave Container Bug

### DIFF
--- a/Content.Server/_Goobstation/Kitchen/MicrowaveEventsSystem.cs
+++ b/Content.Server/_Goobstation/Kitchen/MicrowaveEventsSystem.cs
@@ -1,7 +1,8 @@
-// SPDX-FileCopyrightText: 2025 AirFryerBuyOneGetOneFree <airfryerbuyonegetonefree@gmail.com>
-// SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
-// SPDX-FileCopyrightText: 2025 deltanedas <@deltanedas:kde.org>
-// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 AirFryerBuyOneGetOneFree
+// SPDX-FileCopyrightText: 2025 GoobBot
+// SPDX-FileCopyrightText: 2025 deltanedas
+// SPDX-FileCopyrightText: 2025 portfiend
+// SPDX-FileCopyrightText: 2025 sleepyyapril
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/_Goobstation/Kitchen/MicrowaveEventsSystem.cs
+++ b/Content.Server/_Goobstation/Kitchen/MicrowaveEventsSystem.cs
@@ -25,6 +25,7 @@ public sealed class MicrowaveEventsSystem : EntitySystem
 
     private void OnRemoveAttempt(Entity<ActiveMicrowaveComponent> ent, ref ContainerIsRemovingAttemptEvent args)
     {
-        args.Cancel();
+        if (ent.Comp.CookTimeRemaining > 0)
+            args.Cancel();
     }
 }


### PR DESCRIPTION
## About the PR
fixes #889

## Why / Balance
i put my hands up theyre playing my song the butterflies fly away im nodding my head like yeah movin my hips like yeah i got my hands up theyre playin my song i know im gonna be okay yeaaahaaahh its a party in the usa

## Technical details
apparently goobstation adds an event callback for attempting to remove an item from a container, which CanRemove calls, which EmptyContainer calls. (the latter two are engine functions). 

i (optimistically) assume goob had a good reason for blocking the CanRemove event callback for microwaves, so i just added a check to make sure that the microwave is in the middle of cooking (i.e. cooking time remaining > 0) to cancel that event

## Media
https://github.com/user-attachments/assets/f0e8cdeb-02d0-4326-a4ca-c5a48895589b

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
more like fixing changes

**Changelog**
:cl:
- fix: Microwaves will now properly eject remaining items (such as containers) once the microwave finishes cooking.
