### PR TITLE
Fix: Broken Skewer/Kebab Prototype

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
@@ -30,14 +30,14 @@
   components:
   - type: Sprite
     sprite: Objects/Consumable/Food/skewer.rsi
-    state: 
+    state:
     layers:
     - state: skewer
     - map: ["foodSequenceLayers"]
   - type: LandAtCursor
   - type: Fixtures
     fixtures:
-      fix1: 
+      fix1:
         shape: !type:PolygonShape
           vertices:
             - -0.40,-0.20
@@ -71,60 +71,8 @@
     - Trash
     - Skewer
   - type: Food
-    trash: 
+    trash:
     - FoodKebabSkewer
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 6
-        - ReagentId: Vitamin
-          Quantity: 2
-
-- type: entity
-  name: double rat kebab
-  parent: FoodKebabSkewer
-  id: FoodMeatRatdoubleKebab
-  description: A double serving of not so delicious rat meat, on a stick.
-  components:
-  - type: Sprite
-    layers:
-      - state: skewer
-      - state: skewer-rat
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        reagents:
-        - ReagentId: Nutriment
-          Quantity: 12
-        - ReagentId: Vitamin
-          Quantity: 6
-
-- type: entity
-  name: fiesta kebab
-  parent: FoodKebabSkewer
-  id: FoodMeatFiestaKebab
-  description: Always a cruise ship party somewhere in the world, right?
-  components:
-  - type: Sprite
-    layers:
-      - state: skewer
-      - state: skewer-pepper
-      - state: skewer-corn
-      - state: skewer-mushroom
-      - state: skewer-tomato
-
-- type: entity
-  name: snake kebab
-  parent: FoodKebabSkewer
-  id: FoodMeatSnakeKebab
-  description: Snake meat on a stick. It's a little tough.
-  components:
-  - type: Sprite
-    layers:
-      - state: skewer
-      - state: skewer-snake
   - type: SolutionContainerManager
     solutions:
       food:
@@ -134,7 +82,7 @@
     key: Skewer
     maxLayers: 4
     startPosition: -0.27, -0.19
-    inverseLayers: true 
+    inverseLayers: true
     offset: 0.2, 0.1
     nameGeneration: food-sequence-skewer-gen
     contentSeparator: ", "

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/skewer.yml
@@ -1,21 +1,20 @@
-# SPDX-FileCopyrightText: 2021 20kdc <asdd2808@gmail.com>
-# SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-# SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
-# SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2021 Ygg01 <y.laughing.man.y@gmail.com>
-# SPDX-FileCopyrightText: 2022 Jessica M <jessica@jessicamaybe.com>
-# SPDX-FileCopyrightText: 2022 Rane <60792108+Elijahrane@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 LankLTE <135308300+LankLTE@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Tunguso4ka <71643624+Tunguso4ka@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Velcroboy <107660393+IamVelcroboy@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2023 Velcroboy <107660393+iamvelcroboy@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Debug <49997488+DebugOk@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Ed <96445749+TheShuEd@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Nim <128169402+Nimfar11@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 SimpleStation14 <130339894+SimpleStation14@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 sleepyyapril <flyingkarii@gmail.com>
-# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 20kdc
+# SPDX-FileCopyrightText: 2021 Pieter-Jan Briers
+# SPDX-FileCopyrightText: 2021 Swept
+# SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto
+# SPDX-FileCopyrightText: 2021 Ygg01
+# SPDX-FileCopyrightText: 2022 Jessica M
+# SPDX-FileCopyrightText: 2022 Rane
+# SPDX-FileCopyrightText: 2023 LankLTE
+# SPDX-FileCopyrightText: 2023 Tunguso4ka
+# SPDX-FileCopyrightText: 2023 Velcroboy
+# SPDX-FileCopyrightText: 2024 Debug
+# SPDX-FileCopyrightText: 2024 Ed
+# SPDX-FileCopyrightText: 2024 Nim
+# SPDX-FileCopyrightText: 2024 SimpleStation14
+# SPDX-FileCopyrightText: 2024 lzk
+# SPDX-FileCopyrightText: 2025 portfiend
+# SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 


### PR DESCRIPTION
## About the PR
the foodsequence kebabs were not correctly merged so there were prototypes that shouldn't exist and components in the wrong places (like the skewer itself being edible). this PR brings skewers pretty much up to par with wizard's den's implementation

## Why / Balance
this is a bug

## Technical details
my dual blades CTRL+C and CTRL+V

## Media

https://github.com/user-attachments/assets/0e0da5da-20fc-495e-811f-78672ae1d48e

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- fix: Skewers now Work Properly and you're gonna have to take my word for it.