### PR TITLE
Fix Butlertron Test Fail + Make Butlertron Definition Not Ass

### DIFF
--- a/Content.IntegrationTests/Tests/_DV/RoboisseurTest.cs
+++ b/Content.IntegrationTests/Tests/_DV/RoboisseurTest.cs
@@ -1,6 +1,7 @@
-// SPDX-FileCopyrightText: 2023 Debug <sidneymaatman@gmail.com>
-// SPDX-FileCopyrightText: 2025 BlitzTheSquishy <73762869+BlitzTheSquishy@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2023 Debug
+// SPDX-FileCopyrightText: 2025 BlitzTheSquishy
+// SPDX-FileCopyrightText: 2025 portfiend
+// SPDX-FileCopyrightText: 2025 sleepyyapril
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Content.IntegrationTests/Tests/_DV/RoboisseurTest.cs
+++ b/Content.IntegrationTests/Tests/_DV/RoboisseurTest.cs
@@ -29,37 +29,30 @@ public sealed class RoboisseurTest
         var prototypeManager = server.ResolveDependency<IPrototypeManager>();
         var entityManager = server.ResolveDependency<IEntityManager>();
         var entitySystemManager = server.ResolveDependency<IEntitySystemManager>();
+        var componentFactory = server.ResolveDependency<IComponentFactory>();
 
         var roboisseurSystem = entitySystemManager.GetEntitySystem<RoboisseurSystem>();
-        var roboisseurComponent = new RoboisseurComponent();
 
         var testMap = await pair.CreateTestMap();
 
         await server.WaitAssertion(() =>
         {
-            var allProtos = roboisseurComponent.Tier2Protos.Concat(roboisseurComponent.Tier3Protos)
-                .Concat(roboisseurComponent.RobossuierRewards);
-            var enumerable = allProtos as string[] ?? allProtos.ToArray();
-            var blacklistedProtos = roboisseurComponent.BlacklistedProtos;
-            var coordinates = testMap.GridCoords;
+            var grid = mapManager.CreateGridEntity(testMap.MapId);
+            var coord = new EntityCoordinates(grid.Owner, 0, 0);
+            var protos = prototypeManager.EnumeratePrototypes<EntityPrototype>()
+                .Where(p => !p.Abstract
+                    && !pair.IsTestPrototype(p)
+                    && p.TryGetComponent<RoboisseurComponent>(out _, componentFactory))
+                .Select(p => p.ID)
+                .ToList();
 
-            Assert.That(enumerable.Any(), "Roboisseur has no valid prototypes!");
+            Console.WriteLine($"Found {protos.Count} entity prototypes with RoboisseurComponent for testing.");
 
-            foreach (var proto in enumerable)
+            foreach (var protoId in protos)
             {
-                Assert.That(prototypeManager.TryIndex(proto, out var _),
-                    $"Roboisseur has invalid prototype {proto}!");
-
-                var spawned = entityManager.SpawnEntity(proto, coordinates);
-
-                Assert.That(entityManager.HasComponent<ItemComponent>(spawned),
-                    $"Roboisseur can request non-item  {proto}");
-            }
-
-            foreach (var proto in blacklistedProtos)
-            {
-                Assert.That(prototypeManager.TryIndex(proto, out var _),
-                    $"Roboisseur has invalid prototype {proto} in blacklist!");
+                var ent = entityManager.SpawnEntity(protoId, coord);
+                var roboisseurComponent = entityManager.GetComponent<RoboisseurComponent>(ent);
+                CheckRoboisseurItemsExist(roboisseurComponent, protoId, coord, prototypeManager, entityManager);
             }
 
             // Because Server/Client pairs can be re-used between Tests, we
@@ -70,5 +63,37 @@ public sealed class RoboisseurTest
         });
 
         await pair.CleanReturnAsync();
+    }
+
+    private void CheckRoboisseurItemsExist(RoboisseurComponent roboisseurComponent,
+        EntProtoId protoId,
+        EntityCoordinates coordinates,
+        IPrototypeManager prototypeManager,
+        IEntityManager entityManager)
+    {
+        var allProtos = roboisseurComponent.Tier2Protos
+            .Concat(roboisseurComponent.Tier3Protos)
+            .Concat(roboisseurComponent.RobossuierRewards);
+        var enumerable = allProtos as string[] ?? allProtos.ToArray();
+        var blacklistedProtos = roboisseurComponent.BlacklistedProtos;
+
+        Assert.That(enumerable.Any(), $"RoboisseurComponent in {protoId} has no valid prototypes!");
+
+        foreach (var proto in enumerable)
+        {
+            Assert.That(prototypeManager.TryIndex(proto, out var _),
+                $"RoboisseurComponent in {protoId} has invalid prototype {proto}!");
+
+            var spawned = entityManager.SpawnEntity(proto, coordinates);
+
+            Assert.That(entityManager.HasComponent<ItemComponent>(spawned),
+                $"RoboisseurComponent in {protoId} can request non-item {proto}!");
+        }
+
+        foreach (var proto in blacklistedProtos)
+        {
+            Assert.That(prototypeManager.TryIndex(proto, out var _),
+                $"RoboisseurComponent in {protoId} has invalid prototype {proto} in blacklist!");
+        }
     }
 }

--- a/Content.Server/_DV/NPC/Roboisseur/RoboisseurComponent.cs
+++ b/Content.Server/_DV/NPC/Roboisseur/RoboisseurComponent.cs
@@ -99,137 +99,15 @@ namespace Content.Server.Roboisseur.Roboisseur
         };
 
         [DataField("tier2Protos")]
-        public List<String> Tier2Protos = new()
-        {
-            "FoodBurgerEmpowered",
-            "FoodSoupClown",
-            "FoodSoupChiliClown",
-            "FoodBurgerSuper",
-            "FoodNoodlesCopy",
-            // "FoodMothMallow",
-            "FoodPizzaCorncob",
-            "FoodPizzaDonkpocket",
-            "FoodSoupMonkey",
-            "FoodMothSeedSoup",
-            "FoodTartGrape",
-            "FoodMealCubancarp",
-            "FoodMealSashimi",
-            "FoodBurgerCarp",
-            "FoodMealSoftTaco",
-            "FoodMothMacBalls",
-            "FoodSoupNettle",
-            "FoodBurgerDuck",
-            "FoodBurgerBaseball"
-        };
+        public List<String> Tier2Protos = new();
 
         [DataField("tier3Protos")]
-        public List<String> Tier3Protos = new()
-        {
-            "FoodBurgerGhost",
-            "FoodSaladWatermelonFruitBowl",
-            "FoodBakedCannabisBrownieBatch",
-            "FoodPizzaDank",
-            "FoodBurgerBear",
-            "FoodBurgerMime",
-            "FoodCakeSuppermatter",
-            "FoodSoupChiliCold",
-            "FoodSoupBisque",
-            "FoodCakeSlime",
-            "FoodBurgerCrazy"
-        };
+        public List<String> Tier3Protos = new();
 
         [DataField("robossuierRewards")]
-        public IReadOnlyList<String> RobossuierRewards = new[]
-        {
-            "DrinkIceCreamGlass",
-            "FoodFrozenPopsicleOrange",
-            "FoodFrozenPopsicleBerry",
-            "FoodFrozenPopsicleJumbo",
-            "FoodFrozenSnowconeBerry",
-            "FoodFrozenSnowconeFruit",
-            "FoodFrozenSnowconeClown",
-            "FoodFrozenSnowconeMime",
-            "FoodFrozenSnowconeRainbow",
-            "FoodFrozenCornuto",
-            "FoodFrozenSundae",
-            "FoodFrozenFreezy",
-            "FoodFrozenSandwichStrawberry",
-            "FoodFrozenSandwich",
-        };
+        public IReadOnlyList<String> RobossuierRewards = new List<string>();
 
         [DataField("blacklistedProtos")]
-        public IReadOnlyList<String> BlacklistedProtos = new[]
-        {
-            "FoodBurgerSpell",
-            "FoodBreadBanana",
-            "FoodMothSqueakingFry",
-            "FoodMothFleetSalad",
-            "FoodBreadMeatSpider",
-            "FoodBurgerHuman",
-            "FoodNoodlesBoiled",
-            "FoodMothOatStew",
-            "FoodKebabSkewer",
-            "FoodSoupTomato",
-            "FoodDonkpocketBerryWarm",
-            "FoodBreadButteredToast",
-            "FoodMothCottonSoup",
-            "LeavesTobaccoDried",
-            "FoodSoupEyeball",
-            "FoodMothKachumbariSalad",
-            "FoodMeatRatdoubleKebab",
-            "FoodBurgerCorgi",
-            "FoodBreadPlain",
-            "FoodBreadBun",
-            "FoodBurgerCat",
-            "FoodSoupTomatoBlood",
-            "FoodMothSaladBase",
-            "FoodPieXeno",
-            "FoodPiePumpkin",
-            "FoodPiePumpkinSlice",
-            "FoodDonkpocketTeriyakiWarm",
-            "FoodMothBakedCheese",
-            "FoodMothPizzaCotton",
-            "AloeCream",
-            "FoodSnackPopcorn",
-            "FoodBurgerSoy",
-            "FoodMothToastedSeeds",
-            "FoodMothCornmealPorridge",
-            "FoodMothBakedCorn",
-            // "FoodBreadMoldySlice",
-            "FoodRiceBoiled",
-            "FoodMothEyeballSoup",
-            "FoodBreadCreamcheese",
-            "FoodSoupOnion",
-            "FoodBurgerAppendix",
-            "FoodBurgerRat",
-            "RegenerativeMesh",
-            "FoodCheeseCurds",
-            "FoodDonkpocketHonkWarm",
-            "FoodOatmeal",
-            "FoodBreadJellySlice",
-            "FoodMothCottonSalad",
-            // "FoodBreadMoldy",
-            "FoodDonkpocketSpicyWarm",
-            "FoodCannabisButter",
-            "FoodNoodles",
-            "FoodBreadMeat",
-            "LeavesCannabisDried",
-            "FoodBurgerCheese",
-            "FoodDonkpocketDankWarm",
-            "FoodSpaceshroomCooked",
-            "FoodMealFries",
-            "MedicatedSuture",
-            "FoodDonkpocketWarm",
-            "FoodCakePlain",
-            "DisgustingSweptSoup",
-            "FoodBurgerPlain",
-            "FoodBreadGarlicSlice",
-            "FoodSoupMushroom",
-            "FoodSoupWingFangChu",
-            "FoodBreadMeatXeno",
-            "FoodCakeBrain",
-            "FoodBurgerBrain",
-            "FoodSaladCaesar"
-        };
+        public IReadOnlyList<String> BlacklistedProtos = new List<string>();
     }
 }

--- a/Resources/Prototypes/_DV/NPC/roboisseur.yml
+++ b/Resources/Prototypes/_DV/NPC/roboisseur.yml
@@ -6,8 +6,131 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
+# TODO: These should probably be EntityTables, or some other data structure that isn't a string list
+
 - type: entity
-  parent: BaseStructure
+  id: ButlertronRecipesBase
+  abstract: true
+  components:
+  - type: Roboisseur
+    tier2Protos:
+      - FoodBurgerEmpowered
+      - FoodSoupClown
+      - FoodSoupChiliClown
+      - FoodBurgerSuper
+      - FoodNoodlesCopy
+      - FoodPizzaCorncob
+      - FoodPizzaDonkpocket
+      - FoodSoupMonkey
+      - FoodMothSeedSoup
+      - FoodTartGrape
+      - FoodMealCubancarp
+      - FoodMealSashimi
+      - FoodBurgerCarp
+      - FoodMealSoftTaco
+      - FoodMothMacBalls
+      - FoodSoupNettle
+      - FoodBurgerDuck
+      - FoodBurgerBaseball
+    tier3Protos:
+      - FoodBurgerGhost
+      - FoodSaladWatermelonFruitBowl
+      - FoodBakedCannabisBrownieBatch
+      - FoodPizzaDank
+      - FoodBurgerBear
+      - FoodBurgerMime
+      - FoodCakeSuppermatter
+      - FoodSoupChiliCold
+      - FoodSoupBisque
+      - FoodCakeSlime
+      - FoodBurgerCrazy
+    robossuierRewards:
+      - DrinkIceCreamGlass
+      - FoodFrozenPopsicleOrange
+      - FoodFrozenPopsicleBerry
+      - FoodFrozenPopsicleJumbo
+      - FoodFrozenSnowconeBerry
+      - FoodFrozenSnowconeFruit
+      - FoodFrozenSnowconeClown
+      - FoodFrozenSnowconeMime
+      - FoodFrozenSnowconeRainbow
+      - FoodFrozenCornuto
+      - FoodFrozenSundae
+      - FoodFrozenFreezy
+      - FoodFrozenSandwichStrawberry
+      - FoodFrozenSandwich
+    blacklistedProtos:
+      - FoodBurgerSpell
+      - FoodBreadBanana
+      - FoodMothSqueakingFry
+      - FoodMothFleetSalad
+      - FoodBreadMeatSpider
+      - FoodBurgerHuman
+      - FoodNoodlesBoiled
+      - FoodMothOatStew
+      - FoodKebabSkewer
+      - FoodSoupTomato
+      - FoodDonkpocketBerryWarm
+      - FoodBreadButteredToast
+      - FoodMothCottonSoup
+      - LeavesTobaccoDried
+      - FoodSoupEyeball
+      - FoodMothKachumbariSalad
+      - FoodMeatRatdoubleKebab
+      - FoodBurgerCorgi
+      - FoodBreadPlain
+      - FoodBreadBun
+      - FoodBurgerCat
+      - FoodSoupTomatoBlood
+      - FoodMothSaladBase
+      - FoodPieXeno
+      - FoodPiePumpkin
+      - FoodPiePumpkinSlice
+      - FoodDonkpocketTeriyakiWarm
+      - FoodMothBakedCheese
+      - FoodMothPizzaCotton
+      - AloeCream
+      - FoodSnackPopcorn
+      - FoodBurgerSoy
+      - FoodMothToastedSeeds
+      - FoodMothCornmealPorridge
+      - FoodMothBakedCorn
+      - FoodRiceBoiled
+      - FoodMothEyeballSoup
+      - FoodBreadCreamcheese
+      - FoodSoupOnion
+      - FoodBurgerAppendix
+      - FoodBurgerRat
+      - RegenerativeMesh
+      - FoodCheeseCurds
+      - FoodDonkpocketHonkWarm
+      - FoodOatmeal
+      - FoodBreadJellySlice
+      - FoodMothCottonSalad
+      - FoodDonkpocketSpicyWarm
+      - FoodCannabisButter
+      - FoodNoodles
+      - FoodBreadMeat
+      - LeavesCannabisDried
+      - FoodBurgerCheese
+      - FoodDonkpocketDankWarm
+      - FoodSpaceshroomCooked
+      - FoodMealFries
+      - MedicatedSuture
+      - FoodDonkpocketWarm
+      - FoodCakePlain
+      - DisgustingSweptSoup
+      - FoodBurgerPlain
+      - FoodBreadGarlicSlice
+      - FoodSoupMushroom
+      - FoodSoupWingFangChu
+      - FoodBreadMeatXeno
+      - FoodCakeBrain
+      - FoodBurgerBrain
+      - FoodSaladCaesar
+
+- type: entity
+  parent: [BaseStructure, ButlertronRecipesBase]
   id: Roboisseur
   name: Mr. Butlertron
   description: It asks for food to deliver to exotic customers across the cosmos. Powered by the latest technology in bluespace food delivery.

--- a/Resources/Prototypes/_DV/NPC/roboisseur.yml
+++ b/Resources/Prototypes/_DV/NPC/roboisseur.yml
@@ -76,7 +76,6 @@
       - LeavesTobaccoDried
       - FoodSoupEyeball
       - FoodMothKachumbariSalad
-      - FoodMeatRatdoubleKebab
       - FoodBurgerCorgi
       - FoodBreadPlain
       - FoodBreadBun


### PR DESCRIPTION
## About the PR
Removed mention of the Double Rat Kekab from Butlertron's prototype list because it does not exist

Also moved ALL of the entity prototype IDs out of the RoboisseurComponent.cs file and into YML

## Why / Balance
Fixes a test fail. As for the refactor change, makes future updates for Butlertron not fucking suck

## Technical details
I made the recipes an abstract prototype that Butlertron inherits from so that it doesn't make Butlertron's component list unreadable

I also refactored `RoboisseurTest.cs` so that it tests all _prototypes_ with the Roboisseur component, rather than testing the RoboisseurComponent's default values - this was causing a test fail. This approach makes more sense anyway because RoboisseurTest in its current state wouldn't pick up on whether or not (hypothetical) other Roboisseurs have invalid definitions.

## Media
Don't need one

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Shouldn't be any