### PR TITLE
Survival is hell

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -304,8 +304,9 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: RampingStationEventScheduler
-    startingChaosRatio: 0.02
-    shiftLengthModifier: 0.3
+    startingChaosRatio: 0.01
+    chaosModifier: 1.5
+    shiftLengthModifier: 0.25
 
 - type: entity
   id: HellshiftStationEventScheduler

--- a/Resources/Prototypes/_DEN/random_presets.yml
+++ b/Resources/Prototypes/_DEN/random_presets.yml
@@ -5,13 +5,13 @@
 - type: presetPicker
   id: HighDanger
   possibleWeightedPresets:
-    SurvivalIrregularExtended: 0.6
-    Hellshift: 0.2
-    Nukeops: 0.2
+    Survival: 0.5
+    Hellshift: 0.25
+    Nukeops: 0.25
 
 - type: presetPicker
   id: LowDanger
   possibleWeightedPresets:
-    Survival: 0.6
+    SurvivalIrregularExtended: 0.6
     Extended: 0.2
     Traitor: 0.2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Survival has been made worse, as the gods intended.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
High Danger should be higher danger.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Tweaked Survival to be higher danger, and Irregular Extended has been changed to low danger.
- tweak: There is a 0.5% higher chance of Hellshift and Nukeops on High Danger.