### PR TITLE
No More Ninja Emag Objective

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -209,7 +209,7 @@
   - type: AntagObjectives
     objectives:
     #- StealResearchObjective # DeltaV: Moved to random objectives
-  #  - DoorjackObjective
+  #  - DoorjackObjective # Den: bad objective, use cooler ones
     - SpiderChargeObjective
     #- TerrorObjective # DeltaV: Moved to random objectives
     #- MassArrestObjective # DeltaV: Moved to random objectives


### PR DESCRIPTION
removed ninja emag objective because we have like 30 more objectives now which are better and more fun

:cl:
- remove: The ninja no longer gets the emag objective