### PR TITLE
[TWEAK]: Balance Changes to Loadouts & Guns

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -59,7 +59,7 @@
       - id: WeaponDisabler
         prob: 0.3
       - id: ClothingBeltSecurityFilled
-      - id: ClothingHandsGlovesKravMaga # Goobstation - Martial Arts
+      # - id: ClothingHandsGlovesKravMaga # Goobstation - Martial Arts
       - id: Flash
       - id: ClothingEyesGlassesSunglasses
       - id: ClothingHeadsetAltSecurity

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Security/warden.yml
@@ -46,6 +46,8 @@
       id: LoadoutWardenShield #TheDen
     - type: loadout
       id: LoadoutWardenShotgun #TheDen
+    - type: loadout
+      id: LoadoutWardenGlovesKravMaga #TheDen
 
 
 #- type: characterItemGroup
@@ -59,6 +61,8 @@
   items:
     - type: loadout
       id: LoadoutClothingHandsGlovesCombat
+    - type: loadout
+      id: LoadoutWardenGlovesKravMaga #TheDen
 
 - type: characterItemGroup
   id: LoadoutWardenHead

--- a/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -133,7 +133,7 @@
 - type: loadout
   id: LoadoutBSORifleChester
   category: JobsCommandBlueshieldOfficer
-  cost: 0
+  cost: 6
   canBeHeirloom: true
   guideEntry: SecurityWeapons
   requirements:
@@ -145,44 +145,44 @@
   items:
     - WeaponLeverChester
 
-- type: loadout
-  id: LoadoutMagazineShotgunLeverRifle
-  category: JobsCommandBlueshieldOfficer
-  cost: 2
-  exclusive: true
-  requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Security
-      min: 3600 # 1 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - MagazineShotgunLeverRifle
+# - type: loadout
+#   id: LoadoutMagazineShotgunLeverRifle
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 2
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterDepartmentTimeRequirement
+#       department: Security
+#       min: 3600 # 1 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSecurityEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - MagazineShotgunLeverRifle
 
-- type: loadout
-  id: LoadoutMagazineShotgunLeverRifleSpare
-  category: JobsCommandBlueshieldOfficer
-  cost: 4
-  exclusive: true
-  requirements:
-    - !type:CharacterDepartmentTimeRequirement
-      department: Security
-      min: 3600 # 1 hours
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutSecurityEquipment
-    - !type:CharacterJobRequirement
-      jobs:
-        - BlueshieldOfficer
-  items:
-    - MagazineShotgunLeverRifle
+# - type: loadout
+#   id: LoadoutMagazineShotgunLeverRifleSpare
+#   category: JobsCommandBlueshieldOfficer
+#   cost: 4
+#   exclusive: true
+#   requirements:
+#     - !type:CharacterDepartmentTimeRequirement
+#       department: Security
+#       min: 3600 # 1 hours
+#     - !type:CharacterItemGroupRequirement
+#       group: LoadoutSecurityEquipment
+#     - !type:CharacterJobRequirement
+#       jobs:
+#         - BlueshieldOfficer
+#   items:
+#     - MagazineShotgunLeverRifle
 
 - type: loadout
   id: LoadoutBSORifleBRDIR25
   category: JobsCommandBlueshieldOfficer
-  cost: 9 # Significant upgrade over a Chester, offered here for the STYLE. Intentionally priced at you not being able to buy all 3 medical items alongside it, plus being unable to buy it alongside the CQC Manual.
+  cost: 6 # Significant upgrade over a Chester, offered here for the STYLE. Intentionally priced at you not being able to buy all 3 medical items alongside it, plus being unable to buy it alongside the CQC Manual.
   canBeHeirloom: true
   guideEntry: SecurityWeapons
   requirements:

--- a/Resources/Prototypes/_DEN/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -39,3 +39,16 @@
   parent: WeaponEnergyShotgun
   id: WeaponEnergyShotgunWarden
   description: One of a few surviving prototypes of an energy shotgun, which never made it to mass production. It offers the possibility of both lethal and non-lethal shots, making it a versatile weapon.
+  components:
+  - type: ProjectileBatteryAmmoProvider
+    proto: BulletLaserSpread
+    fireCost: 200
+  - type: BatteryWeaponFireModes
+    fireModes:
+    - proto: BulletLaserSpread
+      fireCost: 200
+    - proto: BulletDisablerSmgSpread
+      fireCost: 100
+  - type: Battery
+    maxCharge: 1000
+    startingCharge: 1000

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/warden.yml
@@ -79,6 +79,23 @@
     - WeaponEnergyShotgunWarden
 
 - type: loadout
+  id: LoadoutWardenGlovesKravMaga
+  category: JobsSecurityWarden
+  cost: 0
+  exclusive: true
+  canBeHeirloom: true
+  requirements:
+    - !type:CharacterJobRequirement
+      jobs:
+        - Warden
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWardenWeapons
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutWardenGloves
+  items:
+    - ClothingHandsGlovesKravMaga
+
+- type: loadout
   id: LoadoutUniformJumpsuitWarden
   category: JobsSecurityWarden
   cost: 0

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Back/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Back/modsuit.yml
@@ -66,7 +66,7 @@
     slots:
       cell_slot: true
   - type: PowerCellDraw
-    drawRate: 1 # Sealed draw rate
+    drawRate: 0.5 # Sealed draw rate
   - type: PowerCellSlot
     cellSlotId: cell_slot
     fitsInCharger: false

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -76,9 +76,9 @@
   - type: Gun
     fireRate: 3.8
     projectileSpeed: 30
-    burstFireRate: 4
+    burstFireRate: 7.5
     shotsPerBurst: 2
-    burstCooldown: 0.8
+    burstCooldown: 1
     selectedMode: Burst
     availableModes:
       - Burst


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
**Warden**
- Removed Slug fire mode from e-shotgun
- Reduced battery size on e-shotgun
- Rebalanced battery cost on Disabler and Lethal fire modes
-- 10 disabler volleys/5 lethal volleys
- Removed Krav Maga gloves from locker
- Krav Maga gloves can now be selected as the Wardens loadout weapon

**Blue Shield Officer**
- Increased Chester loadout cost to 6 points
- Decreased BRDI loadout cost to 6 points
- Removed spare magazines for the Chester from the loadout
- Reduced the drain of the Praetorian Modsuit when deployed

**Salvage Specialist**
- Increased the burst fire rate of the Gestio from 6 => 7
- Increased the time between bursts from 0.8 => 1.0 seconds


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
No more stealing krav maga gloves. The energy shotgun is a bit over-tuned and shouldn't have been handed out in it's base state. 

The Chester has been buffed, and no longer deserves to be free. Likewise, the BRDI has been nerfed and doesn't need to be so expensive. 
No other primary has ammo available in the loadout, and the cost of 2 mags is now the cost of the Chester. Go ask the Warden/HOS/ACO nicely.

The Gestio nerfed a little too hard, this makes it *feel* better to use, without giving it too much power back.

## Technical details
<!-- Summary of code changes for easier review. -->
.yml changes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Jakumba
- fix: Modsuit drain should now be correct. BSOs' and Deserters rejoice.
- tweak: Krav Maga gloves are now a loadout option for the Warden
- tweak: Rebalanced the Warden antique energy shotgun
- tweak: Gestio burst fire is faster, but the time between bursts is also increased
- tweak: BSOs' Chester loadout cost has increased 0 => 6 points
- tweak: BSOs' BRDI loadout cost has decreased 9 => 6 points
- remove: Krav Maga gloves from the Warden locker
- remove: Spare Chester mags from BSOs' loadout
