### PR TITLE
No Slot Cost

### DIFF
--- a/Resources/Prototypes/_DEN/Traits/physical.yml
+++ b/Resources/Prototypes/_DEN/Traits/physical.yml
@@ -140,6 +140,7 @@
   id: TailWag
   category: TraitsPhysicalBiological
   points: 0
+  slots: 0
   requirements:
   - !type:CharacterJobRequirement
     inverted: true

--- a/Resources/Prototypes/_Floof/Traits/lewd.yml
+++ b/Resources/Prototypes/_Floof/Traits/lewd.yml
@@ -10,6 +10,7 @@
 - type: trait
   id: CumProducer
   category: Lewd
+  slots: 0
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -44,6 +45,7 @@
 - type: trait
   id: MilkProducer
   category: Lewd
+  slots: 0
   requirements:
     - !type:CharacterJobRequirement
       inverted: true
@@ -78,6 +80,7 @@
 - type: trait
   id: SquirtProducer
   category: Lewd
+  slots: 0
   requirements:
     - !type:CharacterJobRequirement
       inverted: true

--- a/Resources/Prototypes/_Floof/Traits/mental.yml
+++ b/Resources/Prototypes/_Floof/Traits/mental.yml
@@ -9,6 +9,7 @@
   id: HypnoticGaze
   category: Mental
   points: 0
+  slots: 0
   functions:
     - !type:TraitAddPsionics
       psionicPowers:


### PR DESCRIPTION
Traits that now no longer cost a slot:
- All body-related lewd traits
- Tail wag
- Hypnotic gaze

Body and tail stuff is because you just kinda have it. Hypnotic gaze doesn't take up a slot because it can't be used without consent anyway.

:cl:
- tweak: Certain traits no longer take up a slot.