### PR TITLE
Added Relevant Ccvars to Debug and Tool Builds

### DIFF
--- a/Resources/ConfigPresets/Build/debug.toml
+++ b/Resources/ConfigPresets/Build/debug.toml
@@ -13,3 +13,6 @@ enabled = true
 
 [shuttle]
 auto_call_time = 0
+
+[rules]
+exempt_local = true

--- a/Resources/ConfigPresets/Build/debug.toml
+++ b/Resources/ConfigPresets/Build/debug.toml
@@ -7,6 +7,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
+[game]
+traits_max = 25
+traits_default_points = 20
+loadouts_points = 30
+
 [events]
 # Annoying - setting to false disabled all events.
 enabled = true

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -42,3 +42,6 @@ see_own_notes = true
 
 [lavaland] # Lavaland Change
 enabled = false
+
+[rules]
+exempt_local = true

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -16,6 +16,9 @@ lobbyenabled = false
 # Dev map for faster loading & convenience
 map = "Dev"
 role_timers = false
+traits_max = 25
+traits_default_points = 20
+loadouts_points = 30
 
 [gateway]
 generator_enabled = false


### PR DESCRIPTION
## About the PR
No more "are you 18" popup on debug and tools builds plus the amount of traits, trait points and loadout points on release and debug/tool builds is the same now. 

## Technical details
Set existing CCVars to the correct setting for debug and tool builds.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**
:cl:
- fix: No more "are you 18" popup on debug and tools builds. Contributors and mappers rejoice!
- fix: The amount of traits, trait points and loadout points on release and debug/tool builds is the same now. 