### PR TITLE
Fix Vent & Thermomachine Disassembly

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosPipeLayersSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosPipeLayersSystem.cs
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2025 ArtisticRoomba
+// SPDX-FileCopyrightText: 2025 Carlen White
+// SPDX-FileCopyrightText: 2025 Perry Fraser
 // SPDX-FileCopyrightText: 2025 chromiumboy
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Server/Atmos/EntitySystems/AtmosPipeLayersSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosPipeLayersSystem.cs
@@ -43,7 +43,7 @@ public sealed partial class AtmosPipeLayersSystem : SharedAtmosPipeLayersSystem
         if (ent.Comp.PipeLayersLocked)
             return;
 
-        base.SetPipeLayer(ent, layer);
+        base.SetPipeLayer(ent, layer, user, used);
 
         if (!TryComp<NodeContainerComponent>(ent, out var nodeContainer))
             return;

--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2025 ArtisticRoomba
+// SPDX-FileCopyrightText: 2025 Carlen White
+// SPDX-FileCopyrightText: 2025 Perry Fraser
 // SPDX-FileCopyrightText: 2025 chromiumboy
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later

--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
@@ -124,14 +124,16 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
         if (ent.Comp.NumberOfPipeLayers <= 1 || ent.Comp.PipeLayersLocked)
             return;
 
+        if (!TryComp<ToolComponent>(args.Used, out var tool) || !_tool.HasQuality(args.Used, ent.Comp.Tool, tool))
+            return;
+
         if (TryComp<SubFloorHideComponent>(ent, out var subFloorHide) && subFloorHide.IsUnderCover)
         {
-            _popup.PopupPredicted(Loc.GetString("atmos-pipe-layers-component-cannot-adjust-pipes"), ent, args.User);
+            _popup.PopupClient(Loc.GetString("atmos-pipe-layers-component-cannot-adjust-pipes"), ent, args.User);
             return;
         }
 
-        if (TryComp<ToolComponent>(args.Used, out var tool) && _tool.HasQuality(args.Used, ent.Comp.Tool, tool))
-            _tool.UseTool(args.Used, args.User, ent, ent.Comp.Delay, tool.Qualities, new TrySetNextPipeLayerCompletedEvent());
+        _tool.UseTool(args.Used, args.User, ent, ent.Comp.Delay, tool.Qualities, new TrySetNextPipeLayerCompletedEvent());
     }
 
     private void OnUseInHandEvent(Entity<AtmosPipeLayersComponent> ent, ref UseInHandEvent args)
@@ -146,7 +148,7 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
                 var toolName = Loc.GetString(toolProto.ToolName).ToLower();
                 var message = Loc.GetString("atmos-pipe-layers-component-tool-missing", ("toolName", toolName));
 
-                _popup.PopupPredicted(message, ent, args.User);
+                _popup.PopupClient(message, ent, args.User);
             }
 
             return;
@@ -222,7 +224,7 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
             var layerName = GetPipeLayerName(ent.Comp.CurrentPipeLayer);
             var message = Loc.GetString("atmos-pipe-layers-component-change-layer", ("layerName", layerName));
 
-            _popup.PopupPredicted(message, ent, user);
+            _popup.PopupClient(message, ent, user);
         }
     }
 

--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosPipeLayersSystem.cs
@@ -37,7 +37,10 @@ public abstract partial class SharedAtmosPipeLayersSystem : EntitySystem
 
         SubscribeLocalEvent<AtmosPipeLayersComponent, ExaminedEvent>(OnExamined);
         SubscribeLocalEvent<AtmosPipeLayersComponent, GetVerbsEvent<Verb>>(OnGetVerb);
+        /* FIXME: Vents and thermomachines depend on being screwdriven and this interferes with that.
+            For the time being this will be disabled. Using the Verbs will work per usual.
         SubscribeLocalEvent<AtmosPipeLayersComponent, InteractUsingEvent>(OnInteractUsing);
+        */
         SubscribeLocalEvent<AtmosPipeLayersComponent, UseInHandEvent>(OnUseInHandEvent);
         SubscribeLocalEvent<AtmosPipeLayersComponent, TrySetNextPipeLayerCompletedEvent>(OnSetNextPipeLayerCompleted);
         SubscribeLocalEvent<AtmosPipeLayersComponent, TrySettingPipeLayerCompletedEvent>(OnSettingPipeLayerCompleted);


### PR DESCRIPTION
Fixes this [Discord Thread](https://discord.com/channels/1301753657024319488/1394313641402175508)

## About the PR
Because of the deconstruction steps of the vents and thermomachines conflicting with changing the pipe layer, ~~`PipeLayersLockedIfUnanchored` was added so vents can be deconstructed~~ the interaction has been commented out. This was the least egregious fix personally since alternatives are:
 * removing the ability to weld shut a unanchored vent by it going straight for sheets, or
 * using wirecutters instead of a screwdriver first.

It also includes a upstream cherry-pick fixing some edge cases with popups.

**Changelog**
:cl:
- removed: Removed using a screwdriver directly on pipes to change its layer as it conflicts with deconstruction of vents and thermomachines. You can still right-click and use the verbs instead or hold the device and use while having a screwdriver in the off-hand. This will be revisited for a better solution.
- fixed: Vents and thermomachines can be deconstructed again.
