### PR TITLE
FIx Consent Menu Description Overflow

### DIFF
--- a/Content.Client/Consent/UI/Windows/ConsentWindow.xaml.cs
+++ b/Content.Client/Consent/UI/Windows/ConsentWindow.xaml.cs
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 Pierson Arnold <greyalphawolf7@gmail.com>
-// SPDX-FileCopyrightText: 2024 sleepyyapril <***>
-// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 Pierson Arnold
+// SPDX-FileCopyrightText: 2025 sleepyyapril
+// SPDX-FileCopyrightText: 2025 wheelwrightt
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Content.Client/Consent/UI/Windows/ConsentWindow.xaml.cs
+++ b/Content.Client/Consent/UI/Windows/ConsentWindow.xaml.cs
@@ -130,9 +130,10 @@ public sealed partial class ConsentWindow : FancyWindow
 
         container.AddChild(header);
 
-        var desc = new Label
+        var desc = new RichTextLabel
         {
             Text = Loc.GetString($"consent-{prototype.ID}-desc"),
+            MaxWidth = 850,
         };
 
         container.AddChild(desc);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Text in the description of the consent menu should no longer overflow and instead move to the next line. Fixes #945 

## Technical details
Consent option descriptions are now a RichTextLabel with MaxWidth = 850. The text should now wrap at a comfortable line length and remain readable (This was tested on a 1920x1080 monitor).

## Media
Fixed
<img width="959" height="712" alt="fixed" src="https://github.com/user-attachments/assets/f589231c-4fe0-4155-88fb-7a58a6a0fa3d" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**
:cl: Wheels
- fix: Consent menu descriptions should no longer overflow
