### PR TITLE
Traitor spawns

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -196,7 +196,7 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]
-      max: 2 # Floof - Balance around Security Pop
+      max: 6 # Floof - Balance around Security Pop
       playerRatio: 10
       blacklist:
         components:

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -83,24 +83,24 @@
       state: shuttle
   - type: EscapeShuttleCondition
 
-- type: entity
-  categories: [HideSpawnMenu]
-  parent: BaseTraitorObjective
-  id: DieObjective
-  name: Die a glorious death
-  description: Die.
-  components:
-  - type: Objective
-    difficulty: 0.5
-    icon:
-      sprite: Mobs/Ghosts/ghost_human.rsi
-      state: icon
-  - type: ObjectiveBlacklistRequirement
-    blacklist:
-      components:
-      - EscapeShuttleCondition
-      - StealCondition
-  - type: DieCondition
+# - type: entity
+#   categories: [HideSpawnMenu]
+#   parent: BaseTraitorObjective
+#   id: DieObjective
+#   name: Die a glorious death
+#   description: Die.
+#   components:
+#   - type: Objective
+#     difficulty: 0.5
+#     icon:
+#       sprite: Mobs/Ghosts/ghost_human.rsi
+#       state: icon
+#   - type: ObjectiveBlacklistRequirement
+#     blacklist:
+#       components:
+#       - EscapeShuttleCondition
+#       - StealCondition
+#   - type: DieCondition
 
 - type: entity
   categories: [HideSpawnMenu]


### PR DESCRIPTION
Removed Die a Glorious Death
Increased maximum number of traitors per event from 2 to 6 (requires 60 players to hit 6 traitors)

2 traitors on 50 pop...

:cl:
- tweak: Maximum number of traitors per event from2 to 6, requiring 60 people to hit 6.
- remove: Removed die a glorious death objective.