### PR TITLE
Selfdamage bugfixes / improvements

### DIFF
--- a/Content.Server/_DEN/Administration/Commands/SelfDamageCommand.cs
+++ b/Content.Server/_DEN/Administration/Commands/SelfDamageCommand.cs
@@ -9,6 +9,7 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Robust.Shared.Console;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Server._DEN.Administration.Commands;
 
@@ -21,6 +22,8 @@ sealed class SelfDamageCommand : IConsoleCommand
     public string Command => "selfdamage";
     public string Description => Loc.GetString("self-damage-command-description");
     public string Help => Loc.GetString("self-damage-command-help", ("command", Command));
+
+    private string _defaultDamageType = "Brute";
 
     private string[] _ignoreTypesGroups = new[]
     {
@@ -71,59 +74,73 @@ sealed class SelfDamageCommand : IConsoleCommand
     {
         if (!float.TryParse(args[0], out var amount))
         {
-            shell.WriteLine(Loc.GetString("damage-command-error-quantity", ("arg", args[1])));
+            shell.WriteError(Loc.GetString("damage-command-error-quantity", ("arg", args[0])));
             func = null;
             return false;
         }
 
-        var damageTypeOrGroup = args.Length > 2 ? args[1] : "Brute";
+        if (!args.TryGetValue(1, out var damageTypeOrGroup))
+            damageTypeOrGroup = _defaultDamageType;
 
         if (_ignoreTypesGroups.Contains(damageTypeOrGroup))
         {
-            shell.WriteLine("You cannot use this damage type or group.");
+            shell.WriteError(Loc.GetString("damage-command-error-forbidden-damage-type", ("arg", damageTypeOrGroup)));
             func = null;
             return false;
         }
 
         if (amount <= 0)
         {
-            shell.WriteLine("You cannot do negative or zero damage.");
+            shell.WriteError(Loc.GetString("damage-command-error-negative-or-zero"));
             func = null;
             return false;
         }
 
+        DamageSpecifier? damageSpecifier = null;
+
         if (_prototypeManager.TryIndex<DamageGroupPrototype>(damageTypeOrGroup, out var damageGroup))
-        {
-            func = (entity, ignoreResistances) =>
-            {
-                var damage = new DamageSpecifier(damageGroup, amount);
-                _entManager.System<DamageableSystem>().TryChangeDamage(entity, damage, ignoreResistances);
-            };
+            damageSpecifier = new DamageSpecifier(damageGroup, amount);
+        else if (_prototypeManager.TryIndex<DamageTypePrototype>(damageTypeOrGroup, out var damageType))
+            damageSpecifier = new DamageSpecifier(damageType, amount);
 
-            return true;
+        if (damageSpecifier == null)
+        {
+            shell.WriteLine(Loc.GetString("damage-command-error-type", ("arg", damageTypeOrGroup)));
+            func = null;
+            return false;
         }
 
-        if (_prototypeManager.TryIndex<DamageTypePrototype>(damageTypeOrGroup, out var damageType))
+        func = (entity, ignoreResistances) =>
         {
-            func = (entity, ignoreResistances) =>
+            var name = entity.ToString();
+            if (_entManager.TryGetComponent<MetaDataComponent>(entity, out var meta))
+                name = meta.EntityName;
+
+            var damageResult = _entManager.System<DamageableSystem>()
+                .TryChangeDamage(entity, damageSpecifier, ignoreResistances);
+
+            if (damageResult == null)
             {
-                var damage = new DamageSpecifier(damageType, amount);
-                _entManager.System<DamageableSystem>().TryChangeDamage(entity, damage, ignoreResistances);
-            };
+                shell.WriteError(Loc.GetString("damage-command-fail-message",
+                    ("entity", name)));
+                return;
+            }
 
-            return true;
-        }
+            shell.WriteLine(Loc.GetString("damage-command-success-message",
+                ("damage", damageResult.GetTotal()),
+                ("type", damageTypeOrGroup),
+                ("entity", name)));
+        };
 
-        shell.WriteLine(Loc.GetString("damage-command-error-type", ("arg", args[0])));
-        func = null;
-        return false;
+        return true;
     }
 
     public void Execute(IConsoleShell shell, string argStr, string[] args)
     {
         if (args.Length < 1 || args.Length > 3)
         {
-            shell.WriteLine(Loc.GetString("damage-command-error-args"));
+            shell.WriteError(Loc.GetString("damage-command-error-args"));
+            shell.WriteLine(Help);
             return;
         }
 
@@ -133,7 +150,7 @@ sealed class SelfDamageCommand : IConsoleCommand
             target = playerEntity;
         else
         {
-            shell.WriteLine(Loc.GetString("self-damage-command-error-player"));
+            shell.WriteError(Loc.GetString("self-damage-command-error-player"));
             return;
         }
 
@@ -145,7 +162,7 @@ sealed class SelfDamageCommand : IConsoleCommand
         {
             if (!bool.TryParse(args[2], out ignoreResistances))
             {
-                shell.WriteLine(Loc.GetString("damage-command-error-bool", ("arg", args[2])));
+                shell.WriteError(Loc.GetString("damage-command-error-bool", ("arg", args[2])));
                 return;
             }
         }

--- a/Resources/Locale/en-US/damage/damage-command.ftl
+++ b/Resources/Locale/en-US/damage/damage-command.ftl
@@ -5,10 +5,10 @@
 
 ## Damage command loc.
 
-damage-command-description = Add or remove damage to an entity. 
+damage-command-description = Add or remove damage to an entity.
 damage-command-help = Usage: {$command} <type/group> <amount> [ignoreResistances] [uid]
 
-self-damage-command-description = Add or remove damage to yourself, for RP purposes. 
+self-damage-command-description = Add or remove damage to yourself, for RP purposes.
 self-damage-command-help = Usage: {$command} <amount> <type/group> [ignoreResistances]
 
 self-damage-command-error-player = No entity attached to session.
@@ -17,9 +17,14 @@ damage-command-arg-type = <damage type or group>
 damage-command-arg-quantity = [quantity]
 damage-command-arg-target = [target euid]
 
+damage-command-error-negative-or-zero = Damage amount must be greater than 0.
+damage-command-error-forbidden-damage-type = {$arg} is a forbidden damage group or type.
 damage-command-error-type = {$arg} is not a valid damage group or type.
 damage-command-error-euid = {$arg} is not a valid entity uid.
 damage-command-error-quantity = {$arg} is not a valid quantity.
 damage-command-error-bool = {$arg} is not a valid bool.
-damage-command-error-player = No entity attached to session. You must specify a target uid
-damage-command-error-args = Invalid number of arguments 
+damage-command-error-player = No entity attached to session. You must specify a target uid.
+damage-command-error-args = Invalid number of arguments.
+
+damage-command-success-message = Dealt {$damage} {$type} damage to {$entity}.
+damage-command-fail-message = Could not deal damage to {$entity}!


### PR DESCRIPTION
## About the PR
Fixed a bug with Selfdamage command where only providing two arguments causes you to default to Brute damage.
In addition, the command has been given improved console feedback in general for better user experience.

Namely:
- Successful selfdamage commands now tell you how much damage was inflicted and what type.
- A couple of unlocalized error messages were converted into locales.
- If your character cannot take damage, there will be a "failure" message.
- Putting in the wrong number of arguments (0 or 4+) will display usage instructions for the command.

## Why / Balance
Bug report

## Technical details
I did a little bit of refactoring to make the code a little easier to follow.

## Media
<img width="623" height="299" alt="image" src="https://github.com/user-attachments/assets/4a7f0f84-0299-4ecb-897b-c42c62af27ba" />
<img width="436" height="255" alt="image" src="https://github.com/user-attachments/assets/5ac6340c-2e87-427e-8b19-8468f3e8a4af" />
<img width="426" height="290" alt="image" src="https://github.com/user-attachments/assets/f9e6164a-1ad2-4e6b-86a0-dfc73089754a" />
<img width="457" height="212" alt="image" src="https://github.com/user-attachments/assets/b2be0ff8-a9f1-44a4-be85-7045beec8136" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed selfdamage command improperly using "Brute" damage when only two arguments are provided.
- tweak: Selfdamage command has improved console response messages - now you'll be given details if the command succeeded!