### PR TITLE
NoRandom Datafield

### DIFF
--- a/Content.Server/Research/Oracle/OracleSystem.cs
+++ b/Content.Server/Research/Oracle/OracleSystem.cs
@@ -195,7 +195,7 @@ public sealed class OracleSystem : EntitySystem
         if (_random.Prob(oracle.Comp.AbnormalReagentChance))
         {
             var allReagents = _protoMan.EnumeratePrototypes<ReagentPrototype>()
-                .Where(x => !x.Abstract)
+                .Where(x => !x.Abstract && !x.NoRandom)
                 .Select(x => x.ID).ToList();
 
             reagent = _random.Pick(allReagents);

--- a/Content.Server/Research/Oracle/OracleSystem.cs
+++ b/Content.Server/Research/Oracle/OracleSystem.cs
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2024 FoxxoTrystan <trystan.garnierhein@gmail.com>
-// SPDX-FileCopyrightText: 2024 Mnemotechnican <69920617+Mnemotechnician@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Rane <60792108+Elijahrane@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 ShatteredSwords <135023515+ShatteredSwords@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 sleepyyapril <flyingkarii@gmail.com>
-// SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>
-// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2024 FoxxoTrystan
+// SPDX-FileCopyrightText: 2024 Mnemotechnican
+// SPDX-FileCopyrightText: 2024 Rane
+// SPDX-FileCopyrightText: 2024 ShatteredSwords
+// SPDX-FileCopyrightText: 2025 MajorMoth
+// SPDX-FileCopyrightText: 2025 VMSolidus
+// SPDX-FileCopyrightText: 2025 sleepyyapril
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -186,6 +186,15 @@ namespace Content.Shared.Chemistry.Reagent
         [DataField]
         public SoundSpecifier FootstepSound = new SoundCollectionSpecifier("FootstepWater", AudioParams.Default.WithVolume(6));
 
+        // The Den start
+        /// <summary>
+        /// This helps exclude certain reagents from systems that pick a completely random reagent. 
+        /// </summary>
+        [DataField]
+
+        public bool NoRandom = false;
+        // The Den end
+
         public FixedPoint2 ReactionTile(TileRef tile, FixedPoint2 reactVolume)
         {
             var removed = FixedPoint2.Zero;

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -1,43 +1,38 @@
-// SPDX-FileCopyrightText: 2019 moneyl <8206401+Moneyl@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2020 Injazz <injazza@gmail.com>
-// SPDX-FileCopyrightText: 2020 Víctor Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2020 Víctor Aguilera Puerto <zddm@outlook.es>
-// SPDX-FileCopyrightText: 2020 nuke <47336974+nuke-makes-games@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2021 Acruid <shatter66@gmail.com>
-// SPDX-FileCopyrightText: 2021 Paul <ritter.paul1+git@googlemail.com>
-// SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-// SPDX-FileCopyrightText: 2021 TemporalOroboros <TemporalOroboros@gmail.com>
-// SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <6766154+Zumorica@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto <gradientvera@outlook.com>
-// SPDX-FileCopyrightText: 2021 ike709 <ike709@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2021 py01 <60152240+collinlunn@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Alex Evgrashin <aevgrashin@yandex.ru>
-// SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Moony <moonheart08@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Paul Ritter <ritter.paul1@googlemail.com>
-// SPDX-FileCopyrightText: 2022 Rane <60792108+Elijahrane@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Sam Weaver <weaversam8@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 ShadowCommander <10494922+ShadowCommander@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 corentt <36075110+corentt@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 metalgearsloth <comedian_vs_clown@hotmail.com>
-// SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
-// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Kara <lunarautomaton6@gmail.com>
-// SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Moony <moony@hellomouse.net>
-// SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Slava0135 <40753025+Slava0135@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Visne <39844191+Visne@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 deltanedas <39013340+deltanedas@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 deltanedas <@deltanedas:kde.org>
-// SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Adrian16199 <144424013+Adrian16199@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT <77995199+DEATHB4DEFEAT@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
-// SPDX-FileCopyrightText: 2024 sleepyyapril <flyingkarii@gmail.com>
-// SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2019 moneyl
+// SPDX-FileCopyrightText: 2020 Injazz
+// SPDX-FileCopyrightText: 2020 Víctor Aguilera Puerto
+// SPDX-FileCopyrightText: 2020 nuke
+// SPDX-FileCopyrightText: 2021 Acruid
+// SPDX-FileCopyrightText: 2021 Paul
+// SPDX-FileCopyrightText: 2021 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2021 TemporalOroboros
+// SPDX-FileCopyrightText: 2021 Vera Aguilera Puerto
+// SPDX-FileCopyrightText: 2021 ike709
+// SPDX-FileCopyrightText: 2021 py01
+// SPDX-FileCopyrightText: 2022 Alex Evgrashin
+// SPDX-FileCopyrightText: 2022 Flipp Syder
+// SPDX-FileCopyrightText: 2022 Paul Ritter
+// SPDX-FileCopyrightText: 2022 Rane
+// SPDX-FileCopyrightText: 2022 Sam Weaver
+// SPDX-FileCopyrightText: 2022 ShadowCommander
+// SPDX-FileCopyrightText: 2022 corentt
+// SPDX-FileCopyrightText: 2022 mirrorcult
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2023 Kara
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 Moony
+// SPDX-FileCopyrightText: 2023 Nemanja
+// SPDX-FileCopyrightText: 2023 Slava0135
+// SPDX-FileCopyrightText: 2023 Visne
+// SPDX-FileCopyrightText: 2023 deltanedas
+// SPDX-FileCopyrightText: 2023 metalgearsloth
+// SPDX-FileCopyrightText: 2024 Adrian16199
+// SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT
+// SPDX-FileCopyrightText: 2024 SlamBamActionman
+// SPDX-FileCopyrightText: 2024 Tayrtahn
+// SPDX-FileCopyrightText: 2024 themias
+// SPDX-FileCopyrightText: 2025 MajorMoth
+// SPDX-FileCopyrightText: 2025 sleepyyapril
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/_Floof/Reagents/Aphrodisiacs/medicine.yml
+++ b/Resources/Prototypes/_Floof/Reagents/Aphrodisiacs/medicine.yml
@@ -59,6 +59,7 @@
         conditions:
           - !type:ReagentThreshold
             max: 0.1
+  noRandom: true # The Den
 
 - type: reagent
   id: Philterex
@@ -137,3 +138,4 @@
         conditions:
           - !type:ReagentThreshold
             max: 0.1
+  noRandom: true # The Den

--- a/Resources/Prototypes/_Floof/Reagents/Aphrodisiacs/medicine.yml
+++ b/Resources/Prototypes/_Floof/Reagents/Aphrodisiacs/medicine.yml
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2024 FoxxoTrystan
 # SPDX-FileCopyrightText: 2024 ShatteredSwords
+# SPDX-FileCopyrightText: 2025 MajorMoth
 # SPDX-FileCopyrightText: 2025 Rosycup
 # SPDX-FileCopyrightText: 2025 SleepyScarecrow
+# SPDX-FileCopyrightText: 2025 Vanessa
 # SPDX-FileCopyrightText: 2025 Vanessa Louwagie
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 #

--- a/Resources/Prototypes/_Floof/Reagents/Aphrodisiacs/narcotics.yml
+++ b/Resources/Prototypes/_Floof/Reagents/Aphrodisiacs/narcotics.yml
@@ -58,3 +58,4 @@
         conditions:
           - !type:ReagentThreshold
             max: 0.1
+  noRandom: true # The Den

--- a/Resources/Prototypes/_Floof/Reagents/Aphrodisiacs/narcotics.yml
+++ b/Resources/Prototypes/_Floof/Reagents/Aphrodisiacs/narcotics.yml
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2024 FoxxoTrystan
 # SPDX-FileCopyrightText: 2024 ShatteredSwords
+# SPDX-FileCopyrightText: 2025 MajorMoth
 # SPDX-FileCopyrightText: 2025 Rosycup
 # SPDX-FileCopyrightText: 2025 SleepyScarecrow
+# SPDX-FileCopyrightText: 2025 Vanessa
 # SPDX-FileCopyrightText: 2025 Vanessa Louwagie
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 #

--- a/Resources/Prototypes/_Floof/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/_Floof/Reagents/Consumable/Drink/alcohol.yml
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: 2024 Fansana <116083121+Fansana@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 FoxxoTrystan <trystan.garnierhein@gmail.com>
-# SPDX-FileCopyrightText: 2024 SleepyScarecrow <sharedjunkemail69@gmail.com>
-# SPDX-FileCopyrightText: 2024 neuPanda <chriseparton@gmail.com>
-# SPDX-FileCopyrightText: 2025 Rosycup <178287475+Rosycup@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 SleepyScarecrow <136123749+SleepyScarecrow@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Fansana
+# SPDX-FileCopyrightText: 2024 FoxxoTrystan
+# SPDX-FileCopyrightText: 2024 neuPanda
+# SPDX-FileCopyrightText: 2025 MajorMoth
+# SPDX-FileCopyrightText: 2025 Rosycup
+# SPDX-FileCopyrightText: 2025 SleepyScarecrow
+# SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/_Floof/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/_Floof/Reagents/Consumable/Drink/alcohol.yml
@@ -33,6 +33,7 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.09
+  noRandom: true # The Den
 
 - type: reagent
   id: A.B.Lustine
@@ -56,6 +57,7 @@
       - !type:AdjustReagent
         reagent: Pomelustine
         amount: 0.25
+  noRandom: true # The Den
 
 - type: reagent
   id: Anisette
@@ -191,6 +193,7 @@
       - !type:AdjustReagent
         reagent: Pomelustine
         amount: 0.5
+  noRandom: true # The Den
 
 - type: reagent
   id: CafeDeCacao
@@ -329,6 +332,7 @@
       - !type:AdjustReagent
         reagent: Pomelustine
         amount: 1
+  noRandom: true # The Den
 
 - type: reagent
   id: DirtyWastelander
@@ -372,6 +376,7 @@
       effects:
       - !type:SatiateThirst
         factor: 3
+  noRandom: true # The Den
 
 - type: reagent
   id: DragonsBlood
@@ -438,6 +443,7 @@
       effects:
       - !type:SatiateThirst
         factor: 2
+  noRandom: true # The Den
 
 - type: reagent
   id: EmeraldSwinger
@@ -553,6 +559,7 @@
       - !type:AdjustReagent
         reagent: Pomelustine
         amount: 0.25
+  noRandom: true # The Den
 
 - type: reagent
   id: HolyVice
@@ -599,6 +606,7 @@
       - !type:AdjustReagent
         reagent: Libidozenithizine
         amount: 0.25
+  noRandom: true # The Den
 
 - type: reagent
   id: KoboldKooler
@@ -619,6 +627,7 @@
       effects:
       - !type:SatiateThirst
         factor: 3
+  noRandom: true # The Den
 
 - type: reagent
   id: KoboldKorkscrew
@@ -639,6 +648,7 @@
       effects:
       - !type:SatiateThirst
         factor: 3
+  noRandom: true # The Den
 
 - type: reagent
   id: Lamplight
@@ -677,6 +687,7 @@
           shouldHave: true
         reagent: Philterex
         amount: 0.25
+  noRandom: true # The Den
 
 - type: reagent
   id: LemonPopsicle
@@ -723,6 +734,7 @@
       - !type:AdjustReagent
         reagent: Pomelustine
         amount: 0.5
+  noRandom: true # The Den
 
 - type: reagent
   id: MarieJulep
@@ -871,6 +883,7 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.05
+  noRandom: true # The Den
 
 - type: reagent
   id: Pomonade
@@ -891,6 +904,7 @@
       effects:
       - !type:SatiateThirst
         factor: 3
+  noRandom: true # The Den
 
 - type: reagent
   id: PomPassion
@@ -914,6 +928,7 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.0415
+  noRandom: true # The Den
 
 - type: reagent
   id: PomTwist
@@ -937,6 +952,7 @@
       - !type:AdjustReagent
         reagent: Pomelustine
         amount: 0.25
+  noRandom: true # The Den
 
 - type: reagent
   id: PrairieOyster
@@ -1000,6 +1016,7 @@
       effects:
       - !type:SatiateThirst
         factor: 3
+  noRandom: true # The Den
 
 - type: reagent
   id: RandyStallion
@@ -1026,7 +1043,7 @@
       - !type:AdjustReagent
         reagent: Pomelustine
         amount: 0.25
-
+  noRandom: true # The Den
 
 - type: reagent
   id: RedRocket
@@ -1050,6 +1067,7 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.0415
+  noRandom: true # The Den
 
 - type: reagent
   id: SalvagersDelight
@@ -1096,6 +1114,7 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.023
+  noRandom: true # The Den
 
 # horrifyingly, this is a real drink from a real cocktail book online
 - type: reagent
@@ -1117,6 +1136,7 @@
       effects:
       - !type:SatiateThirst
         factor: 3
+  noRandom: true # The Den
 
 - type: reagent
   id: SilverStallion
@@ -1137,6 +1157,7 @@
       effects:
       - !type:SatiateThirst
         factor: 2
+  noRandom: true # The Den
 
 - type: reagent
   id: SlimesDelight
@@ -1193,6 +1214,7 @@
       effects:
       - !type:SatiateThirst
         factor: 3
+  noRandom: true # The Den
 
 - type: reagent
   id: SpecialSundae
@@ -1216,6 +1238,7 @@
       - !type:AdjustReagent
         reagent: Pomelustine
         amount: 0.025
+  noRandom: true # The Den
 
 - type: reagent
   id: SyndicatesOverseer
@@ -1325,6 +1348,7 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.05
+  noRandom: true # The Den
 
 - type: reagent
   id: TheWaterslide
@@ -1417,6 +1441,7 @@
       - !type:AdjustReagent
         reagent: Pomelustine
         amount: 0.25
+  noRandom: true # The Den
 
 - type: reagent
   id: AxelsAle
@@ -1443,6 +1468,7 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.095
+  noRandom: true # The Den
 
 - type: reagent
   id: JennTonic
@@ -1512,6 +1538,7 @@
       - !type:AdjustReagent
         reagent: Pomelustine
         amount: 0.05
+  noRandom: true # The Den
 
 - type: reagent
   id: SyndicateEggnog

--- a/Resources/Prototypes/_Floof/Reagents/natural_sauce.yml
+++ b/Resources/Prototypes/_Floof/Reagents/natural_sauce.yml
@@ -26,6 +26,7 @@
     collection: FootstepSticky
     params:
       volume: 6
+  noRandom: true # The Den
 
 - type: reagent
   id: NaturalLubricant
@@ -51,3 +52,4 @@
     paralyzeTime: 0.5
     launchForwardsMultiplier: 1.2
     requiredSlipSpeed: 1
+  noRandom: true # The Den

--- a/Resources/Prototypes/_Floof/Reagents/natural_sauce.yml
+++ b/Resources/Prototypes/_Floof/Reagents/natural_sauce.yml
@@ -1,7 +1,8 @@
-# SPDX-FileCopyrightText: 2024 FoxxoTrystan <trystan.garnierhein@gmail.com>
-# SPDX-FileCopyrightText: 2024 Pierson Arnold <greyalphawolf7@gmail.com>
-# SPDX-FileCopyrightText: 2025 Rosycup <178287475+Rosycup@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 FoxxoTrystan
+# SPDX-FileCopyrightText: 2024 Pierson Arnold
+# SPDX-FileCopyrightText: 2025 MajorMoth
+# SPDX-FileCopyrightText: 2025 Rosycup
+# SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 


### PR DESCRIPTION
## About the PR
Adds a `NoRandom` datafield to `ReagentPrototype` which allows to discriminate for NSFW reagents when picking at random.
I made `NoRandom` true for the NSFW reagents I know, I might've missed some drinks made with NSFW reagents though.
Changed `OracleSystem.cs` to discrimate reagents based on `NoRandom`

aughhh psychic damage

## Why / Balance
consent breaches begone
https://discord.com/channels/1301753657024319488/1395313821882781696

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**
:cl:
- fix: The Oracle will now stop spawning NSFW reagents.