### PR TITLE
Port: Removes the HarpyHideWing Tag

### DIFF
--- a/Resources/Changelog/Den.yml
+++ b/Resources/Changelog/Den.yml
@@ -8113,3 +8113,16 @@ Entries:
   id: 772
   time: '2025-07-18T08:27:14.0000000+00:00'
   url: https://github.com/TheDenSS14/TheDen/pull/1116
+- author: portfiend
+  changes:
+    - type: Fix
+      message: >-
+        Fixed selfdamage command improperly using "Brute" damage when only two
+        arguments are provided.
+    - type: Tweak
+      message: >-
+        Selfdamage command has improved console response messages - now you'll
+        be given details if the command succeeded!
+  id: 773
+  time: '2025-07-18T16:45:06.0000000+00:00'
+  url: https://github.com/TheDenSS14/TheDen/pull/1123

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -209,7 +209,7 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
-    - HidesHarpyWings #DeltaV: Used by harpies to help render their hardsuit sprites
+    # HidesHarpyWings #Floof change, caused vulp tails to be hidden in hardsuits(with singer trait only) #DeltaV: Used by harpies to help render their hardsuit sprites
     - AllowLamiaHardsuit
     - FullBodyOuter
     - PlasmamanSafe
@@ -354,8 +354,7 @@
   - type: Tag
     tags:
     - AllowLamiaHardsuit #DeltaV: Used by Lamia to render snek hardsuits
-    - HidesHarpyWings #DeltaV: Used by harpies to help render their hardsuit sprites
-    - PlasmamanSafe
+    # HidesHarpyWings #DeltaV: Used by harpies to help render their hardsuit sprites (this caused vulp tails to be hidden in hardsuits)
   - type: Clothing
     equipDelay: 1.25 # Softsuits are easier to put on and off
     unequipDelay: 1

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -711,7 +711,7 @@
     - MonkeyWearable
     - Hardsuit
     - WhitelistChameleon
-    - HidesHarpyWings
+    # HidesHarpyWings #Floof change, caused vulp tails to be hidden in hardsuits(with singer trait only)
   - type: StaminaDamageResistance
     coefficient: 0.5 # 50%
 
@@ -732,7 +732,7 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
-    - HidesHarpyWings
+    # HidesHarpyWings  Floof Change
   - type: StaminaDamageResistance
     coefficient: 0.5 # 50%
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -34,7 +34,7 @@
     - MonkeyWearable
     - WhitelistChameleon
     - AllowLamiaHardsuit
-    - HidesHarpyWings
+    # HidesHarpyWings #Floof change, caused vulp tails to be hidden in hardsuits(with singer trait only)
 
 #Syndicate EVA
 - type: entity
@@ -53,7 +53,7 @@
     - MonkeyWearable
     - WhitelistChameleon
     - AllowLamiaHardsuit
-    - HidesHarpyWings
+    # HidesHarpyWings  Floof Change
 
 #Emergency EVA
 - type: entity
@@ -96,7 +96,7 @@
     - MonkeyWearable
     - WhitelistChameleon
     - AllowLamiaHardsuit
-    - HidesHarpyWings
+    # HidesHarpyWings  Floof Change
 
 #NTSRA Voidsuit / Ancient Voidsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -130,7 +130,7 @@
   - type: Tag
     tags:
       - WhitelistChameleon
-    # HidesHarpyWings #Floof change, caused vulp tails to be hidden in hardsuits(with singer trait only)
+      # HidesHarpyWings #Floof change, caused vulp tails to be hidden in hardsuits(with singer trait only)
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -70,7 +70,8 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
-    - HidesHarpyWings
+    - FullBodyOuter
+    # HidesHarpyWings #Floof change, caused vulp tails to be hidden in hardsuits(with singer trait only)
   - type: ClothingRequiredStepTriggerImmune
     slots: WITHOUT_POCKET
 
@@ -129,7 +130,7 @@
   - type: Tag
     tags:
       - WhitelistChameleon
-      - HidesHarpyWings
+    # HidesHarpyWings #Floof change, caused vulp tails to be hidden in hardsuits(with singer trait only)
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing]
@@ -164,7 +165,7 @@
     - type: Tag
       tags:
         - WhitelistChameleon
-        - HidesHarpyWings
+        # HidesHarpyWings #Floof change, caused vulp tails to be hidden in hardsuits(with singer trait only)
 
 - type: entity
   parent: [ClothingOuterBaseLarge, GeigerCounterClothing, AllowSuitStorageClothing]
@@ -193,7 +194,7 @@
   - type: Tag
     tags:
       - WhitelistChameleon
-      - HidesHarpyWings
+      # HidesHarpyWings #Floof change, caused vulp tails to be hidden in hardsuits(with singer trait only)
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseToggleClothing]

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -53,7 +53,7 @@
   id: HandLabeler
 
 - type: Tag
-  id: HidesHarpyWings
+  id: HidesHarpyWings # was Removed from the clothing. Floof change
 
 - type: Tag
   id: MagazinePistolSpecial # For the .38 special ammo and pistol


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## About the PR
Ported from [Floof](https://github.com/Floof-Station/Floof-Station/pull/971). With the singer trait enabled, vulp tails were hidden when equipping hardsuits. See the PR for details but generally they commented out the HarpyHideWing tag. This also causes harpy wings to be shown when wearing hardsuits which we may or may not want (personally i prefer their wings showing).

## Technical details
See original PR.

## Media
<img width="218" height="205" alt="imagen" src="https://github.com/user-attachments/assets/da292c3d-4f6f-4328-92d8-d58d6a9907cb" />
<img width="112" height="98" alt="imagen" src="https://github.com/user-attachments/assets/78da2927-4ac9-49cc-b5d8-d2fabfdd875a" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**
:cl: Wheels
- fix: Vulps with the singer trait enabled will now have their tail show correctly when wearing hardsuits.
- add: Harpy wings will now show when wearing hardsuits.