### PR TITLE
Port: Haircuts Notify the Target, Do-After Time Altered

### DIFF
--- a/Content.Server/MagicMirror/MagicMirrorSystem.cs
+++ b/Content.Server/MagicMirror/MagicMirrorSystem.cs
@@ -19,8 +19,12 @@ using Content.Server.Humanoid;
 using Content.Shared.DoAfter;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
+using Content.Shared.Inventory;
 using Content.Shared.MagicMirror;
+using Content.Shared.Popups;
+using Content.Shared.Tag;
 using Robust.Shared.Audio.Systems;
 
 namespace Content.Server.MagicMirror;
@@ -34,6 +38,9 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
     [Dependency] private readonly DoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly MarkingManager _markings = default!;
     [Dependency] private readonly HumanoidAppearanceSystem _humanoid = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly TagSystem _tagSystem = default!;
 
     public override void Initialize()
     {
@@ -61,8 +68,25 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         if (component.Target is not { } target)
             return;
 
+        // Check if the target getting their hair altered has any clothes that hides their hair
+        if (CheckHeadSlotOrClothes(message.Actor, component.Target.Value))
+        {
+            _popup.PopupEntity(
+                component.Target == message.Actor
+                    ? Loc.GetString("magic-mirror-blocked-by-hat-self")
+                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target"),
+                message.Actor,
+                message.Actor,
+                PopupType.Medium);
+            return;
+        }
+
         _doAfterSystem.Cancel(component.DoAfter);
         component.DoAfter = null;
+
+        var doafterTime = component.SelectSlotTime;
+        if (component.Target == message.Actor)
+            doafterTime /= 3;
 
         var doAfter = new MagicMirrorSelectDoAfterEvent()
         {
@@ -71,7 +95,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             Marking = message.Marking,
         };
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, component.SelectSlotTime, doAfter, uid, target: target, used: uid)
+        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, doafterTime, doAfter, uid, target: target, used: uid)
         {
             DistanceThreshold = SharedInteractionSystem.InteractionRange,
             BreakOnDamage = true,
@@ -80,6 +104,15 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
+
+        if (component.Target == message.Actor)
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-change-slot-self"), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
+        else
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-change-slot-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
 
         component.DoAfter = doAfterId;
         _audio.PlayPvs(component.ChangeHairSound, uid);
@@ -117,8 +150,25 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         if (component.Target is not { } target)
             return;
 
+                // Check if the target getting their hair altered has any clothes that hides their hair
+        if (CheckHeadSlotOrClothes(message.Actor, component.Target.Value))
+        {
+            _popup.PopupEntity(
+                component.Target == message.Actor
+                    ? Loc.GetString("magic-mirror-blocked-by-hat-self")
+                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target"),
+                message.Actor,
+                message.Actor,
+                PopupType.Medium);
+            return;
+        }
+
         _doAfterSystem.Cancel(component.DoAfter);
         component.DoAfter = null;
+
+        var doafterTime = component.ChangeSlotTime;
+        if (component.Target == message.Actor)
+            doafterTime /= 3;
 
         var doAfter = new MagicMirrorChangeColorDoAfterEvent()
         {
@@ -127,7 +177,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             Colors = message.Colors,
         };
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, component.ChangeSlotTime, doAfter, uid, target: target, used: uid)
+        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, doafterTime, doAfter, uid, target: target, used: uid)
         {
             BreakOnDamage = true,
             BreakOnMove = true,
@@ -135,6 +185,15 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
+
+        if (component.Target == message.Actor)
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-change-color-self"), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
+        else
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-change-color-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
 
         component.DoAfter = doAfterId;
     }
@@ -171,8 +230,25 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         if (component.Target is not { } target)
             return;
 
+        // Check if the target getting their hair altered has any clothes that hides their hair
+        if (CheckHeadSlotOrClothes(message.Actor, component.Target.Value))
+        {
+            _popup.PopupEntity(
+                component.Target == message.Actor
+                    ? Loc.GetString("magic-mirror-blocked-by-hat-self")
+                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target"),
+                message.Actor,
+                message.Actor,
+                PopupType.Medium);
+            return;
+        }
+
         _doAfterSystem.Cancel(component.DoAfter);
         component.DoAfter = null;
+
+        var doafterTime = component.RemoveSlotTime;
+        if (component.Target == message.Actor)
+            doafterTime /= 3;
 
         var doAfter = new MagicMirrorRemoveSlotDoAfterEvent()
         {
@@ -180,7 +256,7 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             Slot = message.Slot,
         };
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, component.RemoveSlotTime, doAfter, uid, target: target, used: uid)
+        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, doafterTime, doAfter, uid, target: target, used: uid)
         {
             DistanceThreshold = SharedInteractionSystem.InteractionRange,
             BreakOnDamage = true,
@@ -188,6 +264,15 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
+
+        if (component.Target == message.Actor)
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-remove-slot-self"), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
+        else
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-remove-slot-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
 
         component.DoAfter = doAfterId;
         _audio.PlayPvs(component.ChangeHairSound, uid);
@@ -225,15 +310,32 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
         if (component.Target == null)
             return;
 
+        // Check if the target getting their hair altered has any clothes that hides their hair
+        if (CheckHeadSlotOrClothes(message.Actor, component.Target.Value))
+        {
+            _popup.PopupEntity(
+                component.Target == message.Actor
+                    ? Loc.GetString("magic-mirror-blocked-by-hat-self")
+                    : Loc.GetString("magic-mirror-blocked-by-hat-self-target"),
+                message.Actor,
+                message.Actor,
+                PopupType.Medium);
+            return;
+        }
+
         _doAfterSystem.Cancel(component.DoAfter);
         component.DoAfter = null;
+
+        var doafterTime = component.AddSlotTime;
+        if (component.Target == message.Actor)
+            doafterTime /= 3;
 
         var doAfter = new MagicMirrorAddSlotDoAfterEvent()
         {
             Category = message.Category,
         };
 
-        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, component.AddSlotTime, doAfter, uid, target: component.Target.Value, used: uid)
+        _doAfterSystem.TryStartDoAfter(new DoAfterArgs(EntityManager, message.Actor, doafterTime, doAfter, uid, target: component.Target.Value, used: uid)
         {
             BreakOnDamage = true,
             BreakOnMove = true,
@@ -241,6 +343,15 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
             NeedHand = true
         },
             out var doAfterId);
+
+        if (component.Target == message.Actor)
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-add-slot-self"), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
+        else
+        {
+            _popup.PopupEntity(Loc.GetString("magic-mirror-add-slot-target", ("user", Identity.Name(message.Actor, EntityManager))), component.Target.Value, component.Target.Value, PopupType.Medium);
+        }
 
         component.DoAfter = doAfterId;
         _audio.PlayPvs(component.ChangeHairSound, uid);
@@ -279,5 +390,33 @@ public sealed class MagicMirrorSystem : SharedMagicMirrorSystem
     {
         ent.Comp.Target = null;
         Dirty(ent);
+    }
+
+    /// <summary>
+    /// Helper function that checks if the wearer has anything on their head
+    /// Or if they have any clothes that hides their hair
+    /// </summary>
+    private bool CheckHeadSlotOrClothes(EntityUid user, EntityUid target)
+    {
+        if (TryComp<InventoryComponent>(target, out var inventoryComp))
+        {
+            // any hat whatsoever will block haircutting
+            if (_inventory.TryGetSlotEntity(target, "head", out var hat, inventoryComp))
+            {
+                return true;
+            }
+
+            // maybe there's some kind of armor that has the HidesHair tag as well, so check every slot for it
+            var slots = _inventory.GetSlotEnumerator((target, inventoryComp), SlotFlags.WITHOUT_POCKET);
+            while (slots.MoveNext(out var slot))
+            {
+                if (slot.ContainedEntity != null && _tagSystem.HasTag(slot.ContainedEntity.Value, "HidesHair"))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/Content.Server/MagicMirror/MagicMirrorSystem.cs
+++ b/Content.Server/MagicMirror/MagicMirrorSystem.cs
@@ -1,15 +1,16 @@
-// SPDX-FileCopyrightText: 2022 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Debug <49997488+DebugOk@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 csqrb <56765288+CaptainSqrBeard@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT <77995199+DEATHB4DEFEAT@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Ed <96445749+TheShuEd@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
-// SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 DrSmugleaf
+// SPDX-FileCopyrightText: 2022 Flipp Syder
+// SPDX-FileCopyrightText: 2023 Debug
+// SPDX-FileCopyrightText: 2023 Leon Friedrich
+// SPDX-FileCopyrightText: 2023 csqrb
+// SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT
+// SPDX-FileCopyrightText: 2024 Ed
+// SPDX-FileCopyrightText: 2024 Nemanja
+// SPDX-FileCopyrightText: 2024 Pieter-Jan Briers
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+// SPDX-FileCopyrightText: 2024 nikthechampiongr
+// SPDX-FileCopyrightText: 2025 sleepyyapril
+// SPDX-FileCopyrightText: 2025 wheelwrightt
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Content.Shared/MagicMirror/MagicMirrorComponent.cs
+++ b/Content.Shared/MagicMirror/MagicMirrorComponent.cs
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: 2022 Flipp Syder <76629141+vulppine@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT <77995199+DEATHB4DEFEAT@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Ed <96445749+TheShuEd@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 Flipp Syder
+// SPDX-FileCopyrightText: 2023 DrSmugleaf
+// SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT
+// SPDX-FileCopyrightText: 2024 Ed
+// SPDX-FileCopyrightText: 2024 Nemanja
+// SPDX-FileCopyrightText: 2024 metalgearsloth
+// SPDX-FileCopyrightText: 2025 sleepyyapril
+// SPDX-FileCopyrightText: 2025 wheelwrightt
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Content.Shared/MagicMirror/MagicMirrorComponent.cs
+++ b/Content.Shared/MagicMirror/MagicMirrorComponent.cs
@@ -30,28 +30,28 @@ public sealed partial class MagicMirrorComponent : Component
     public EntityUid? Target;
 
     /// <summary>
-    /// doafter time required to add a new slot
+    /// Do after time to add a new slot, adding hair to a person
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan AddSlotTime = TimeSpan.FromSeconds(5);
+    public TimeSpan AddSlotTime = TimeSpan.FromSeconds(7);
 
     /// <summary>
-    /// doafter time required to remove a existing slot
+    /// Do after time to remove a slot, removing hair from a person
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan RemoveSlotTime = TimeSpan.FromSeconds(2);
+    public TimeSpan RemoveSlotTime = TimeSpan.FromSeconds(7);
 
     /// <summary>
-    /// doafter time required to change slot
+    /// Do after time to change a person's hairstyle
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan SelectSlotTime = TimeSpan.FromSeconds(3);
+    public TimeSpan SelectSlotTime = TimeSpan.FromSeconds(7);
 
     /// <summary>
-    /// doafter time required to recolor slot
+    /// Do after time to change a person's hair color
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan ChangeSlotTime = TimeSpan.FromSeconds(1);
+    public TimeSpan ChangeSlotTime = TimeSpan.FromSeconds(7);
 
     /// <summary>
     /// Sound emitted when slots are changed

--- a/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
+++ b/Resources/Locale/en-US/character-appearance/components/magic-mirror-component.ftl
@@ -7,3 +7,15 @@
 magic-mirror-component-activate-user-has-no-hair = You can't have any hair!
 
 magic-mirror-window-title = Magic Mirror
+magic-mirror-add-slot-self = You're giving yourself some hair.
+magic-mirror-remove-slot-self = You're removing some of your hair.
+magic-mirror-change-slot-self = You're changing your hairstyle.
+magic-mirror-change-color-self = You're changing your hair color.
+
+magic-mirror-add-slot-target = Hair is being added to you by {$user}.
+magic-mirror-remove-slot-target = Your hair is being cut off by {$user}.
+magic-mirror-change-slot-target = Your hairstyle is being changed by {$user}.
+magic-mirror-change-color-target = Your hair color is being changed by {$user}.
+
+magic-mirror-blocked-by-hat-self = You need to take off your hat before changing your hair.
+magic-mirror-blocked-by-hat-self-target = You try to change their hair but their clothes gets in the way.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Ported [PR #30366](https://github.com/space-wizards/space-station-14/pull/30366) from Wizden. 
Gives the player a popup if their hair is being cut by someone else or themselves. Functionality also extends to magic mirror. 
Changes the do-after time needed to alter your or someone else's hair.
Also makes it so hats/helmets need to be taken off before hair can be cut.

## Technical details
No changes made. See original PR for details

## Media
See original PR.
<img width="324" height="227" alt="imagen" src="https://github.com/user-attachments/assets/c7ef1cbd-1e18-446f-849a-03f8053b0cd8" />
<img width="472" height="182" alt="imagen" src="https://github.com/user-attachments/assets/7dcbf84f-996c-4e15-bb54-db1aea900bff" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**
:cl: Wheels
- add: Attempting to cut your own or someone else's hair will now notify the target with a popup
- tweak: Hair cannot be cut while wearing a hat/helmet