### PR TITLE
Add EvenHealthChange Effect (#37129)

### DIFF
--- a/Content.Server/EntityEffects/Effects/EvenHealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/EvenHealthChange.cs
@@ -1,0 +1,141 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.EntityEffects;
+using Content.Shared.FixedPoint;
+using Content.Shared.Localizations;
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server.EntityEffects.Effects;
+
+/// <summary>
+/// Version of <see cref="HealthChange"/> that distributes the healing to groups
+/// </summary>
+[UsedImplicitly]
+public sealed partial class EvenHealthChange : EntityEffect
+{
+    /// <summary>
+    /// Damage to heal, collected into entire damage groups.
+    /// </summary>
+    [DataField(required: true)]
+    public Dictionary<ProtoId<DamageGroupPrototype>, FixedPoint2> Damage = new();
+
+    /// <summary>
+    /// Should this effect scale the damage by the amount of chemical in the solution?
+    /// Useful for touch reactions, like styptic powder or acid.
+    /// Only usable if the EntityEffectBaseArgs is an EntityEffectReagentArgs.
+    /// </summary>
+    [DataField]
+    public bool ScaleByQuantity;
+
+    /// <summary>
+    /// Should this effect ignore damage modifiers?
+    /// </summary>
+    [DataField]
+    public bool IgnoreResistances = true;
+
+    protected override string ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+    {
+        var damages = new List<string>();
+        var heals = false;
+        var deals = false;
+
+        var damagableSystem = entSys.GetEntitySystem<DamageableSystem>();
+        var universalReagentDamageModifier = damagableSystem.UniversalReagentDamageModifier;
+        var universalReagentHealModifier = damagableSystem.UniversalReagentHealModifier;
+
+        foreach (var (group, amount) in Damage)
+        {
+            var groupProto = prototype.Index(group);
+
+            var sign = FixedPoint2.Sign(amount);
+            var mod = 1f;
+
+            if (sign < 0)
+            {
+                heals = true;
+                mod = universalReagentHealModifier;
+            }
+            else if (sign > 0)
+            {
+                deals = true;
+                mod = universalReagentDamageModifier;
+            }
+
+            damages.Add(
+                Loc.GetString("health-change-display",
+                    ("kind", groupProto.LocalizedName),
+                    ("amount", MathF.Abs(amount.Float() * mod)),
+                    ("deltasign", sign)
+                ));
+        }
+
+        var healsordeals = heals ? (deals ? "both" : "heals") : (deals ? "deals" : "none");
+        return Loc.GetString("reagent-effect-guidebook-even-health-change",
+            ("chance", Probability),
+            ("changes", ContentLocalizationManager.FormatList(damages)),
+            ("healsordeals", healsordeals));
+    }
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        if (!args.EntityManager.TryGetComponent<DamageableComponent>(args.TargetEntity, out var damageable))
+            return;
+
+        var protoMan = IoCManager.Resolve<IPrototypeManager>();
+
+        var scale = FixedPoint2.New(1);
+
+        if (args is EntityEffectReagentArgs reagentArgs)
+        {
+            scale = ScaleByQuantity ? reagentArgs.Quantity * reagentArgs.Scale : reagentArgs.Scale;
+        }
+
+        var damagableSystem = args.EntityManager.System<DamageableSystem>();
+        var universalReagentDamageModifier = damagableSystem.UniversalReagentDamageModifier;
+        var universalReagentHealModifier = damagableSystem.UniversalReagentHealModifier;
+
+        var dspec = new DamageSpecifier();
+
+        foreach (var (group, amount) in Damage)
+        {
+            var groupProto = protoMan.Index(group);
+            var groupDamage = new Dictionary<string, FixedPoint2>();
+            foreach (var damageId in groupProto.DamageTypes)
+            {
+                var damageAmount = damageable.Damage.DamageDict.GetValueOrDefault(damageId);
+                if (damageAmount != FixedPoint2.Zero)
+                    groupDamage.Add(damageId, damageAmount);
+            }
+
+            var sum = groupDamage.Values.Sum();
+            foreach (var (damageId, damageAmount) in groupDamage)
+            {
+                var existing = dspec.DamageDict.GetOrNew(damageId);
+                dspec.DamageDict[damageId] = existing + damageAmount / sum * amount;
+            }
+        }
+
+        if (universalReagentDamageModifier != 1 || universalReagentHealModifier != 1)
+        {
+            foreach (var (type, val) in dspec.DamageDict)
+            {
+                if (val < 0f)
+                {
+                    dspec.DamageDict[type] = val * universalReagentHealModifier;
+                }
+                if (val > 0f)
+                {
+                    dspec.DamageDict[type] = val * universalReagentDamageModifier;
+                }
+            }
+        }
+
+        damagableSystem.TryChangeDamage(
+            args.TargetEntity,
+            dspec * scale,
+            IgnoreResistances,
+            interruptsDoAfters: false);
+    }
+}

--- a/Content.Server/EntityEffects/Effects/EvenHealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/EvenHealthChange.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Nemanja
+// SPDX-FileCopyrightText: 2025 Sir Warock
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/EntityEffects/Effects/EvenHealthChange.cs
+++ b/Content.Server/EntityEffects/Effects/EvenHealthChange.cs
@@ -41,10 +41,6 @@ public sealed partial class EvenHealthChange : EntityEffect
         var heals = false;
         var deals = false;
 
-        var damagableSystem = entSys.GetEntitySystem<DamageableSystem>();
-        var universalReagentDamageModifier = damagableSystem.UniversalReagentDamageModifier;
-        var universalReagentHealModifier = damagableSystem.UniversalReagentHealModifier;
-
         foreach (var (group, amount) in Damage)
         {
             var groupProto = prototype.Index(group);
@@ -55,12 +51,10 @@ public sealed partial class EvenHealthChange : EntityEffect
             if (sign < 0)
             {
                 heals = true;
-                mod = universalReagentHealModifier;
             }
             else if (sign > 0)
             {
                 deals = true;
-                mod = universalReagentDamageModifier;
             }
 
             damages.Add(
@@ -93,8 +87,6 @@ public sealed partial class EvenHealthChange : EntityEffect
         }
 
         var damagableSystem = args.EntityManager.System<DamageableSystem>();
-        var universalReagentDamageModifier = damagableSystem.UniversalReagentDamageModifier;
-        var universalReagentHealModifier = damagableSystem.UniversalReagentHealModifier;
 
         var dspec = new DamageSpecifier();
 
@@ -116,22 +108,7 @@ public sealed partial class EvenHealthChange : EntityEffect
                 dspec.DamageDict[damageId] = existing + damageAmount / sum * amount;
             }
         }
-
-        if (universalReagentDamageModifier != 1 || universalReagentHealModifier != 1)
-        {
-            foreach (var (type, val) in dspec.DamageDict)
-            {
-                if (val < 0f)
-                {
-                    dspec.DamageDict[type] = val * universalReagentHealModifier;
-                }
-                if (val > 0f)
-                {
-                    dspec.DamageDict[type] = val * universalReagentDamageModifier;
-                }
-            }
-        }
-
+        
         damagableSystem.TryChangeDamage(
             args.TargetEntity,
             dspec * scale,

--- a/Resources/Changelog/Den.yml
+++ b/Resources/Changelog/Den.yml
@@ -8212,3 +8212,12 @@ Entries:
   id: 782
   time: '2025-07-18T21:22:49.0000000+00:00'
   url: https://github.com/TheDenSS14/TheDen/pull/1118
+- author: juniwoofs
+  changes:
+    - type: Add
+      message: Added Manta Station and its' evac shuttle the NTES Remora
+    - type: Remove
+      message: Removed 13 cans of monster energy pipeline punch from juni's veins
+  id: 783
+  time: '2025-07-18T21:25:31.0000000+00:00'
+  url: https://github.com/TheDenSS14/TheDen/pull/1120

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -94,6 +94,21 @@ reagent-effect-guidebook-health-change =
                  }
     } { $changes }
 
+reagent-effect-guidebook-even-health-change =
+    { $chance ->
+        [1] { $healsordeals ->
+            [heals] Evenly heals
+            [deals] Evenly deals
+            *[both] Evenly modifies health by
+        }
+        *[other] { $healsordeals ->
+            [heals] evenly heal
+            [deals] evenly deal
+            *[both] evenly modify health by
+        }
+    } { $changes }
+
+
 reagent-effect-guidebook-status-effect =
     { $type ->
         [add]   { $chance ->

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -69,6 +69,7 @@
 # SPDX-FileCopyrightText: 2025 Eagle-0
 # SPDX-FileCopyrightText: 2025 Nemanja
 # SPDX-FileCopyrightText: 2025 Sapphire
+# SPDX-FileCopyrightText: 2025 Sir Warock
 # SPDX-FileCopyrightText: 2025 SleepyScarecrow
 # SPDX-FileCopyrightText: 2025 Timfa
 # SPDX-FileCopyrightText: 2025 sleepyyapril

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -904,11 +904,10 @@
       effects:
       - !type:EvenHealthChange
         damage:
-          groups:
-            Burn: -3
-            Toxin: -3
-            Airloss: -3
-            Brute: -3 # Was 2, Buffed due to limb damage changes
+          Burn: -3
+          Toxin: -3
+          Airloss: -3
+          Brute: -3 # Was 2, Buffed due to limb damage changes
 
 - type: reagent
   id: Ultravasculine

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -902,7 +902,7 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:HealthChange
+      - !type:EvenHealthChange
         damage:
           groups:
             Burn: -3


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Ported over Even Healing from Wizden https://github.com/space-wizards/space-station-14/pull/37129
Author: https://github.com/SlamBamActionman
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's a nice thing to have, especially for Omnizine.
I am thinking about introducing this to Chemicals like Bicaridine, but especially Necrosol.
Just, uh, think about the Interdyne Omnizine Smokes.
## Technical details
<!-- Summary of code changes for easier review. -->
Simply cherry-picked the commit.
However, I removed every mention of "UniversalReagentDamageModifier" & "UniversalReagentHealModifier" as they appear to be not used in Den.
I don't know what exactly they're used for in Wizden, but I imagine it's used to increase or decrease effectiveness of reagants broadly with modifying only one attribute. Perhaps for Species.
Den doesn't use it, so I removed it.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="448" height="247" alt="grafik" src="https://github.com/user-attachments/assets/afa34bdf-ff54-40cb-8cc7-8f40cd05cb55" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: SlamBamActionman, SirWarock
- tweak: Introduced the Even Heal System from Wizden, with Omnizine now evenly healing damages!


