### PR TITLE
Update Buildchecker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,4 @@
             "url": "https://raw.githubusercontent.com/Simple-Station/Einstein-Engines/master/.github/rsi-schema.json"
         }
     ],
-    "dotnet.preferCSharpExtension": true
 }

--- a/BuildChecker/BuildChecker.csproj
+++ b/BuildChecker/BuildChecker.csproj
@@ -26,10 +26,10 @@ You want to handle the Build, Clean and Rebuild tasks to prevent missing task er
 If you want to learn more about these kinds of things, check out Microsoft's official documentation about MSBuild:
 https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild
 -->
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{C899FCA4-7037-4E49-ABC2-44DE72487110}</ProjectGuid>
-    <TargetFrameworkMoniker>.NETFramework, Version=v4.7.2</TargetFrameworkMoniker>
+    <TargetFramework>net4.7.2</TargetFramework>
     <RestorePackages>false</RestorePackages>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
## About the PR
This allows for the use of the not-shit and not-on-life-support C# Dev Kit as opposed to Omnisharp.
C# Dev Kit gives you this:
<img width="1866" height="872" alt="image" src="https://github.com/user-attachments/assets/c0eb2e95-d8f3-49a7-9c50-e737b8178b4f" />
Wizden people have had this for 5 months atp. Jealous. 
Tested and after these changes C# Dev Kit works perfectly and doesn't fail to load any projects anymore. 

## Why / Balance
I really want.

## Technical details
I don't know what I'm doing, but it works perfectly fine on wizden and I ported that. 

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.