### PR TITLE
Consent Examine Fix

### DIFF
--- a/Content.Client/_Floof/Examine/CustomExamineSystem.cs
+++ b/Content.Client/_Floof/Examine/CustomExamineSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Mnemotechnican
+// SPDX-FileCopyrightText: 2025 sleepyyapril
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/_Floof/Examine/CustomExamineSystem.cs
+++ b/Content.Server/_Floof/Examine/CustomExamineSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Mnemotechnican
+// SPDX-FileCopyrightText: 2025 sleepyyapril
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Shared/_Floof/Examine/CustomExamineSystem.cs
+++ b/Content.Shared/_Floof/Examine/CustomExamineSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Mnemotechnican
+// SPDX-FileCopyrightText: 2025 sleepyyapril
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
Resolves #1139
Resolves #1138

Consent Examine no longer activates on click, instead only using the verb.

:cl:
- tweak: Consent Examine can no longer be used on anything by admins.
- fix: Consent Examine no longer activates on click, instead only using the verb.