### PR TITLE
Fix Lathes Getting Unrelated Recipes

### DIFF
--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -186,9 +186,12 @@ namespace Content.Server.Lathe
         [PublicAPI]
         public bool TryGetAvailableRecipes(EntityUid uid, [NotNullWhen(true)] out List<ProtoId<LatheRecipePrototype>>? recipes, [NotNullWhen(true)] LatheComponent? component = null, bool getUnavailable = false)
         {
-            recipes = null;
             if (!Resolve(uid, ref component))
+            {
+                recipes = null;
                 return false;
+            }
+
             recipes = GetAvailableRecipes(uid, component, getUnavailable);
             return true;
         }
@@ -403,7 +406,7 @@ namespace Content.Server.Lathe
             ref TechnologyDatabaseModifiedEvent args
         )
         {
-            if (args.UnlockedRecipes == null || args.UnlockedRecipes.Count == 0)
+            if (args.UnlockedRecipes.Count == 0)
                 return;
 
             if (!TryGetAvailableRecipes(ent.Owner, out var potentialRecipes))
@@ -417,10 +420,10 @@ namespace Content.Server.Lathe
                 if (string.IsNullOrWhiteSpace(recipeId))
                     continue;
 
-                if (potentialRecipes.Contains(new(recipeId)))
+                if (!_proto.TryIndex(recipeId, out var recipe))
                     continue;
 
-                if (!_proto.TryIndex(recipeId, out var recipe))
+                if (potentialRecipes.All(targetRecipe => targetRecipe.Id != recipeId))
                     continue;
 
                 var itemName = GetRecipeName(recipe);

--- a/Content.Server/Research/Systems/ResearchSystem.Technology.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Technology.cs
@@ -16,6 +16,8 @@ using Content.Shared.Database;
 using Content.Shared.Research.Components;
 using Content.Shared.Research.Prototypes;
 using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+
 
 namespace Content.Server.Research.Systems;
 
@@ -149,7 +151,8 @@ public sealed partial class ResearchSystem
         }
 
         component.UnlockedTechnologies.Add(technology.ID);
-        var addedRecipes = new List<string>();
+        var addedRecipes = new List<ProtoId<LatheRecipePrototype>>();
+
         foreach (var unlock in technology.RecipeUnlocks)
         {
             if (component.UnlockedRecipes.Contains(unlock))
@@ -158,9 +161,10 @@ public sealed partial class ResearchSystem
             component.UnlockedRecipes.Add(unlock);
             addedRecipes.Add(unlock);
         }
+        
         Dirty(uid, component);
 
-        var ev = new TechnologyDatabaseModifiedEvent(technology.ID, technology.RecipeUnlocks); // Goobstation - Lathe message on recipes update
+        var ev = new TechnologyDatabaseModifiedEvent(technology.ID, addedRecipes); // Goobstation - Lathe message on recipes update
         RaiseLocalEvent(uid, ref ev);
     }
 

--- a/Content.Server/Research/Systems/ResearchSystem.Technology.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Technology.cs
@@ -161,10 +161,10 @@ public sealed partial class ResearchSystem
             component.UnlockedRecipes.Add(unlock);
             addedRecipes.Add(unlock);
         }
-        
+
         Dirty(uid, component);
 
-        var ev = new TechnologyDatabaseModifiedEvent(technology.ID, addedRecipes); // Goobstation - Lathe message on recipes update
+        var ev = new TechnologyDatabaseModifiedEvent(uid, technology.ID, addedRecipes); // Goobstation - Lathe message on recipes update
         RaiseLocalEvent(uid, ref ev);
     }
 

--- a/Content.Shared/Research/Components/TechnologyDatabaseComponent.cs
+++ b/Content.Shared/Research/Components/TechnologyDatabaseComponent.cs
@@ -72,13 +72,16 @@ public sealed partial class TechnologyDatabaseComponent : Component
 [ByRefEvent]
 public readonly record struct TechnologyDatabaseModifiedEvent // Goobstation - Lathe message on recipes update
 {
+    public readonly EntityUid Server;
     public readonly ProtoId<TechnologyPrototype>? Technology;
-    public readonly List<ProtoId<LatheRecipePrototype>> UnlockedRecipes;
+    public readonly List<ProtoId<LatheRecipePrototype>> UnlockedRecipes = new();
 
     public TechnologyDatabaseModifiedEvent(
+        EntityUid server,
         ProtoId<TechnologyPrototype>? technology,
         List<ProtoId<LatheRecipePrototype>>? unlockedRecipes = null)
     {
+        Server = server;
         Technology = technology;
         UnlockedRecipes = unlockedRecipes ?? new();
     }

--- a/Content.Shared/Research/Systems/SharedResearchSystem.cs
+++ b/Content.Shared/Research/Systems/SharedResearchSystem.cs
@@ -309,7 +309,7 @@ public abstract class SharedResearchSystem : EntitySystem
         Dirty(uid, component);
 
         var recipes = new List<ProtoId<LatheRecipePrototype>> { recipe };
-        var ev = new TechnologyDatabaseModifiedEvent(null, recipes);
+        var ev = new TechnologyDatabaseModifiedEvent(uid, null, recipes);
         RaiseLocalEvent(uid, ref ev);
     }
 }


### PR DESCRIPTION
lathes will no longer spam departments who got fuckall

:cl:
- fix: Lathes no longer spam with recipes they didn't receive anything from.
- fix: Lathes will no longer announce stations on a separate grid from the research server.