### PR TITLE
DE Sword changes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -341,10 +341,10 @@
     guides: [ SecurityWeapons ]
 
 - type: entity
-  name: double-bladed energy sword
+  name: energy staff
   parent: EnergySword
   id: EnergySwordDouble
-  description: Syndicate Command's intern thought that having only one blade on energy swords was not cool enough. This can be stored in pockets.
+  description: A long, two handed energy staff intended for defensive combat, with a larger handle the typical energy swords, preventing pocket storage, however, allows for faster back to back swings. Significantly louder than other energy melee weapons.  
   components:
   - type: ItemToggle
     onUse: false # wielding events control it instead
@@ -360,11 +360,11 @@
     activatedSoundOnSwing:
       path: /Audio/Weapons/eblademiss.ogg
       params:
-        volume: 3
+        volume: 4
         variation: 0.250
     activatedDamage:
         types:
-            Slash: 12
+            Slash: 5
             Heat: 15
             Structural: 30
   - type: ItemToggleActiveSound
@@ -381,7 +381,7 @@
     wieldSound: null # esword light sound instead
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: .6666
+    attackRate: .75
     angle: 100
     damage:
       types:
@@ -399,11 +399,9 @@
     size: Small
     sprite: Objects/Weapons/Melee/e_sword_double-inhands.rsi
   - type: Reflect
-    reflectProb: .80
+    reflectProb: .65
     minReflectProb: .65
-    spread: 75
-    reflects:
-      - Energy #DeltaV: 80% Energy Reflection but no ballistics.
+    spread: 65 
   - type: UseDelay
     delay: 1
   - type: ToggleableLightVisuals


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
changes the DE sword to the energy staff. It has slightly higher attack speed but significantly lower damage per swing. Lowered it's deflection chance, but can block bullets now. Intended as a tank weapon for Nukies and loud traitors. Not yet implemented into uplink because it's YML scares me.

## Why / Balance
The DESword is cool and having it unused is lame as hell. Made it a defensive alternative to the E-Sword, with superior deflect (though lower than it was before) and has lower base damage, though still 20 a swing to unarmored.


**Changelog**
:cl:
- tweak: Changed the DESword to the Energy Staff. Check pr for details. (not yet added to uplink, it's yml scares me.)
- remove: Hidden sith lord in the code

