### PR TITLE
Fix Examination Using The Wrong Person

### DIFF
--- a/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
+++ b/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
@@ -230,7 +230,7 @@ public sealed class HealthExaminableSystem : EntitySystem
         using (args.PushGroup(nameof(HealthExaminableComponent)))
         {
             // only show the default health inspect, leave self-aware to the actual health examine action
-            args.PushMessage(CreateMarkup(args.Examiner, component, damage, false));
+            args.PushMessage(CreateMarkup(examinedUid, component, damage, false));
         }
     }
 }

--- a/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
+++ b/Content.Shared/HealthExaminable/HealthExaminableSystem.cs
@@ -8,6 +8,7 @@
 // SPDX-FileCopyrightText: 2024 Angelo Fallaria
 // SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT
 // SPDX-FileCopyrightText: 2024 Remuchi
+// SPDX-FileCopyrightText: 2025 Sir Warock
 // SPDX-FileCopyrightText: 2025 ash lea
 // SPDX-FileCopyrightText: 2025 sleepyyapril
 //


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Fixed Health Examinations. When you looked at someone while you were bleeding or were pale, others looked as if they were pale or bleeding.
Additionally, they were always using your pronouns, not theirs. I fixed this to be correct.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because tis a bug
## Technical details
<!-- Summary of code changes for easier review. -->
I changed one line of code.
XD.
Lmao, even.
The health examination was going off the examiner (you), not the examined (The one the information was coming from).
I think. I didn't understand it at all, I just kinda saw this look wrong, changed it, and it worked. Lmao.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="452" height="286" alt="grafik" src="https://github.com/user-attachments/assets/7bd5b374-d801-4733-904f-50add302f2c5" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Health Examination being shown wrong in weird ways!
