### PR TITLE
[HOTFIX] Tweak: Make Muzzle Accents Not Toggleable

### DIFF
--- a/Content.Server/Speech/Components/AddAccentClothingComponent.cs
+++ b/Content.Server/Speech/Components/AddAccentClothingComponent.cs
@@ -39,4 +39,10 @@ public sealed partial class AddAccentClothingComponent : Component
     ///     Who is currently wearing the item?
     /// </summary>
     public EntityUid Wearer; // Frontier
+
+    /// <summary>
+    ///     DEN: Can you toggle the accent on/off with an alt verb? Default is true.
+    /// </summary>
+    [DataField]
+    public bool Toggleable = true;
 }

--- a/Content.Server/Speech/Components/AddAccentClothingComponent.cs
+++ b/Content.Server/Speech/Components/AddAccentClothingComponent.cs
@@ -3,7 +3,9 @@
 // SPDX-FileCopyrightText: 2022 wrexbe
 // SPDX-FileCopyrightText: 2023 DrSmugleaf
 // SPDX-FileCopyrightText: 2025 Alkheemist
+// SPDX-FileCopyrightText: 2025 portfiend
 // SPDX-FileCopyrightText: 2025 sleepyyapril
+// SPDX-FileCopyrightText: 2025 wheelwrightt
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Server/Speech/EntitySystems/AddAccentClothingSystem.cs
+++ b/Content.Server/Speech/EntitySystems/AddAccentClothingSystem.cs
@@ -70,7 +70,9 @@ public sealed class AddAccentClothingSystem : EntitySystem
     /// </summary>
     private void OnGetAltVerbs(EntityUid uid, AddAccentClothingComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.CanInteract || args.User != component.Wearer) //only the wearer can toggle the effect
+        if (!args.CanInteract
+            || !component.Toggleable // DEN - Allow some accent clothing to not be toggleable
+            || args.User != component.Wearer) //only the wearer can toggle the effect
             return;
 
         AlternativeVerb verb = new()
@@ -100,7 +102,7 @@ public sealed class AddAccentClothingSystem : EntitySystem
                 return;
 
             // add accent to the user
-            var accentComponent = (Component)_componentFactory.GetComponent(componentType);
+            var accentComponent = (Component) _componentFactory.GetComponent(componentType);
             AddComp(component.Wearer, accentComponent);
 
             // snowflake case for replacement accent

--- a/Content.Server/Speech/EntitySystems/AddAccentClothingSystem.cs
+++ b/Content.Server/Speech/EntitySystems/AddAccentClothingSystem.cs
@@ -7,7 +7,9 @@
 // SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT
 // SPDX-FileCopyrightText: 2025 Alkheemist
 // SPDX-FileCopyrightText: 2025 metalgearsloth
+// SPDX-FileCopyrightText: 2025 portfiend
 // SPDX-FileCopyrightText: 2025 sleepyyapril
+// SPDX-FileCopyrightText: 2025 wheelwrightt
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -385,6 +385,7 @@
   - type: AddAccentClothing
     accent: ReplacementAccent
     replacement: mumble
+    toggleable: false # DEN - No alt verb for toggling accent
   - type: Tag
     tags:
     - IPCMaskWearable
@@ -424,6 +425,7 @@
   - type: Unremoveable
   - type: AddAccentClothing
     accent: StutteringAccent
+    toggleable: false # DEN - No alt verb for toggling accent
 
 - type: entity
   parent: ClothingMaskGasExplorer

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -56,6 +56,7 @@
 # SPDX-FileCopyrightText: 2025 MajorMoth
 # SPDX-FileCopyrightText: 2025 Rosycup
 # SPDX-FileCopyrightText: 2025 Skubman
+# SPDX-FileCopyrightText: 2025 portfiend
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -416,6 +416,7 @@
     - type: AddAccentClothing
       accent: ReplacementAccent
       replacement: mumble
+      toggleable: false # DEN - No alt verb for toggling accent
     - type: Butcherable
       butcheringType: Knife
       spawned:

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -61,6 +61,7 @@
 # SPDX-FileCopyrightText: 2025 Your Name
 # SPDX-FileCopyrightText: 2025 fishbait
 # SPDX-FileCopyrightText: 2025 hoshizora
+# SPDX-FileCopyrightText: 2025 portfiend
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 # SPDX-FileCopyrightText: 2025 wheelwrightt
 #


### PR DESCRIPTION
## About the PR
This PR makes it so you cannot toggle accents for muzzles, damp rags, and the cluwne mask.

## Why / Balance
#1238 has been merged but not yet added to the game. This is a hotfix patch I think is appropriate because in the case of muzzles and damp rags, the accent _prevents speech entirely_ which has mechanical balance implications, e.g. for antagonism or security. The cluwne mask is also included here because it is an item that is very much intended to be inescapable and detrimental, and the forced stutter is kind of part of the bit.

## Technical details
Adds a new field to `AddAccentClothingComponent` for whether or not an accented clothing is toggleable, default true. This check has been added to OnGetAltVerbs function.

## Media
<img width="272" height="170" alt="image" src="https://github.com/user-attachments/assets/0936dc19-9307-4eb1-b142-5c7e50378b00" />

<img width="256" height="184" alt="image" src="https://github.com/user-attachments/assets/a866daba-88a3-4907-b429-33170d987f64" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Muzzles and damp rags can no longer have their "muffled speech" toggled off via alt verb, nor can you toggle the stuttering of the cluwne mask.