### PR TITLE
Consistent Medical/Corpsman Loadout

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/chiefMedicalOfficer.yml
@@ -41,10 +41,12 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutChiefMedicalOfficerEyes
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutChiefMedicalOfficerEyes
+  maxItems: 1
+  items:
+    - type: loadout
+      id: ClothingEyesGlassesMedical
 
 - type: characterItemGroup
   id: LoadoutChiefMedicalOfficerGloves

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/chiefMedicalOfficer.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2025 BlitzTheSquishy
 # SPDX-FileCopyrightText: 2025 KyuPolaris
 # SPDX-FileCopyrightText: 2025 Skubman
+# SPDX-FileCopyrightText: 2025 Tanix
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/uncategorized.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2025 Blitz
 # SPDX-FileCopyrightText: 2025 BlitzTheSquishy
 # SPDX-FileCopyrightText: 2025 Lonofera
+# SPDX-FileCopyrightText: 2025 Tanix
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/uncategorized.yml
@@ -177,6 +177,8 @@
   cost: 0
   exclusive: true
   requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMedicalEyes
     - !type:CharacterDepartmentRequirement
       departments:
         - Medical

--- a/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
@@ -129,7 +129,7 @@
 
 - type: loadout
   id: LoadoutMedicalEyesCorpsmanEyepatchHudMedical
-  category: JobsMedicalAUncategorized
+  category: JobsSecurityCorpsman
   cost: 0
   exclusive: true
   requirements:

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
@@ -9,10 +9,10 @@
   cost: 2
   exclusive: true
   requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutEyes
-  - !type:CharacterJobRequirement
-    jobs:
-    - ChiefMedicalOfficer
+    - !type:CharacterItemGroupRequirement
+        group: LoadoutChiefMedicalOfficerEyes
+    - !type:CharacterJobRequirement
+      jobs:
+        - ChiefMedicalOfficer
   items:
   - ClothingEyesGlassesMedical

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Medical/chiefMedicalOfficer.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Sir Warock
+# SPDX-FileCopyrightText: 2025 Tanix
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Medical/uncategorized.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Medical/uncategorized.yml
@@ -31,8 +31,11 @@
   cost: 0
   exclusive: true
   requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutEyes
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutMedicalEyes
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Medical
   items:
   - ClothingEyesGlassesCheapMedical
 

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Medical/uncategorized.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Medical/uncategorized.yml
@@ -14,14 +14,9 @@
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutMedicalEyes
-    - !type:CharacterLogicOrRequirement
-      requirements:
-        - !type:CharacterDepartmentRequirement
-          departments:
-            - Medical
-        - !type:CharacterJobRequirement
-          jobs:
-            - Brigmedic
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Medical
   items:
     - ClothingEyesGlassesMedicalVisor
 

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Medical/uncategorized.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Medical/uncategorized.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2025 BlitzTheSquishy
 # SPDX-FileCopyrightText: 2025 Rosycup
 # SPDX-FileCopyrightText: 2025 Sir Warock
+# SPDX-FileCopyrightText: 2025 Tanix
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/corpsman.yml
@@ -59,3 +59,16 @@
     - Brigmedic
   items:
   - ClothingEyesGlassesMedical
+
+- type: loadout
+  id: LoadoutCorpsmanEyesGlassesMedicalVisor
+  category: JobsSecurityCorpsman
+  cost: 0
+  requirements:
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutCorpsmanEyes
+    - !type:CharacterJobRequirement
+      jobs:
+        - Brigmedic
+  items:
+    - ClothingEyesGlassesMedicalVisor

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Security/corpsman.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Blitz
 # SPDX-FileCopyrightText: 2025 Sir Warock
+# SPDX-FileCopyrightText: 2025 Tanix
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Originally a fix PR for #1251, this PR now also manages the inconsistency between the rest of the fucked up glasses between medical and the corpsman.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
my ocd
## Technical details
<!-- Summary of code changes for easier review. -->
enabled Eyes group for CMO and put the new CMO glasses in it, moved corpsman's eyepatch back where it belongs, correctly seperated the medical visor between medical/corpsman departments for consistency, and added all of the proper eyewear and department restrictions to items that lacked them.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Medical Glasses now have medical restrictions.
- fix: Shielded Medical Glasses now take up their proper eyewear slots.
- fix: Medical Visor Glasses now correctly show up in the Corpsman's loadout.
- fix: Corpsman's Medical Hud Eyepatch now correctly shows up in the Corpsman's loadout.
- fix: Medical Huds now take up the Medical Eyewear slot.