### PR TITLE
Bloodfeeders Can Examine Blood (and so Can You, for 1 Trait Point)

### DIFF
--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -48,6 +48,7 @@ using Content.Shared.Chemistry.Reaction;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Drunk;
+using Content.Shared.Examine;
 using Content.Shared.FixedPoint;
 using Content.Shared.HealthExaminable;
 using Content.Shared.Mobs.Systems;
@@ -63,7 +64,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Server.Body.Systems;
 
-public sealed class BloodstreamSystem : EntitySystem
+public sealed partial class BloodstreamSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
@@ -95,6 +96,9 @@ public sealed class BloodstreamSystem : EntitySystem
         SubscribeLocalEvent<BloodstreamComponent, ReactionAttemptEvent>(OnReactionAttempt);
         SubscribeLocalEvent<BloodstreamComponent, SolutionRelayEvent<ReactionAttemptEvent>>(OnReactionAttempt);
         SubscribeLocalEvent<BloodstreamComponent, RejuvenateEvent>(OnRejuvenate);
+
+        // DEN - Examine text for bloodstreams. Used for blood examiner component.
+        SubscribeLocalEvent<BloodstreamComponent, ExaminedEvent>(OnExamined);
     }
 
     private void OnMapInit(Entity<BloodstreamComponent> ent, ref MapInitEvent args)

--- a/Content.Server/Vampire/BloodSuckerComponent.cs
+++ b/Content.Server/Vampire/BloodSuckerComponent.cs
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
+using Content.Server._DEN.Body.Systems;
+
 namespace Content.Server.Vampiric
 {
     [RegisterComponent]
@@ -45,5 +47,10 @@ namespace Content.Server.Vampiric
         /// </summary>
         [DataField("webRequired")]
         public bool WebRequired = false;
+
+        /// <summary>
+        ///     DEN: Used to track BloodExaminer, but only if it is added by this component.
+        /// </summary>
+        public BloodExaminerComponent? AddedBloodExaminer;
     }
 }

--- a/Content.Server/Vampire/BloodSuckerSystem.cs
+++ b/Content.Server/Vampire/BloodSuckerSystem.cs
@@ -26,10 +26,11 @@ using Content.Shared.HealthExaminable;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Utility;
+using Content.Server._DEN.Body.Systems;
 
 namespace Content.Server.Vampiric
 {
-    public sealed class BloodSuckerSystem : EntitySystem
+    public sealed partial class BloodSuckerSystem : EntitySystem
     {
         [Dependency] private readonly BodySystem _bodySystem = default!;
         [Dependency] private readonly SharedSolutionContainerSystem _solutionSystem = default!;
@@ -49,6 +50,9 @@ namespace Content.Server.Vampiric
             SubscribeLocalEvent<BloodSuckerComponent, GetVerbsEvent<InnateVerb>>(AddSuccVerb);
             SubscribeLocalEvent<BloodSuckedComponent, HealthBeingExaminedEvent>(OnHealthExamined);
             SubscribeLocalEvent<BloodSuckedComponent, DamageChangedEvent>(OnDamageChanged);
+
+            SubscribeLocalEvent<BloodSuckerComponent, ComponentStartup>(OnStartup); // DEN
+            SubscribeLocalEvent<BloodSuckerComponent, ComponentShutdown>(OnShutdown); // DEN
             SubscribeLocalEvent<BloodSuckerComponent, BloodSuckDoAfterEvent>(OnDoAfter);
         }
 

--- a/Content.Server/_DEN/Body/Components/BloodExaminerComponent.cs
+++ b/Content.Server/_DEN/Body/Components/BloodExaminerComponent.cs
@@ -1,0 +1,18 @@
+using Content.Server.Body.Systems;
+
+namespace Content.Server._DEN.Body.Systems;
+
+/// <summary>
+///     This entity can see the bloodstream reagents of other species.
+///     Note that this does not detect all chemicals in the bloodstream - just whatever their
+///     actual BloodstreamComponent blood is.
+/// </summary>
+[RegisterComponent, Access(typeof(BloodstreamSystem))]
+public sealed partial class BloodExaminerComponent : Component
+{
+    [DataField]
+    public LocId ExamineText = "blood-examiner-component-examine";
+
+    [DataField]
+    public LocId BloodSuffix = "blood-examiner-component-blood-suffix";
+}

--- a/Content.Server/_DEN/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/_DEN/Body/Systems/BloodstreamSystem.cs
@@ -1,0 +1,54 @@
+
+using System.Runtime.InteropServices;
+using Content.Server._DEN.Body.Systems;
+using Content.Server.Body.Components;
+using Content.Shared.Examine;
+using Content.Shared.Interaction;
+using Robust.Shared.Utility;
+
+namespace Content.Server.Body.Systems;
+
+public sealed partial class BloodstreamSystem
+{
+    [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+
+    private void OnExamined(Entity<BloodstreamComponent> target, ref ExaminedEvent args)
+    {
+        if (TryComp<BloodExaminerComponent>(args.Examiner, out var bloodExaminer))
+            BloodExaminerExamined((args.Examiner, bloodExaminer), target, ref args);
+    }
+
+    private void BloodExaminerExamined(Entity<BloodExaminerComponent> examiner,
+        Entity<BloodstreamComponent> target,
+        ref ExaminedEvent args)
+    {
+        if (examiner.Owner == target.Owner)
+            return;
+
+        // Blood drinker range.
+        if (!_interactionSystem.InRangeUnobstructed(examiner.Owner, target.Owner))
+            return;
+
+        if (!_prototypeManager.TryIndex(target.Comp.BloodReagent, out var blood))
+            throw new DebugAssertException($"Entity {target.Owner} has invalid blood reagent: "
+                + target.Comp.BloodReagent.ToString());
+
+        var bloodName = blood.LocalizedName;
+        var bloodSuffix = Loc.GetString(examiner.Comp.BloodSuffix);
+
+        // Blood reagent text is colored.
+        var bloodText = Loc.GetString("blood-examiner-component-chemical",
+            ("color", blood.SubstanceColor.ToHexNoAlpha()),
+            ("blood", blood.LocalizedName));
+
+        // Add "blood" to the end if it doesn't already have it, to make the sentence make sense.
+        // E.g. "You can smell her apple juice." -> "You can smell her apple juice blood."
+        if (!bloodName.EndsWith(bloodSuffix))
+            bloodText = Loc.GetString("blood-examiner-component-examine-not-blood",
+                ("chemical", bloodText),
+                ("suffix", bloodSuffix));
+
+        var examineText = Loc.GetString(examiner.Comp.ExamineText, ("target", target), ("blood", bloodText));
+        args.PushMarkup(examineText);
+    }
+}

--- a/Content.Server/_DEN/Vampiric/BloodSuckerSystem.cs
+++ b/Content.Server/_DEN/Vampiric/BloodSuckerSystem.cs
@@ -12,9 +12,7 @@ public sealed partial class BloodSuckerSystem
     private void OnStartup(Entity<BloodSuckerComponent> ent, ref ComponentStartup args)
     {
         if (!HasComp<BloodExaminerComponent>(ent))
-        {
             ent.Comp.AddedBloodExaminer = EnsureComp<BloodExaminerComponent>(ent);
-        }
     }
 
     private void OnShutdown(Entity<BloodSuckerComponent> ent, ref ComponentShutdown args)

--- a/Content.Server/_DEN/Vampiric/BloodSuckerSystem.cs
+++ b/Content.Server/_DEN/Vampiric/BloodSuckerSystem.cs
@@ -1,0 +1,23 @@
+using Content.Server._DEN.Body.Systems;
+
+namespace Content.Server.Vampiric;
+
+public sealed partial class BloodSuckerSystem
+{
+    // DEN - All bloodsuckers can examine blood.
+    // This is for consent purposes, as some entities may have toxic or drugged blood.
+    private void OnStartup(Entity<BloodSuckerComponent> ent, ref ComponentStartup args)
+    {
+        if (!HasComp<BloodExaminerComponent>(ent))
+        {
+            ent.Comp.AddedBloodExaminer = EnsureComp<BloodExaminerComponent>(ent);
+        }
+    }
+
+    // DEN: Remove blood examiner if this component added it.
+    private void OnShutdown(Entity<BloodSuckerComponent> ent, ref ComponentShutdown args)
+    {
+        if (ent.Comp.AddedBloodExaminer != null)
+            RemCompDeferred(ent, ent.Comp.AddedBloodExaminer);
+    }
+}

--- a/Content.Server/_DEN/Vampiric/BloodSuckerSystem.cs
+++ b/Content.Server/_DEN/Vampiric/BloodSuckerSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 portfiend
+// SPDX-FileCopyrightText: 2025 sleepyyapril
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Content.Server/_DEN/Vampiric/BloodSuckerSystem.cs
+++ b/Content.Server/_DEN/Vampiric/BloodSuckerSystem.cs
@@ -4,7 +4,6 @@ namespace Content.Server.Vampiric;
 
 public sealed partial class BloodSuckerSystem
 {
-    // DEN - All bloodsuckers can examine blood.
     // This is for consent purposes, as some entities may have toxic or drugged blood.
     private void OnStartup(Entity<BloodSuckerComponent> ent, ref ComponentStartup args)
     {
@@ -14,7 +13,6 @@ public sealed partial class BloodSuckerSystem
         }
     }
 
-    // DEN: Remove blood examiner if this component added it.
     private void OnShutdown(Entity<BloodSuckerComponent> ent, ref ComponentShutdown args)
     {
         if (ent.Comp.AddedBloodExaminer != null && HasComp<BloodExaminerComponent>(ent))

--- a/Content.Server/_DEN/Vampiric/BloodSuckerSystem.cs
+++ b/Content.Server/_DEN/Vampiric/BloodSuckerSystem.cs
@@ -17,7 +17,7 @@ public sealed partial class BloodSuckerSystem
     // DEN: Remove blood examiner if this component added it.
     private void OnShutdown(Entity<BloodSuckerComponent> ent, ref ComponentShutdown args)
     {
-        if (ent.Comp.AddedBloodExaminer != null)
+        if (ent.Comp.AddedBloodExaminer != null && HasComp<BloodExaminerComponent>(ent))
             RemCompDeferred(ent, ent.Comp.AddedBloodExaminer);
     }
 }

--- a/Resources/Changelog/Den.yml
+++ b/Resources/Changelog/Den.yml
@@ -9016,3 +9016,10 @@ Entries:
   id: 873
   time: '2025-07-31T22:12:43.0000000+00:00'
   url: https://github.com/TheDenSS14/TheDen/pull/1262
+- author: ZigTag
+  changes:
+    - type: Fix
+      message: voice replacements should no longer break the server
+  id: 874
+  time: '2025-07-31T23:23:05.0000000+00:00'
+  url: https://github.com/TheDenSS14/TheDen/pull/1276

--- a/Resources/Locale/en-US/_DEN/bloodstream/blood-examiner-component.ftl
+++ b/Resources/Locale/en-US/_DEN/bloodstream/blood-examiner-component.ftl
@@ -1,0 +1,4 @@
+blood-examiner-component-examine = [color=lightgray]You can smell {POSS-ADJ($target)} {$blood}.[/color]
+blood-examiner-component-examine-not-blood = {$chemical} {$suffix}
+blood-examiner-component-blood-suffix = blood
+blood-examiner-component-chemical = [color={$color}]{$blood}[/color]

--- a/Resources/Locale/en-US/_DEN/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/traits.ftl
@@ -72,3 +72,9 @@ trait-description-HandsFreePulling =
     These could come from gene modifications, inherited genetics,
     or even custom implantations or modifications.
     You're able to drag things around without using your hands due to your abnormally strong tail or other modifications.
+
+trait-name-BloodExaminer = Blood Smell
+trait-description-BloodExaminer =
+    You can [color=yellow]identify the blood chemical of mobs[/color] when you stand close enough to them.
+    Note that this trait [color=orange]does not detect other chemicals in their blood stream[/color], only what
+    the mob's blood stream is actually made of - such as [color=lightblue]synth blood[/color] or [color=lightblue]insect blood[/color].

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1531,6 +1531,11 @@
       inverted: true
       species:
         - IPC
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+      - BloodExaminer # DEN
+      - HollowFangs
   functions:
   - !type:TraitAddComponent
     components:

--- a/Resources/Prototypes/_DEN/Traits/biological.yml
+++ b/Resources/Prototypes/_DEN/Traits/biological.yml
@@ -1,0 +1,21 @@
+- type: trait
+  id: BloodExaminer
+  category: TraitsPhysicalBiological
+  points: -1
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+    - StationAi
+    - Borg
+    - MedicalBorg
+  - !type:CharacterTraitRequirement
+    inverted: true
+    traits:
+    - Vampirism
+    - HollowFangs
+    # NOTE: I'm allowing IPCs to have this one. Maybe they have a blood detecting sensor.
+  functions:
+  - !type:TraitAddComponent
+    components:
+      - type: BloodExaminer

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -29,6 +29,7 @@
   - !type:CharacterTraitRequirement
     inverted: true
     traits:
+    - BloodExaminer # DEN
     - Vampirism
   functions:
     - !type:TraitAddComponent


### PR DESCRIPTION
## About the PR
You're either a smood bella or a blood smella

## Why / Balance
This is in preparation for #1284 (Thavens), who are going to have drugged blood. If you see a glass of psychedelic blood, you could examine it, see that it is psychedelic blood, and make the decision of whether or not you want to drink it. Bloodfeeders do not have this ability to make an informed decision of what they drink, which can be a consent breach if they consume drugs without being given the chance to know. This PR allows them to know what they are drinking.

In addition, it's added as a general trait independent of bloodfeeder mechanics, because it could be a fun character roleplay flavor - we have sharks, cyborgs, and characters who are kinda morbid and fucked up. Being able to Smell Someone's Blood lends itself well to these sorts of characters.

## Technical details
Adds a new component, BloodExaminerComponent, which allows entities to examine entities that have a bloodstream within interaction range. If the target's blood does not end in the word "blood", then it will have "blood" tacked to the end of it (uncolored, after the reagent name) to ensure the examine text makes sense.

BloodSuckerComponent adds this component upon startup and removes it on shutdown, assuming nothing else adds BloodExaminerComponent. If the entity already has BloodExaminerComponent from an unrelated source, then it doesn't get removed on BloodSucker shutdown.

A new trait adds BloodExaminer on its own. This trait is mutually exclusive with Vampirism/Hollow Fangs, but IPCs can take it.

## Media
<img width="835" height="128" alt="image" src="https://github.com/user-attachments/assets/566dab36-159c-4d1b-813a-cb56d2fd7dc2" />

<img width="393" height="150" alt="image" src="https://github.com/user-attachments/assets/96c03496-1e4e-42f3-82af-735c153f5659" />

<img width="395" height="181" alt="image" src="https://github.com/user-attachments/assets/f5bb62d9-3273-414c-8d17-ea83a7758bc0" />

<img width="396" height="155" alt="image" src="https://github.com/user-attachments/assets/f64a9e79-8b3e-4631-9c4f-110c89927863" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
Not to my knowledge?

**Changelog**
:cl:
- add: A new "blood smell" trait has been added, allowing you to view what reagent a mob's blood stream is made of.
- tweak: Bloodfeeders of all kinds (whether it's traits, species, or some other thing) are now also capable of examining a target's blood.