### PR TITLE
Make Bodybuilder/Weakling Actually Do Something

### DIFF
--- a/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
+++ b/Content.Shared/Movement/Pulling/Components/PullerComponent.cs
@@ -41,16 +41,22 @@ public sealed partial class PullerComponent : Component
     [DataField]
     public TimeSpan PushChangeCooldown = TimeSpan.FromSeconds(0.1f), PushDuration = TimeSpan.FromSeconds(5f);
 
-    // Before changing how this is updated, please see SharedPullerSystem.RefreshMovementSpeed
-    public float WalkSpeedModifier => Pulling == default ? 1.0f : 0.95f;
+    [DataField("walkSpeedModifier")]
+    public float PullWalkSpeedModifier = 0.95f; // DEN - Allow pull speed to be changed
 
-    public float SprintSpeedModifier => Pulling == default ? 1.0f : 0.95f;
-	
+    [DataField("sprintSpeedModifier")]
+    public float PullSprintSpeedModifier = 0.95f; // DEN - Allow pull speed to be changed
+
+    // Before changing how this is updated, please see SharedPullerSystem.RefreshMovementSpeed
+    public float WalkSpeedModifier => Pulling == default ? 1.0f : PullWalkSpeedModifier;
+
+    public float SprintSpeedModifier => Pulling == default ? 1.0f : PullSprintSpeedModifier;
+
     /// <summary>
     /// whether or not to apply speed modifiers to the puller
     /// </summary>
 	[AutoNetworkedField, DataField]
-	public bool ApplySpeedModifier = true;
+    public bool ApplySpeedModifier = true;
 
     /// <summary>
     ///     Entity currently being pulled/pushed if applicable.

--- a/Resources/Changelog/Den.yml
+++ b/Resources/Changelog/Den.yml
@@ -9016,3 +9016,10 @@ Entries:
   id: 873
   time: '2025-07-31T22:12:43.0000000+00:00'
   url: https://github.com/TheDenSS14/TheDen/pull/1262
+- author: ZigTag
+  changes:
+    - type: Fix
+      message: voice replacements should no longer break the server
+  id: 874
+  time: '2025-07-31T23:23:05.0000000+00:00'
+  url: https://github.com/TheDenSS14/TheDen/pull/1276

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1479,6 +1479,7 @@
           softGrabSpeedModifier: 0.95
           hardGrabSpeedModifier: 0.85
           chokeGrabSpeedModifier: 0.7
+          pushAcceleration: 0.45 # DEN: 0.3 -> 0.45, 50% increase
     - !type:TraitPushDescription
       descriptionExtensions:
         - description: examine-bodybuilder-message
@@ -1510,6 +1511,7 @@
           softGrabSpeedModifier: 0.8
           hardGrabSpeedModifier: 0.4
           chokeGrabSpeedModifier: 0.2
+          pushAcceleration: 0.15 # DEN: 0.3 -> 0.15, 50% decrease
     - !type:TraitPushDescription
       descriptionExtensions:
         - description: examine-weakling-message


### PR DESCRIPTION
## About the PR
Allows entities with the `Puller` component to have different walk/run speed multipliers.

In addition, Bodybuilder and Weakling traits have modified `pushAccelearation` values, allowing them to push (CTRL + right click) pulled entities easier.

## Why / Balance
The Bodybuilder and Weakling traits are supposed to modify the walk/run speeds when you're pulling, but they didn't actually do it because walkSpeedModifier and sprintSpeedModifier were not real fields that the Puller component has. Now it works.

## Technical details
Two new DataFields were added to Puller: PullWalkSpeedModifier and PullSprintSpeedModifier. They are aliased to `walkSpeedModifier` and `sprintSpeedModifier` in YML respectively to prevent breaking changes. The component now draws from these values when determining pull walk/spring speed.

You may notice the diona example in Media has both look visually indistinguishable and this is literally just because the difference between a 0.975x and a 0.9x speed modifier is really minute and should probably be changed but whatever

## Media
https://github.com/user-attachments/assets/28171d60-5bcb-4d66-a5c6-ca2379268389

https://github.com/user-attachments/assets/add4f4d9-88b3-47b9-80e7-fbfb23bcbc1e

https://github.com/user-attachments/assets/a7e45242-70f1-4b6e-8b03-62132e3628e9

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
None

**Changelog**
:cl:
- fix: Bodybuilder and Weakling traits now appropriately modify your speed and pushing strength.