### PR TITLE
Fix Chaplains Showing up as Unknown Department on Crew Monitor

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -59,10 +59,12 @@
 # SPDX-FileCopyrightText: 2024 chavonadelal
 # SPDX-FileCopyrightText: 2024 degradka
 # SPDX-FileCopyrightText: 2024 deltanedas
+# SPDX-FileCopyrightText: 2025 Blitz
 # SPDX-FileCopyrightText: 2025 BlitzTheSquishy
 # SPDX-FileCopyrightText: 2025 Rosycup
 # SPDX-FileCopyrightText: 2025 Tobias Berger
 # SPDX-FileCopyrightText: 2025 Will-Oliver-Br
+# SPDX-FileCopyrightText: 2025 portfiend
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -441,8 +441,8 @@
     - state: subdepartment
       color: "#58C800"
     - state: chaplain
-    - type: PresetIdCard
-      job: Chaplain
+  - type: PresetIdCard
+    job: Chaplain
 
 - type: entity
   parent: IDCardStandard


### PR DESCRIPTION
## About the PR
title

## Why / Balance
bug

## Technical details
2 line yaml indent

## Media
<img width="536" height="66" alt="image" src="https://github.com/user-attachments/assets/a4902802-5826-484d-a084-c7afa4d6e20e" />

**Changelog**
:cl:
- fix: Chaplains will now show up under the correct department in the crew monitor.