### PR TITLE
No Admins Count because They Can Bypass

### DIFF
--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -309,7 +309,7 @@ namespace Content.Server.Connection
 
             if (!_cfg.GetCVar(CCVars.AdminsCountForMaxPlayers))
             {
-                softPlayerCount -= _adminManager.ActiveAdmins.Count();
+                softPlayerCount -= _adminManager.AllAdmins.Count();
             }
 
             if ((softPlayerCount >= _cfg.GetCVar(CCVars.SoftMaxPlayers) && !adminBypass) && !wasInGame)


### PR DESCRIPTION
Instead of only removing active admins from the player count, remove all admins since they can bypass regardless.

:cl:
- tweak: Admins no longer count at All to the player count.