### PR TITLE
Add Consentprefs Command that Can Be Used Anytime

### DIFF
--- a/Content.Client/_DEN/Consent/ConsentEui.cs
+++ b/Content.Client/_DEN/Consent/ConsentEui.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 portfiend
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Client._Floof.Consent.UI.Windows;
 using Content.Client.Eui;
 using JetBrains.Annotations;

--- a/Content.Client/_DEN/Consent/ConsentEui.cs
+++ b/Content.Client/_DEN/Consent/ConsentEui.cs
@@ -1,0 +1,28 @@
+using Content.Client._Floof.Consent.UI.Windows;
+using Content.Client.Eui;
+using JetBrains.Annotations;
+
+namespace Content.Client._DEN.Consent;
+
+[UsedImplicitly]
+public sealed class ConsentEui : BaseEui
+{
+    private ConsentWindow Window { get; }
+
+    public ConsentEui()
+    {
+        Window = new ConsentWindow();
+    }
+
+    public override void Opened()
+    {
+        base.Opened();
+        Window.OpenCentered();
+    }
+
+    public override void Closed()
+    {
+        base.Closed();
+        Window.Close();
+    }
+}

--- a/Content.Server/_DEN/Consent/ConsentEui.cs
+++ b/Content.Server/_DEN/Consent/ConsentEui.cs
@@ -1,0 +1,12 @@
+using Content.Server.EUI;
+
+namespace Content.Server._DEN.Consent;
+
+public sealed class ConsentEui : BaseEui
+{
+    // TODO make the lobby consent ui button use this as well ppbtbbbbfttt faaart fartt fartttt ill get to it
+    public ConsentEui()
+    {
+        IoCManager.InjectDependencies(this);
+    }
+}

--- a/Content.Server/_DEN/Consent/ConsentEui.cs
+++ b/Content.Server/_DEN/Consent/ConsentEui.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 portfiend
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Server.EUI;
 
 namespace Content.Server._DEN.Consent;

--- a/Content.Server/_DEN/Consent/ConsentWindowCommand.cs
+++ b/Content.Server/_DEN/Consent/ConsentWindowCommand.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Content.Server.EUI;
+using Content.Shared.Administration;
+using Content.Shared.CCVar;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Server._DEN.Consent;
+
+[AnyCommand]
+sealed class ConsentWindowCommand : IConsoleCommand
+{
+    [Dependency] private readonly EuiManager _eui = default!;
+
+    public const string CommandName = "consentprefs";
+
+    public string Command => CommandName;
+    public string Description => Loc.GetString("consent-window-command-description");
+    public string Help => Loc.GetString("consent-window-command-help", ("command", CommandName));
+
+    public async void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (shell.Player is not { } player)
+        {
+            shell.WriteError("This does not work from the server console.");
+            return;
+        }
+
+        var consent = new ConsentEui();
+        _eui.OpenEui(consent, player);
+    }
+}

--- a/Content.Server/_DEN/Consent/ConsentWindowCommand.cs
+++ b/Content.Server/_DEN/Consent/ConsentWindowCommand.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 portfiend
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.EUI;

--- a/Resources/Locale/en-US/_DEN/commands/consent-window-command.ftl
+++ b/Resources/Locale/en-US/_DEN/commands/consent-window-command.ftl
@@ -1,0 +1,2 @@
+consent-window-command-description = Opens the Consent Window.
+consent-window-command-help = Usage: {$command}


### PR DESCRIPTION
## About the PR
Adds a new command, `consentprefs`, that allows you to edit your OOC consent prefs any time - even in the lobby.

## Why / Balance
Can't add a new UI button to the lobby trivially so i just do this

## Technical details
I made a new Eui for this

## Media

https://github.com/user-attachments/assets/acd4ef16-02ae-4677-a0da-add6a97f4e98

https://github.com/user-attachments/assets/26b0d4e9-2c5f-4860-95ef-2f97b6098bfd

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
none

**Changelog**
:cl:
- add: You can now edit your OOC consent preferences anywhere, including the lobby, with the `consentprefs` command.
