### PR TITLE
Restore Knife Storage for Security Thigh-High Socks

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Clothing/departmental_clothes.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/departmental_clothes.yml
@@ -7,6 +7,7 @@
 # SPDX-FileCopyrightText: 2025 BlitzTheSquishy
 # SPDX-FileCopyrightText: 2025 DeNatus
 # SPDX-FileCopyrightText: 2025 Rosycup
+# SPDX-FileCopyrightText: 2025 portfiend
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/_Floof/Entities/Clothing/departmental_clothes.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/departmental_clothes.yml
@@ -350,7 +350,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBaseSocks #TheDen
+  parent: [ClothingShoesBaseSocks, ClothingShoesMilitaryBase] #TheDen
   id: ClothingUnderSocksMantisEpi
   name: psionic mantis' thigh-high socks
   description: A pair of thigh-high socks, styled for a Psionic Mantis.
@@ -684,7 +684,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBaseSocks #TheDen
+  parent: [ClothingShoesBaseSocks, ClothingShoesMilitaryBase] #TheDen
   id: ClothingUnderSocksSecurity
   name: security thigh-high socks
   description: A pair of thigh-high socks, styled for Security roles.
@@ -725,7 +725,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBaseSocks #TheDen
+  parent: [ClothingShoesBaseSocks, ClothingShoesMilitaryBase] #TheDen
   id: ClothingUnderSocksHeadSecurity
   name: HoS thigh-high socks
   description: A pair of thigh-high socks, styled for the HoS.
@@ -766,7 +766,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: ClothingShoesBaseSocks #TheDen
+  parent: [ClothingShoesBaseSocks, ClothingShoesMilitaryBase] #TheDen
   id: ClothingUnderSocksDetective
   name: detective's thigh-high socks
   description: A pair of thigh-high socks, styled for a Detective.


### PR DESCRIPTION
## About the PR
#883 reparented all the Sock prototypes, including the security and mantis socks (which were previously able to store knives). this PR restores that functionality

## Why / Balance
jenn wants

## Technical details
the prototypes inherit from both socks and security boots, i tested it and this doesn't seem to have any unwanted side effects so it should be fine

## Media
https://github.com/user-attachments/assets/b8108afd-8a19-47fd-a3d4-7cc00a9bc5c3

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
if more things are added to security boot parent prototype that arent supposed to be on socks it might be a problem but its fine for now

**Changelog**
:cl:
- fix: Security, HOS, Detective, and Psionic Mantic thigh-high socks can now store knives again.
