### PR TITLE
Fix save button in HumanoidProfileEditor

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -408,7 +408,7 @@ namespace Content.Client.Lobby.UI
                 if (Profile is null)
                     return;
                 Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithHairStyleName(newStyle.id));
-                IsDirty = true;
+                SetDirty();
                 ReloadProfilePreview();
             };
 
@@ -419,7 +419,7 @@ namespace Content.Client.Lobby.UI
                 Profile = Profile.WithCharacterAppearance(
                     Profile.Appearance.WithHairColor(newColor.marking.MarkingColors[0]));
                 UpdateCMarkingsHair();
-                IsDirty = true;
+                SetDirty();
                 ReloadProfilePreview();
             };
 
@@ -429,7 +429,7 @@ namespace Content.Client.Lobby.UI
                     return;
                 Profile = Profile.WithCharacterAppearance(
                     Profile.Appearance.WithFacialHairStyleName(newStyle.id));
-                IsDirty = true;
+                SetDirty();
                 ReloadProfilePreview();
             };
 
@@ -440,7 +440,7 @@ namespace Content.Client.Lobby.UI
                 Profile = Profile.WithCharacterAppearance(
                     Profile.Appearance.WithFacialHairColor(newColor.marking.MarkingColors[0]));
                 UpdateCMarkingsFacialHair();
-                IsDirty = true;
+                SetDirty();
                 ReloadProfilePreview();
             };
 
@@ -453,7 +453,7 @@ namespace Content.Client.Lobby.UI
                 );
                 UpdateHairPickers();
                 UpdateCMarkingsHair();
-                IsDirty = true;
+                SetDirty();
                 ReloadProfilePreview();
             };
 
@@ -466,7 +466,7 @@ namespace Content.Client.Lobby.UI
                 );
                 UpdateHairPickers();
                 UpdateCMarkingsFacialHair();
-                IsDirty = true;
+                SetDirty();
                 ReloadProfilePreview();
             };
 
@@ -487,7 +487,7 @@ namespace Content.Client.Lobby.UI
 
                 UpdateHairPickers();
                 UpdateCMarkingsHair();
-                IsDirty = true;
+                SetDirty();
                 ReloadProfilePreview();
             };
 
@@ -508,7 +508,7 @@ namespace Content.Client.Lobby.UI
 
                 UpdateHairPickers();
                 UpdateCMarkingsFacialHair();
-                IsDirty = true;
+                SetDirty();
                 ReloadProfilePreview();
             };
 
@@ -536,7 +536,7 @@ namespace Content.Client.Lobby.UI
                 Profile = Profile.WithCharacterAppearance(
                     Profile.Appearance.WithEyeColor(newColor));
                 Markings.CurrentEyeColor = Profile.Appearance.EyeColor;
-                IsDirty = true;
+                SetDirty();
                 ReloadProfilePreview();
             };
 
@@ -564,7 +564,7 @@ namespace Content.Client.Lobby.UI
                 PreferenceUnavailableButton.SelectId(args.Id);
 
                 Profile = Profile?.WithPreferenceUnavailable((PreferenceUnavailableMode) args.Id);
-                IsDirty = true;
+                SetDirty();
             };
 
             _jobCategories = new Dictionary<string, BoxContainer>();
@@ -664,7 +664,7 @@ namespace Content.Client.Lobby.UI
             UpdateSpeciesGuidebookIcon();
 
             ReloadPreview();
-            IsDirty = false;
+            SetDirty();
         }
 
         /// Refreshes the flavor text editor status
@@ -978,7 +978,6 @@ namespace Content.Client.Lobby.UI
         {
             Profile = profile?.Clone();
             CharacterSlot = slot;
-            IsDirty = false;
             JobOverride = null;
 
             UpdateNameEdit();
@@ -1022,6 +1021,7 @@ namespace Content.Client.Lobby.UI
             if (Profile != null)
                 PreferenceUnavailableButton.SelectId((int) Profile.PreferenceUnavailable);
 
+            SetDirty();
         }
 
         /// A slim reload that only updates the entity itself and not any of the job entities, etc
@@ -1379,7 +1379,7 @@ namespace Content.Client.Lobby.UI
             if (Profile is null)
                 return;
             Profile = Profile.WithCDCharacterRecords(records);
-            IsDirty = true;
+            SetDirty();
         }
         // End CD - Character Records
 
@@ -1389,7 +1389,7 @@ namespace Content.Client.Lobby.UI
                 return;
 
             Profile = Profile.WithFlavorText(content);
-            IsDirty = true;
+            SetDirty();
         }
 
         private void OnMarkingChange(MarkingSet markings)
@@ -1540,7 +1540,7 @@ namespace Content.Client.Lobby.UI
         {
             Profile = Profile?.WithAge(newAge);
             ReloadPreview();
-            IsDirty = true;
+            SetDirty();
         }
 
         private void SetSex(Sex newSex)
@@ -1569,7 +1569,7 @@ namespace Content.Client.Lobby.UI
         {
             Profile = Profile?.WithGender(newGender);
             ReloadPreview();
-            IsDirty = true;
+            SetDirty();
         }
 
         private void SetDisplayPronouns(string? displayPronouns)
@@ -1579,21 +1579,21 @@ namespace Content.Client.Lobby.UI
 
             Profile = Profile?.WithDisplayPronouns(displayPronouns);
             ReloadPreview();
-            IsDirty = true;
+            SetDirty();
         }
 
         private void SetStationAiName(string? stationAiName)
         {
             Profile = Profile?.WithStationAiName(stationAiName);
             ReloadPreview();
-            IsDirty = true;
+            SetDirty();
         }
 
         private void SetCyborgName(string? cyborgName)
         {
             Profile = Profile?.WithCyborgName(cyborgName);
             ReloadPreview();
-            IsDirty = true;
+            SetDirty();
         }
 
         private string GetFormattedPronounsFromGender()
@@ -1617,7 +1617,7 @@ namespace Content.Client.Lobby.UI
             UpdateHeightWidthSliders();
             UpdateWeight();
             UpdateSpeciesGuidebookIcon();
-            IsDirty = true;
+            SetDirty();
             ReloadProfilePreview();
             ReloadClothes(); // Species may have job-specific gear, reload the clothes
         }
@@ -1626,7 +1626,7 @@ namespace Content.Client.Lobby.UI
         {
             Profile = Profile?.WithNationality(newNationality);
             UpdateCharacterRequired();
-            IsDirty = true;
+            SetDirty();
             ReloadProfilePreview();
             ReloadClothes(); // Nationalities may have specific gear, reload the clothes
             UpdateNationalityDescription(newNationality);
@@ -1636,7 +1636,7 @@ namespace Content.Client.Lobby.UI
         {
             Profile = Profile?.WithEmployer(newEmployer);
             UpdateCharacterRequired();
-            IsDirty = true;
+            SetDirty();
             ReloadProfilePreview();
             ReloadClothes(); // Employers may have specific gear, reload the clothes
             UpdateEmployerDescription(newEmployer);
@@ -1646,7 +1646,7 @@ namespace Content.Client.Lobby.UI
         {
             Profile = Profile?.WithLifepath(newLifepath);
             UpdateCharacterRequired();
-            IsDirty = true;
+            SetDirty();
             ReloadProfilePreview();
             ReloadClothes(); // Lifepaths may have specific gear, reload the clothes
             UpdateLifepathDescription(newLifepath);
@@ -1655,7 +1655,7 @@ namespace Content.Client.Lobby.UI
         private void SetName(string newName)
         {
             Profile = Profile?.WithName(newName);
-            IsDirty = true;
+            SetDirty();
 
             if (Profile != null)
                 _entManager.System<MetaDataSystem>().SetEntityName(PreviewDummy, Profile.Name);
@@ -1664,13 +1664,13 @@ namespace Content.Client.Lobby.UI
         private void SetCustomSpecieName(string customname)
         {
             Profile = Profile?.WithCustomSpeciesName(customname);
-            IsDirty = true;
+            SetDirty();
         }
 
         private void SetSpawnPriority(SpawnPriorityPreference newSpawnPriority)
         {
             Profile = Profile?.WithSpawnPriorityPreference(newSpawnPriority);
-            IsDirty = true;
+            SetDirty();
         }
 
         private void SetProfileHeight(float height)
@@ -2200,8 +2200,6 @@ namespace Content.Client.Lobby.UI
                 var profile = _entManager.System<HumanoidAppearanceSystem>().FromStream(file, _playerManager.LocalSession!);
                 var oldProfile = Profile;
                 SetProfile(profile, CharacterSlot);
-
-                IsDirty = !profile.MemberwiseEquals(oldProfile);
             }
             catch (Exception exc)
             {
@@ -2294,7 +2292,7 @@ namespace Content.Client.Lobby.UI
                     .Count(t => !t.Value)));
             AdminUIHelpers.RemoveConfirm(TraitsRemoveUnusableButton, _confirmationData);
 
-            IsDirty = true;
+            SetDirty();
             ReloadProfilePreview();
         }
 
@@ -2504,7 +2502,7 @@ namespace Content.Client.Lobby.UI
 
                     // Update Preferences
                     Profile = Profile?.WithTraitPreference(selector.Trait.ID, preference);
-                    IsDirty = true;
+                    SetDirty();
                     UpdateTraitPreferences();
                     SetProfile(Profile, CharacterSlot);
                 };
@@ -2601,7 +2599,7 @@ namespace Content.Client.Lobby.UI
         private void SelectLoadout(LoadoutPreference preference)
         {
             Profile = Profile?.WithLoadoutPreference(preference);
-            IsDirty = true;
+            SetDirty();
             SetProfile(Profile, CharacterSlot);
         }
 

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -117,6 +117,12 @@ using Content.Client._CD.Records.UI;
 using Content.Shared._CD.Records;
 // End CD - Character Records
 
+// DEN TODO: THIS NEEDS SEVERE OVERHAUL
+// here are some relevant standards i am writing down for those adding things to this UI:
+// NEVER set IsDirty directly. use SetDirty() instead.
+// SetDirty() should be called any time the profile updates
+// and any time an input is changed (e.g. text edits, button toggles.)
+
 namespace Content.Client.Lobby.UI
 {
     [GenerateTypedNameReferences]
@@ -1687,6 +1693,9 @@ namespace Content.Client.Lobby.UI
             ReloadProfilePreview();
         }
 
+        /// <summary>
+        ///     DO NOT SET THIS DIRECTLY. ALWAYS use SetDirty() instead.
+        /// </summary>
         private bool IsDirty
         {
             get => _isDirty;

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -122,6 +122,7 @@ using Content.Shared._CD.Records;
 // NEVER set IsDirty directly. use SetDirty() instead.
 // SetDirty() should be called any time the profile updates
 // and any time an input is changed (e.g. text edits, button toggles.)
+// Do not SetDirty() just before/after doing SetProfile() - this is redundant.
 
 namespace Content.Client.Lobby.UI
 {
@@ -905,7 +906,6 @@ namespace Content.Client.Lobby.UI
                     var reason = _characterRequirementsSystem.GetRequirementsText(reasons);
                     selector.LockRequirements(reason);
                     Profile = Profile?.WithAntagPreference(antag.ID, false);
-                    SetDirty();
                 }
                 else
                     selector.UnlockRequirements();
@@ -1340,7 +1340,6 @@ namespace Content.Client.Lobby.UI
 
                         Profile = Profile?.WithJobPriority(job.ID, (JobPriority) priority);
                         ReloadPreview();
-                        SetDirty();
                         SetProfile(Profile, CharacterSlot);
                     };
 
@@ -2147,7 +2146,6 @@ namespace Content.Client.Lobby.UI
         {
             Profile = HumanoidCharacterProfile.Random();
             SetProfile(Profile, CharacterSlot);
-            SetDirty();
         }
 
         private void SetPreviewRotation(Direction direction)
@@ -2164,7 +2162,6 @@ namespace Content.Client.Lobby.UI
 
             Profile = HumanoidCharacterProfile.RandomBody(Profile);
             SetProfile(Profile, CharacterSlot);
-            SetDirty();
         }
 
         private void RandomizeName()
@@ -2511,7 +2508,6 @@ namespace Content.Client.Lobby.UI
 
                     // Update Preferences
                     Profile = Profile?.WithTraitPreference(selector.Trait.ID, preference);
-                    SetDirty();
                     UpdateTraitPreferences();
                     SetProfile(Profile, CharacterSlot);
                 };
@@ -2608,7 +2604,6 @@ namespace Content.Client.Lobby.UI
         private void SelectLoadout(LoadoutPreference preference)
         {
             Profile = Profile?.WithLoadoutPreference(preference);
-            SetDirty();
             SetProfile(Profile, CharacterSlot);
         }
 

--- a/Content.Shared/Clothing/Loadouts/Systems/SharedLoadoutSystem.cs
+++ b/Content.Shared/Clothing/Loadouts/Systems/SharedLoadoutSystem.cs
@@ -218,6 +218,24 @@ public sealed partial class LoadoutPreference : Loadout
         string? customColorTint = null,
         bool? customHeirloom = null
     ) : base(loadoutName, customName, customDescription, customColorTint, customHeirloom) { }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is not LoadoutPreference other)
+            return false;
+
+        return LoadoutName == other.LoadoutName
+            && CustomName == other.CustomName
+            && CustomDescription == other.CustomDescription
+            && CustomHeirloom == other.CustomHeirloom
+            && CustomColorTint == other.CustomColorTint
+            && Selected == other.Selected;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(LoadoutName, CustomName, CustomDescription, CustomHeirloom, CustomColorTint, Selected);
+    }
 }
 
 /// <summary>

--- a/Content.Shared/Clothing/Loadouts/Systems/SharedLoadoutSystem.cs
+++ b/Content.Shared/Clothing/Loadouts/Systems/SharedLoadoutSystem.cs
@@ -228,13 +228,12 @@ public sealed partial class LoadoutPreference : Loadout
             && CustomName == other.CustomName
             && CustomDescription == other.CustomDescription
             && CustomHeirloom == other.CustomHeirloom
-            && CustomColorTint == other.CustomColorTint
-            && Selected == other.Selected;
+            && CustomColorTint == other.CustomColorTint;
     }
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(LoadoutName, CustomName, CustomDescription, CustomHeirloom, CustomColorTint, Selected);
+        return HashCode.Combine(LoadoutName, CustomName, CustomDescription, CustomHeirloom, CustomColorTint);
     }
 }
 

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -487,7 +487,8 @@ public sealed partial class HumanoidCharacterProfile : ICharacterProfile
 
     public bool MemberwiseEquals(ICharacterProfile maybeOther)
     {
-        return maybeOther is HumanoidCharacterProfile other
+        // DEN: I'm moving this into a var so I can debug this easier.
+        var result = maybeOther is HumanoidCharacterProfile other
             && Name == other.Name
             && Age == other.Age
             && Sex == other.Sex
@@ -503,11 +504,20 @@ public sealed partial class HumanoidCharacterProfile : ICharacterProfile
             && _jobPriorities.SequenceEqual(other._jobPriorities)
             && _antagPreferences.SequenceEqual(other._antagPreferences)
             && _traitPreferences.SequenceEqual(other._traitPreferences)
-            && LoadoutPreferences.SequenceEqual(other.LoadoutPreferences)
+            && _loadoutPreferences.SequenceEqual(other._loadoutPreferences)
             && Appearance.MemberwiseEquals(other.Appearance)
             && FlavorText == other.FlavorText
             && (CDCharacterRecords == null || other.CDCharacterRecords == null
-                || CDCharacterRecords.MemberwiseEquals(other.CDCharacterRecords));
+                || CDCharacterRecords.MemberwiseEquals(other.CDCharacterRecords))
+            // DEN additions below
+            && Customspeciename == other.Customspeciename
+            && Height == other.Height
+            && Width == other.Width
+            && DisplayPronouns == other.DisplayPronouns
+            && StationAiName == other.StationAiName
+            && CyborgName == other.CyborgName;
+
+        return result;
     }
 
     public void EnsureValid(ICommonSession session, IDependencyCollection collection)
@@ -716,7 +726,15 @@ public sealed partial class HumanoidCharacterProfile : ICharacterProfile
         hashCode.Add(Appearance);
         hashCode.Add((int) SpawnPriority);
         hashCode.Add((int) PreferenceUnavailable);
+        // DEN Additions
         hashCode.Add(Customspeciename);
+        hashCode.Add(CDCharacterRecords);
+        hashCode.Add(Height);
+        hashCode.Add(Width);
+        hashCode.Add(DisplayPronouns);
+        hashCode.Add(StationAiName);
+        hashCode.Add(CyborgName);
+        // DEN Additions End
         return hashCode.ToHashCode();
     }
 


### PR DESCRIPTION
## About the PR
Instead of hard-setting IsDirty (the state that allows you to save characters) dozens of times in character profiles, it will update based on the actual profile value. Also reduces redundant calls to this function.

## Why / Balance
Unfortunately a change this extensive was needed in order to get the save button working again

## Technical details
This updates all instances of `IsDirty` to `SetDirty` in the HumanoidProfileEditor XAML, fixes profile equality to ensure it works, and removes some redundant calls to SetDirty()

## Media
Um TBA

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
I changed the way `LoadoutPreference` equality works. I don't think anything uses it except `WithLoadout` but worth mentioning. In fact, profile equality was changed across the board

**Changelog**
:cl:
- fix: The character editor's "save" button should work properly again.
