### PR TITLE
Fixed Ninja Stars Doing Embedded Damage Forever if They Despawned

### DIFF
--- a/Content.Shared/Projectiles/EmbedPassiveDamageSystem.cs
+++ b/Content.Shared/Projectiles/EmbedPassiveDamageSystem.cs
@@ -118,7 +118,8 @@ public sealed class EmbedPassiveDamageSystem : EntitySystem
             if (ent.Embedded is null || !Exists(ent.Embedded)
                 || ent.EmbeddedDamageable is null
                 || ent.EmbeddedMobState is null
-                || ent.EmbeddedMobState.CurrentState == MobState.Dead)
+                || ent.EmbeddedMobState.CurrentState == MobState.Dead
+                || ent.Deleted)
             {
                 _activeEmbeds.Remove(ent);
                 continue;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Added a check to see if the embedded entity exists, and if it doesn't, remove the damage done if it was embedded.

## Why / Balance
Bug.

## Technical details
One-line change lol

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Ninja Stars doing embedded damage forever if they despawned without being removed.

