### PR TITLE
fix: use correct token

### DIFF
--- a/.github/workflows/reuse-updater.yml
+++ b/.github/workflows/reuse-updater.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           ref: ${{ vars.CHANGELOG_BRANCH }}
           fetch-depth: 0
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
Changes to use GITHUB_TOKEN rather than BOT_TOKEN, should hopefully fix the run error.