### PR TITLE
Advanced Chem Tweaks 

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -223,9 +223,9 @@
   metabolisms:
     Medicine:
       effects:
-      - !type:EvenHealthChange # Den
+      - !type:EvenHealthChange
         damage:
-          Brute: -1.6 # Now evenly heals, so reducing the number a bit.
+          Brute: -1.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
@@ -910,6 +910,7 @@
   color: "#520e30"
   metabolisms:
     Medicine:
+      metabolismRate: 0.25
       effects:
       - !type:HealthChange
         conditions:
@@ -918,15 +919,15 @@
           max: 30
         damage:
           groups:
-            Toxin: -3
-            Brute: 0.5
+            Toxin: -1.5
+            Brute: 0.25
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
           min: 30
         damage:
           groups:
-            Toxin: -1
+            Toxin: -0.5
             Brute: 3
       - !type:AdjustReagent
         conditions:
@@ -1036,18 +1037,19 @@
   color: "#e0a5b9"
   metabolisms:
     Medicine:
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
           types:
-            Caustic: -3
+            Caustic: -0.6 # 6 per u
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 16
+          min: 21
         damage:
           types:
-            Heat: 2
+            Heat: 0.2
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
@@ -1076,18 +1078,19 @@
   color: "#283332"
   metabolisms:
     Medicine:
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
           types:
-            Slash: -4 # Was 3, Buffed due to limb damage changes
+            Slash: -0.6 # 6 Per u
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 12
+          min: 21
         damage:
           types:
-            Cold: 3
+            Cold: 1.5 #15 per u
 
 - type: reagent
   id: Puncturase
@@ -1099,19 +1102,20 @@
   color: "#b9bf93"
   metabolisms:
     Medicine:
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
           types:
-            Piercing: -4
-            Blunt: 0.1
+            Piercing: -0.6 # 6 per u
+            Blunt: 0.05 # 0.5 per u
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 11
+          min: 21
         damage:
           types:
-            Blunt: 5
+            Blunt: 1 # 10 per u plus base effect
 
 - type: reagent
   id: Bruizine
@@ -1123,18 +1127,19 @@
   color: "#ff3636"
   metabolisms:
     Medicine:
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
           types:
-            Blunt: -4 # Was 3, Buffed due to limb damage changes(GoobStation)
+            Blunt: -0.6 # 6 per u
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 10.5
+          min: 19
         damage:
           types:
-            Poison: 4
+            Poison: 1.5 # 15 per u
 
 - type: reagent
   id: Pyrazine
@@ -1183,12 +1188,13 @@
   color: "#8147ff"
   metabolisms:
     Medicine:
+      metabolismRate: 0.1
       effects:
       # heals shocks and removes shock chems
       - !type:HealthChange
         damage:
           types:
-            Shock: -4
+            Shock: -0.5 # 5 per u
       - !type:AdjustReagent
         reagent: Licoxide
         amount: -4
@@ -1202,14 +1208,14 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 12
+          min: 15.5
         damage:
           types:
-            Cold: 2
+            Cold: 0.2 # 2 per u but lethal with cooling OD effect below
       - !type:AdjustTemperature
         conditions:
         - !type:ReagentThreshold
-          min: 12
+          min: 15.5
         amount: -30000
       - !type:Jitter
         conditions:

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -487,39 +487,6 @@
     Bruizine: 2
 
 - type: reaction
-  id: BicarLacerinol # mixing any two brute medications will make Razorium
-  impact: Medium
-  reactants:
-    Lacerinol:
-      amount: 1
-    Bicaridine:
-      amount: 1
-  products:
-    Razorium: 1
-
-- type: reaction
-  id: BicarPuncturase # mixing any two brute medications will make Razorium
-  impact: Medium
-  reactants:
-    Puncturase:
-      amount: 1
-    Bicaridine:
-      amount: 1
-  products:
-    Razorium: 1
-
-- type: reaction
-  id: BicarBruizine # mixing any two brute medications will make Razorium
-  impact: Medium
-  reactants:
-    Bruizine:
-      amount: 1
-    Bicaridine:
-      amount: 1
-  products:
-    Razorium: 1
-
-- type: reaction
   id: BruizineLacerinol # mixing any two brute medications will make Razorium
   impact: Medium
   reactants:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Ports https://github.com/space-wizards/space-station-14/pull/38811

Nerfs Advanced Brute chems to 0.1u/tick, but allows for bic to be used along side them. Raises their ODs as well. Basically a combat nerf for these chems.

## Why / Balance
Wizden did it, and as a medical main, its a good change. Advanced brutes were too strong.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Admiral-Obvious-001
- tweak: Several advanced chemicals now act slower, but with raised OD thresholds and lowered OD damage. The healing per unit remains largely the same.
- tweak: Bicaradine no longer makes Razorium when mixed with advanced brute chems. Advanced brute chems still mix and create Razorium when combined.
