### PR TITLE
Consent Default Values + Move Consent Cards

### DIFF
--- a/Content.Client/_Floof/Consent/UI/Windows/ConsentWindow.xaml
+++ b/Content.Client/_Floof/Consent/UI/Windows/ConsentWindow.xaml
@@ -32,7 +32,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
                 Disabled="True" />
         </BoxContainer>
         <Control HorizontalExpand="True" />
-        <controls:NeoTabContainer Name="ConsentTabs" VerticalExpand="True" HScrollEnabled="False" VScrollEnabled="False">
+        <controls:NeoTabContainer Name="ConsentTabs" VerticalExpand="True" Orientation="Vertical" HScrollEnabled="False" VScrollEnabled="False">
             <BoxContainer Name="FreetextTab" Orientation="Vertical" HorizontalExpand="True" Margin="5">
                 <PanelContainer HorizontalExpand="True" VerticalExpand="True" MinWidth="200">
                     <PanelContainer.PanelOverride>
@@ -41,7 +41,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
                     <TextEdit
                         Name="ConsentFreetext"
                         Access="Public"
-                        MinHeight="100"
+                        MinHeight="200"
                         VerticalExpand="True" />
                 </PanelContainer>
             </BoxContainer>
@@ -52,8 +52,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
                     </controls:NeoTabContainer>
                 </ScrollContainer>
             </BoxContainer>
-            <BoxContainer Orientation="Vertical" HorizontalExpand="False" VerticalExpand="True" Margin="5">
-            <Label Text= "Consent Cards"/>
+            <BoxContainer Name="ConsentCardsTab" Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True" Margin="5">
                 <ui:CardButton
                     Name="XCard"
                     Access="Internal"
@@ -62,8 +61,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
                     BackgroundColor="#FF2D2D38"
                     HoverColor="#FF3D3D48"
                     PressedColor="#FF4D4D58"
-                    MinSize="180 150"
-                    VerticalExpand="True"
+                    MinSize="0 200"
+                    HorizontalExpand="True"
                 />
             </BoxContainer>
         </controls:NeoTabContainer>

--- a/Content.Client/_Floof/Consent/UI/Windows/ConsentWindow.xaml.cs
+++ b/Content.Client/_Floof/Consent/UI/Windows/ConsentWindow.xaml.cs
@@ -120,8 +120,14 @@ public sealed partial class ConsentWindow : FancyWindow
 
         foreach (var entry in _entries)
         {
-            if (entry.Button != null && entry.Button.Pressed)
-                toggles[entry.Consent.ID] = "on";
+            if (entry.Button == null
+                || entry.Consent.DefaultValue == entry.Button.Pressed)
+                continue;
+
+            // DEN: I now have to save offs as well.
+            // Side note, who saved this to database as a string?
+            var value = entry.Button.Pressed ? "on" : "off";
+            toggles[entry.Consent.ID] = value;
         }
 
         return new(text, toggles);
@@ -173,12 +179,15 @@ public sealed partial class ConsentWindow : FancyWindow
             HorizontalExpand = true
         };
 
+        var defaultValue = toggle.DefaultValue;
+
         var buttonOff = new Button { Text = "Off" };
         buttonOff.StyleClasses.Add("OpenRight");
-        buttonOff.Pressed = true;
+        buttonOff.Pressed = !defaultValue;
 
         var buttonOn = new Button { Text = "On" };
         buttonOn.StyleClasses.Add("OpenLeft");
+        buttonOn.Pressed = defaultValue;
         state.Button = buttonOn;
 
         buttonOff.OnPressed += _ => ButtonOnPress(buttonOff, buttonOn);

--- a/Content.Client/_Floof/Consent/UI/Windows/ConsentWindow.xaml.cs
+++ b/Content.Client/_Floof/Consent/UI/Windows/ConsentWindow.xaml.cs
@@ -45,9 +45,11 @@ public sealed partial class ConsentWindow : FancyWindow
 
         FreetextTab.Orphan();
         TogglesTab.Orphan();
+        ConsentCardsTab.Orphan();
 
         ConsentTabs.AddTab(FreetextTab, Loc.GetString("consent-window-freetext-label"));
         ConsentTabs.AddTab(TogglesTab, Loc.GetString("consent-window-toggles-label"));
+        ConsentTabs.AddTab(ConsentCardsTab, Loc.GetString("consent-window-cards-label"));
 
         InitializeCategories();
 

--- a/Content.Server/_DV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
+++ b/Content.Server/_DV/ParadoxAnomaly/Systems/ParadoxAnomalySystem.cs
@@ -63,7 +63,7 @@ public sealed class ParadoxAnomalySystem : EntitySystem
     private const string ParadoxAnomalyExamine = "examine-paradox-anomaly-message";
 
     private ISawmill _sawmill = default!;
-    private readonly ProtoId<ConsentTogglePrototype> _paradoxAnomalyConsent = "NoClone";
+    private readonly ProtoId<ConsentTogglePrototype> _paradoxAnomalyConsent = "ParadoxClone";
     private readonly EntProtoId _paradoxAnomalySpawnerId = "SpawnPointGhostParadoxAnomaly";
     private readonly EntProtoId _paradoxAnomalyRule = "ParadoAnomaly";
 
@@ -129,7 +129,7 @@ public sealed class ParadoxAnomalySystem : EntitySystem
             if (_role.MindIsAntagonist(mindId))
                 continue;
 
-            if (_consent.HasConsent(uid, _paradoxAnomalyConsent))
+            if (!_consent.HasConsent(uid, _paradoxAnomalyConsent))
                 continue;
 
             // TODO: when metempsychosis real skip whoever has Karma

--- a/Content.Server/_Floof/Consent/ConsentSystem.cs
+++ b/Content.Server/_Floof/Consent/ConsentSystem.cs
@@ -6,6 +6,7 @@
 
 using Content.Server.Mind;
 using Content.Shared._Floof.Consent;
+using Content.Shared.GameTicking;
 using Robust.Shared.Network;
 using Robust.Shared.Utility;
 
@@ -14,8 +15,21 @@ namespace Content.Server._Floof.Consent;
 
 public sealed class ConsentSystem : SharedConsentSystem
 {
-    [Dependency] private readonly IServerConsentManager _consent = default!;
-    [Dependency] private readonly MindSystem _serverMindSystem = default!;
+    [Dependency] private readonly ConsentSystem _consent = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawned);
+    }
+
+    private void OnPlayerSpawned(PlayerSpawnCompleteEvent ev)
+    {
+        var consent = _consent.HasConsent(ev.Mob, "TestConsent");
+
+        Log.Info(consent.ToString());
+    }
 
     protected override FormattedMessage GetConsentText(NetUserId userId)
     {

--- a/Content.Server/_Floof/Consent/ConsentSystem.cs
+++ b/Content.Server/_Floof/Consent/ConsentSystem.cs
@@ -17,20 +17,6 @@ public sealed class ConsentSystem : SharedConsentSystem
 {
     [Dependency] private readonly ConsentSystem _consent = default!;
 
-    public override void Initialize()
-    {
-        base.Initialize();
-
-        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawned);
-    }
-
-    private void OnPlayerSpawned(PlayerSpawnCompleteEvent ev)
-    {
-        var consent = _consent.HasConsent(ev.Mob, "TestConsent");
-
-        Log.Info(consent.ToString());
-    }
-
     protected override FormattedMessage GetConsentText(NetUserId userId)
     {
         TryGetConsent(userId, out var consent);

--- a/Content.Shared/Devour/SharedDevourSystem.cs
+++ b/Content.Shared/Devour/SharedDevourSystem.cs
@@ -45,7 +45,7 @@ public abstract class SharedDevourSystem : EntitySystem
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private readonly SharedConsentSystem _consentSystem = default!;
 
-    private ProtoId<ConsentTogglePrototype> DevourConsent = "NoDragonDevour";
+    private ProtoId<ConsentTogglePrototype> DevourConsent = "DragonDevour";
 
     public override void Initialize()
     {
@@ -129,7 +129,7 @@ public abstract class SharedDevourSystem : EntitySystem
         {
             case MobState.Critical:
             case MobState.Dead:
-                var isDevourable = !_consentSystem.HasConsent(target, DevourConsent);
+                var isDevourable = _consentSystem.HasConsent(target, DevourConsent);
 
                 _doAfterSystem.TryStartDoAfter(new(
                     EntityManager,

--- a/Content.Shared/_Floof/Consent/ConsentTogglePrototype.cs
+++ b/Content.Shared/_Floof/Consent/ConsentTogglePrototype.cs
@@ -17,4 +17,7 @@ public sealed partial class ConsentTogglePrototype : IPrototype
 {
     [IdDataField]
     public string ID { get; private set; } = default!;
+
+    [DataField]
+    public bool DefaultValue { get; private set; }
 }

--- a/Content.Shared/_Floof/Consent/SharedConsentSystem.cs
+++ b/Content.Shared/_Floof/Consent/SharedConsentSystem.cs
@@ -20,6 +20,7 @@ public abstract partial class SharedConsentSystem : EntitySystem
 {
     [Dependency] private readonly SharedMindSystem _mindSystem = default!;
     [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly ILogManager _log = default!;
 
     private ISawmill _sawmill = default!;
@@ -84,11 +85,14 @@ public abstract partial class SharedConsentSystem : EntitySystem
 
     public bool HasConsent(Entity<MindContainerComponent?> ent, ProtoId<ConsentTogglePrototype> consentId)
     {
+        if (!_prototypeManager.TryIndex(consentId, out var consentToggle))
+            return false;
+
         if (!_mindSystem.TryGetMind(ent.Owner, out _, out var mind)
             || mind.Session == null
             || !UserConsents.TryGetValue(mind.Session.UserId, out var consentSettings)
             || !consentSettings.Toggles.TryGetValue(consentId, out var toggle))
-            return false;
+            return consentToggle.DefaultValue;
 
         return toggle == "on";
     }

--- a/Resources/Locale/en-US/Blep/consent.ftl
+++ b/Resources/Locale/en-US/Blep/consent.ftl
@@ -33,8 +33,8 @@ consent-example1-desc = This is just here as an example for how to add consent t
 consent-Hypno-name = Hypnosis
 consent-Hypno-desc = Allow yourself to be hypnotized.
 
-consent-NoClone-name = Disallow Paradox Anomaly
-consent-NoClone-desc = Don't allow yourself to be the target of a paradox anomaly clone. (on = no paradox anomaly)
+consent-ParadoxClone-name = Paradox Anomaly
+consent-ParadoxClone-desc = Whether you should be able to be the target of a paradox anomaly.
 
 consent-MindSwap-name = Mind Swap
 consent-MindSwap-desc = Should mind swap work on you?
@@ -46,8 +46,8 @@ consent-MassMindSwap-desc = Should a mass mind swap from glimmer work on you?
 consent-ChangelingTarget-name = Changeling Target
 consent-ChangelingTarget-desc = Should your body be allowed to be stolen by changelings?
 
-consent-NoDragonDevour-name = No Dragon Devour
-consent-NoDragonDevour-desc = With this on, you will no longer be able to be devoured by dragons. Your body will still not progress in rot until found.
+consent-DragonDevour-name = Dragon Devour
+consent-DragonDevour-desc = Whether you should be able to be devoured by a space dragon. Your body will still not progress in rot until found.
 
 consent-NSFWDescriptions-name = Show NSFW Descriptions
 consent-NSFWDescriptions-desc = Toggle this on to see dynamic player descriptions that may contain NSFW/ERP content.

--- a/Resources/Locale/en-US/Blep/consent.ftl
+++ b/Resources/Locale/en-US/Blep/consent.ftl
@@ -11,12 +11,14 @@ ui-options-function-open-consent-window = Open consent window
 consent-window-title = OOC Consent & Preferences
 consent-window-text = This information is shown to other players to help with RP and used to opt-in or out of certain gameplay systems.
 consent-window-freetext-label = Freetext
+consent-window-toggles-label = Toggles
+consent-window-cards-label = I Am Uncomfortable
 consent-window-freetext-placeholder = Put your ERP info here, such as:
     Sub/Dom/Switch
     If you are okay with IC noncon
     Which gender(s) you want your partners to be
     Likes and dislikes
-consent-window-toggles-label = Toggles
+
 consent-window-saved-changes = Your changes are saved.
 consent-window-unsaved-changes = You have unsaved changes!
 consent-window-char-limit = Character limit: {$length} / {$maxLength}

--- a/Resources/Prototypes/_DEN/Consent/consent_groups.yml
+++ b/Resources/Prototypes/_DEN/Consent/consent_groups.yml
@@ -4,6 +4,7 @@
   members:
   - NSFWDescriptions
   - LastMessage
+  - TestConsent
 
 - type: consentCategory
   id: mechanics

--- a/Resources/Prototypes/_DEN/Consent/consent_groups.yml
+++ b/Resources/Prototypes/_DEN/Consent/consent_groups.yml
@@ -10,7 +10,7 @@
   priority: 1
   members:
   - Hypno
-  - NoClone
+  - ParadoxClone
   - MindSwap
   - MassMindSwap
 
@@ -19,4 +19,4 @@
   priority: 2
   members:
   - ChangelingTarget
-  - NoDragonDevour
+  - DragonDevour

--- a/Resources/Prototypes/_DEN/Consent/consent_groups.yml
+++ b/Resources/Prototypes/_DEN/Consent/consent_groups.yml
@@ -4,7 +4,6 @@
   members:
   - NSFWDescriptions
   - LastMessage
-  - TestConsent
 
 - type: consentCategory
   id: mechanics

--- a/Resources/Prototypes/consent.yml
+++ b/Resources/Prototypes/consent.yml
@@ -29,3 +29,7 @@
 
 - type: consentToggle
   id: LastMessage
+
+- type: consentToggle
+  id: TestConsent
+  defaultValue: true

--- a/Resources/Prototypes/consent.yml
+++ b/Resources/Prototypes/consent.yml
@@ -8,7 +8,8 @@
   id: Hypno
 
 - type: consentToggle
-  id: NoClone
+  id: ParadoxClone
+  defaultValue: true
 
 - type: consentToggle
   id: MindSwap
@@ -20,7 +21,8 @@
   id: ChangelingTarget
 
 - type: consentToggle
-  id: NoDragonDevour
+  id: DragonDevour
+  defaultValue: true
 
 - type: consentToggle
   id: NSFWDescriptions

--- a/Resources/Prototypes/consent.yml
+++ b/Resources/Prototypes/consent.yml
@@ -29,7 +29,3 @@
 
 - type: consentToggle
   id: LastMessage
-
-- type: consentToggle
-  id: TestConsent
-  defaultValue: true


### PR DESCRIPTION
No longer do I need to do some wack ass shit to have something be defaulted to on.
Also, consent cards were moved to their own tab because I couldn't make it pretty enough and fit in the main tab.

<img width="769" height="349" alt="image" src="https://github.com/user-attachments/assets/13ab9fdd-296b-4e14-b041-976fe60edc87" />
