### PR TITLE
Add the `Spawnplayer` Command

### DIFF
--- a/Content.Server/_DEN/Administration/Commands/SpawnPlayer.cs
+++ b/Content.Server/_DEN/Administration/Commands/SpawnPlayer.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using Content.Server.Administration;
 using Content.Server.Clothing.Systems; // Einstein Engines
 using Content.Server.GameTicking;
-using Content.Server.Players;
 using Content.Server.Players.PlayTimeTracking; // Einstein Engines
 using Content.Server.Preferences.Managers;
 using Content.Server.Station.Systems;
@@ -10,12 +9,9 @@ using Content.Server.Traits; // Einstein Engines
 using Content.Shared.Administration;
 using Content.Shared.Roles;
 using Content.Shared.Mind;
-using Content.Shared.Players;
 using Content.Shared.Preferences;
 using Robust.Server.Player;
 using Robust.Shared.Console;
-using Robust.Shared.Network;
-using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server._DEN.Administration.Commands;
@@ -47,6 +43,7 @@ public sealed class SpawnPlayer : LocalizedEntityCommands
             return;
         }
 
+        // Parse the player
         if (!_playerManager.TryGetSessionByUsername(args[0], out var player))
         {
             shell.WriteError(Loc.GetString("cmd-spawnplayer-error-player", ("player", args[0])));
@@ -55,7 +52,7 @@ public sealed class SpawnPlayer : LocalizedEntityCommands
 
         character = (HumanoidCharacterProfile) _prefs.GetPreferences(player.UserId).SelectedCharacter;
 
-        // Parse out job if one is provided
+        // Parse the job_id
         var jobName = args.Length > 1 ? args[1] : "Passenger"; // just default to passenger
         var jobExists = _prototypeManager.TryIndex<JobPrototype>(jobName, out var jobProto);
 
@@ -94,6 +91,7 @@ public sealed class SpawnPlayer : LocalizedEntityCommands
             jobProto: jobProto // this applies 'special' things with the job's loadout, like mindshields
         );
 
+        // Parse out if we should transfer the mind, and do it if true. Will force even if player has an active 'non-ghost' character.
         if (args.Length > 2 && bool.TryParse(args[2], out bool transferMind) && transferMind)
         {
             mindSystem.TransferTo(mindId, mobUid, transferMind);

--- a/Content.Server/_DEN/Administration/Commands/SpawnPlayer.cs
+++ b/Content.Server/_DEN/Administration/Commands/SpawnPlayer.cs
@@ -1,0 +1,131 @@
+using System.Linq;
+using Content.Server.Administration;
+using Content.Server.Clothing.Systems; // Einstein Engines
+using Content.Server.GameTicking;
+using Content.Server.Players;
+using Content.Server.Players.PlayTimeTracking; // Einstein Engines
+using Content.Server.Preferences.Managers;
+using Content.Server.Station.Systems;
+using Content.Server.Traits; // Einstein Engines
+using Content.Shared.Administration;
+using Content.Shared.Roles;
+using Content.Shared.Mind;
+using Content.Shared.Players;
+using Content.Shared.Preferences;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DEN.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class SpawnPlayer : LocalizedEntityCommands
+{
+
+    [Dependency] private readonly IEntitySystemManager _entitySys = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IServerPreferencesManager _prefs = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly LoadoutSystem _loadout = default!;
+    [Dependency] private readonly TraitSystem _trait = default!;
+    [Dependency] private readonly PlayTimeTrackingManager _playTimeTracking = default!;
+
+    public override string Command => "spawnplayer";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var mindSystem = _entityManager.System<SharedMindSystem>();
+        HumanoidCharacterProfile character;
+
+        if (args.Length < 1)
+        {
+            shell.WriteError(Loc.GetString("cmd-spawnplayer-error-args"));
+            shell.WriteError(Loc.GetString("cmd-spawnplayer-help")); // print usage
+            return;
+        }
+
+        if (!_playerManager.TryGetSessionByUsername(args[0], out var player))
+        {
+            shell.WriteError(Loc.GetString("cmd-spawnplayer-error-player", ("player", args[0])));
+            return;
+        }
+
+        character = (HumanoidCharacterProfile) _prefs.GetPreferences(player.UserId).SelectedCharacter;
+
+        // Parse out job if one is provided
+        var jobName = args.Length > 1 ? args[1] : "Passenger"; // just default to passenger
+        var jobExists = _prototypeManager.TryIndex<JobPrototype>(jobName, out var jobProto);
+
+        if (!jobExists)
+        {
+            shell.WriteError(Loc.GetString("cmd-spawnplayer-error-job"));
+            jobName = "Passenger"; // and if they fuck up, just default to passenger again
+        }
+
+        var coordinates = shell.Player != null && shell.Player.AttachedEntity != null
+            ? _entityManager.GetComponent<TransformComponent>(shell.Player.AttachedEntity.Value).Coordinates
+            : _entitySys.GetEntitySystem<GameTicker>().GetObserverSpawnPoint();
+
+        if (player.AttachedEntity == null ||
+            !mindSystem.TryGetMind(player.AttachedEntity.Value, out var mindId, out var mind))
+            return;
+
+        var mobUid = _entityManager.System<StationSpawningSystem>().SpawnPlayerMob(coordinates, profile: character, entity: null, job: jobName, station: null);
+        var playTimes = _playTimeTracking.GetTrackerTimes(player);
+
+        _trait.ApplyTraits(
+            mobUid,
+            jobName,
+            character,
+            playTimes, //why?!
+            true, // assume true because the person is being manually spawned in and this is a dumb variable to be needed here
+            punishCheater: false
+        );
+
+        _loadout.ApplyCharacterLoadout(
+            mobUid,
+            jobName,
+            character,
+            playTimes,
+            true, // again, assume true
+            jobProto: jobProto // this applies 'special' things with the job's loadout, like mindshields
+        );
+
+        if (args.Length > 2 && bool.TryParse(args[2], out bool transferMind) && transferMind)
+        {
+            mindSystem.TransferTo(mindId, mobUid, transferMind);
+        }
+        else
+            shell.WriteLine(Loc.GetString("cmd-spawnplayer-info-mind-not-transferred", ("entId", mobUid.ToString()), ("player", args[0])));
+
+        shell.WriteLine(Loc.GetString("cmd-spawnplayer-complete"));
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.SessionNames(players: _playerManager),
+                Loc.GetString("cmd-spawnplayer-arg-player"));
+        }
+
+        if (args.Length == 2)
+        {
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.PrototypeIDs<JobPrototype>(),
+                Loc.GetString("cmd-spawnplayer-arg-job"));
+        }
+
+        if (args.Length == 3)
+        {
+            return CompletionResult.FromHintOptions(["true", "false"],
+                Loc.GetString("cmd-spawnplayer-arg-transfer-mind"));
+        }
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Resources/Locale/en-US/_DEN/commands/spawnplayer-command.ftl
+++ b/Resources/Locale/en-US/_DEN/commands/spawnplayer-command.ftl
@@ -1,0 +1,11 @@
+
+cmd-spawnplayer-desc = Spawns the selected player as their current character at the ADMIN's position.
+cmd-spawnplayer-help = Usage: spawnplayer <player_name> <job_id> <transfer_mind?>
+cmd-spawnplayer-complete = Player character spawned.
+cmd-spawnplayer-arg-player = [player name]
+cmd-spawnplayer-arg-job = [job id]
+cmd-spawnplayer-arg-transfer-mind = [transfer mind? (default: false)]
+cmd-spawnplayer-error-player = Player '{$player}' not found.
+cmd-spawnplayer-error-job = Job is invalid or not provided. Defaulting to passenger.
+cmd-spawnplayer-error-args = Not enough arguments provided.
+cmd-spawnplayer-info-mind-not-transferred = Mind not transferred. To transfer mind, run 'setmind {$entId} {$player}'


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Added the `spawnplayer` command.

Usage: `spawnplayer <player_name> <job_id> <transfer_mind? (default: false)>`

For example, to spawn a ghosted passenger player, you'll want to run `spawnplayer javadocs Passenger true`

## Why / Balance
Admin stuff!

## Technical details
look at the code, idk. Its just a command that does most of the functionality of `spawncharacter` but for other people.

I didn't add functionality to choose which of their characters because some people have 20 of the same character with different loadouts and there's no way to tell them apart.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/599485f1-2088-449d-ac98-ab04343d1057


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: ADMIN: Added the `spawnplayer` function to spawn other players with their job loadouts, traits, etc.
