### PR TITLE
Chat QoL

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -653,7 +653,7 @@ public sealed partial class ChatSystem : SharedChatSystem
                 result = perceivedMessage;
                 wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-wrap-message", name, result, language);
             }
-            else if (_interactionSystem.InRangeUnobstructed(source, listener, WhisperMuffledRange))
+            else if (_interactionSystem.InRangeUnobstructed(source, listener, WhisperMuffledRange, _subtleWhisperMask))
             {
                 // Scenario 2: if the listener is too far, they only hear fragments of the message
                 result = ObfuscateMessageReadability(perceivedMessage);
@@ -717,7 +717,10 @@ public sealed partial class ChatSystem : SharedChatSystem
         var ent = Identity.Entity(source, EntityManager);
         var name = FormattedMessage.EscapeText(nameOverride ?? Name(ent));
         action = FormattedMessage.RemoveMarkupPermissive(action);
-        var useSpace = !action.StartsWith("\'s") || !action.StartsWith(",");
+
+        Log.Info(action);
+
+        var useSpace = !(action.StartsWith("'") || action.StartsWith(","));
         var space = useSpace || separateNameAndMessage ? " " : "";
         var locString = "chat-manager-entity-me-wrap-message";
 
@@ -762,8 +765,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         // get the entity's apparent name (if no override provided).
         var ent = Identity.Entity(source, EntityManager);
         var name = FormattedMessage.EscapeText(nameOverride ?? Name(ent));
-        action = FormattedMessage.RemoveMarkupPermissive(action);
-        var useSpace = !action.StartsWith("\'s") || !action.StartsWith(",");
+        action = FormattedMessage.RemoveMarkupPermissive(action).Trim();
+        var useSpace = !(action.StartsWith("'") || action.StartsWith(","));
         var space = useSpace || separateNameAndMessage ? " " : "";
         var locString = "chat-manager-entity-subtle-wrap-message";
 


### PR DESCRIPTION
Fixed ' and , not removing the space between messages because of silly goose moment.
Putting a ! at the front of the action formats it like (Name) Action
Putting a ' or a , at the front of the action removes the space between Name and Action, only if it isn't starting with a !

<img width="305" height="172" alt="image" src="https://github.com/user-attachments/assets/42cba9e0-5616-4f0e-84cb-c5c93f95a9ec" />

:cl:
- add: Added the ability to use a subtledetailed or medetailed format by putting a ! at the front of your action in emote or subtle.
- fix: The space between name and message for subtle and emotes is now properly removed when you put a ' or a , at the front.