### PR TITLE
Chef Tweaks Vol 2

### DIFF
--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -70,7 +70,11 @@ namespace Content.Server.Kitchen.Components
     public sealed partial class MicrowaveComponent : Component
     {
         [DataField]
+        public float BaseCookTimeMultiplier = 1.0f;
+
+        [DataField]
         public float CookTimeMultiplier = 1;
+
         [DataField(customTypeSerializer: typeof(PrototypeIdSerializer<MachinePartPrototype>))]
         public string MachinePartCookTimeMultiplier = "Capacitor";
         [DataField]

--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -426,8 +426,11 @@ namespace Content.Server.Kitchen.EntitySystems
 
         private void OnRefreshParts(Entity<MicrowaveComponent> ent, ref RefreshPartsEvent args)
         {
+            var baseCookTime = ent.Comp.BaseCookTimeMultiplier;
             var cookRating = args.PartRatings[ent.Comp.MachinePartCookTimeMultiplier];
-            ent.Comp.CookTimeMultiplier = MathF.Pow(ent.Comp.CookTimeScalingConstant, cookRating - 1);
+            var partTimeMultiplier = MathF.Pow(ent.Comp.CookTimeScalingConstant, cookRating - 1);
+
+            ent.Comp.CookTimeMultiplier = baseCookTime * partTimeMultiplier;
         }
 
         private void OnUpgradeExamine(Entity<MicrowaveComponent> ent, ref UpgradeExamineEvent args)

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
@@ -21,7 +21,7 @@
     ClothingOuterWinterChef: 2
     ClothingOuterJacketChef: 1
     ClothingMaskItalianMoustache: 2
-    ClothingUniformJumpsuitChef: 1
+    ClothingUniformJumpsuitChef: 2
     ClothingUniformJumpskirtChef:  2
     ClothingUniformJumpsuitWaiter: 2 # DEN
     ClothingUniformJumpskirtWaitress: 2 # DEN

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chefdrobe.yml
@@ -20,9 +20,11 @@
     ClothingWaistApron: 2 # The Den: Added waist apron.
     ClothingOuterWinterChef: 2
     ClothingOuterJacketChef: 1
-    ClothingUniformJumpsuitChef: 1
     ClothingMaskItalianMoustache: 2
+    ClothingUniformJumpsuitChef: 1
     ClothingUniformJumpskirtChef:  2
+    ClothingUniformJumpsuitWaiter: 2 # DEN
+    ClothingUniformJumpskirtWaitress: 2 # DEN
     ClothingHeadHatChef: 2
     ClothingShoesColorBlack: 2
     ClothingShoesBootsWinterChef: 2 #Delta V: Add departmental winter boots

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -539,6 +539,9 @@
         - Skewer
         - MonkeyCube
         - Mayo
+        - Towel
+        - Mustard
+        - Rag
       components:
         - Mousetrap
         - Smokable

--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -16,13 +16,13 @@
     sprite: Clothing/Multiple/towel.rsi
   - type: Clothing
     sprite: Clothing/Multiple/towel.rsi
-    slots: 
+    slots:
     - BELT
     - INNERCLOTHING
     - HEAD
     femaleMask: UniformTop
-    equipSound: 
-    unequipSound: 
+    equipSound:
+    unequipSound:
   - type: Spillable
     solution: absorbed
     spillWhenThrown: false
@@ -45,6 +45,11 @@
     fiberColor: fibers-white
   - type: Item
     size: Small
+  - type: Tag # DEN - Add Towel tag
+    tags:
+    - ClothMade
+    - WhitelistChameleon
+    - Towel
 
 - type: entity
   id: TowelColorWhite
@@ -169,7 +174,7 @@
         color: "#0089EF"
   - type: Fiber
     fiberColor: fibers-blue
-    
+
 - type: entity
   id: TowelColorDarkBlue
   name: dark blue towel
@@ -772,4 +777,3 @@
         color: "#535353"
   - type: Fiber
     fiberColor: fibers-black
-    

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -347,12 +347,15 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 17 # DEN: 15 -> 17 (12 + 5)
         reagents:
-        - ReagentId: Nutriment
-          Quantity: 6
-        - ReagentId: Vitamin
-          Quantity: 1
+        - ReagentId: Nutriment # DEN - 6 -> 5
+          Quantity: 5
+        - ReagentId: Vitamin # DEN - 1 -> 3
+          Quantity: 3
+        - ReagentId: Protein # DEN - Add protein
+          Quantity: 4
+  - type: Food
   - type: Tag
     tags:
     - Meat
@@ -365,7 +368,7 @@
   description: BBQ ribs, slathered in a healthy coating of BBQ sauce. The least vegan thing to ever exist.
   components:
   - type: Food
-    trash: 
+    trash:
     - FoodKebabSkewer
   - type: FlavorProfile
     flavors:
@@ -628,7 +631,7 @@
   description: Buttery.
   components:
   - type: Food
-    trash: 
+    trash:
     - FoodPlate
   - type: FlavorProfile
     flavors:

--- a/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/microwave.yml
@@ -174,7 +174,7 @@
   description: So advanced, it can cook donk-pockets in a mere 2.5 seconds!
   components:
   - type: Microwave
-    cookTimeMultiplier: 0.5
+    baseCookTimeMultiplier: 0.5
     capacity: 10
     canMicrowaveIdsSafely: false
     explosionChance: 0.3

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -225,9 +225,9 @@
           !type:PhysShapeAabb
           bounds: "-0.3,-0.16,0.3,0.40"
         mask:
-        - MachineMask
+        - TabletopMachineMask
         layer:
-        - MachineLayer
+        - TabletopMachineLayer
         density: 190
   - type: Advertise
     pack: CondimentVendAds

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -694,8 +694,7 @@
   reagents:
     Flour: 15
     Egg: 6
-  solids:
-    FoodButterSlice: 1  # DEN - Butter slice
+    OilOlive: 5
 
 - type: microwaveMealRecipe
   id: RecipePastaTomato

--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -476,7 +476,7 @@
   time: 15
   solids:
     FoodDough: 1
-    FoodMeat: 1 #replace with sausage
+    FoodMeatSausage: 1 # DEN - Use sausage
 
 - type: microwaveMealRecipe
   id: RecipeSpiderMeatBread

--- a/Resources/Prototypes/_DEN/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Cooking/meal_recipes.yml
@@ -27,7 +27,7 @@
     Flour: 5
 
 - type: microwaveMealRecipe
-  id: RecipeCroissant
+  id: RecipePigBlanket
   name: pig in a blanket recipe
   result: FoodMealPigblanket
   time: 10

--- a/Resources/Prototypes/_DEN/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Cooking/meal_recipes.yml
@@ -25,3 +25,12 @@
     Sugar: 5
     Water: 5
     Flour: 5
+
+- type: microwaveMealRecipe
+  id: RecipeCroissant
+  name: pig in a blanket recipe
+  result: FoodMealPigblanket
+  time: 10
+  solids:
+    FoodCroissantRaw: 1
+    FoodMeatSausage: 1

--- a/Resources/Prototypes/_DEN/tags.yml
+++ b/Resources/Prototypes/_DEN/tags.yml
@@ -42,6 +42,9 @@
   id: Tofu
 
 - type: Tag
+  id: Towel
+
+- type: Tag
   id: ArachneEmotes
 
 - type: Tag

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/advanced_microwave.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/advanced_microwave.yml
@@ -11,7 +11,7 @@
   description: Don't stand too close to this thing, definitely dont put anything metal in.
   components:
   - type: Microwave
-    cookTimeMultiplier: 0.5
+    baseCookTimeMultiplier: 0.5
     capacity: 30
     canMicrowaveIdsSafely: false # No AA farm
   - type: Sprite

--- a/Resources/Prototypes/_DV/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/_DV/Recipes/Cooking/meal_recipes.yml
@@ -69,8 +69,8 @@
   result: FoodBoxNugget
   time: 10
   reagents:
-    Protein: 20
-    Egg: 4
-    Flour: 6
+    Protein: 18 # DEN: 20u -> 18u
+    Egg: 6 # DEN: 4u -> 6u
+    Flour: 5 # DEN: 6u -> 5u
   solids:
     MaterialCardboard1: 1


### PR DESCRIPTION
## About the PR
few easy tweaks to benefit chefs

## Why / Balance
i have to rep the home team man

suggestion thread by @ therealshirt + personal observations

## Technical details
yml tweaks

one minor microwave refactor - now microwaves have a "base cooking time multiplier" that gets incorporated when part-based speed buffs are taken into accoiunt

can't show it in media, but the chicken nugget box now uses 18u of protein, 5u of flour, 6u of egg, and 1 cardboard. this allows you to make chicken nuggets evenly with two raw meat, one egg, and one "serving" of flour, as opposed to before where the ratios were weird as hell

## Media

**ChefDrobe Changes:**
![](https://github.com/user-attachments/assets/5de9859e-7ba0-4e4c-bcce-565a4df3d23c)

**Recipe Tweaks:**
![](https://github.com/user-attachments/assets/f992ee60-29e5-471b-a6a6-337f65ccc238)

![](https://github.com/user-attachments/assets/0054bd99-81af-47d3-8ae1-8e0541a3014a)

![](https://github.com/user-attachments/assets/a8e9c10c-295f-4879-b1d9-53ecfbe99234)

**Advanced Microwaves Take 1/2 Time:**
![](https://github.com/user-attachments/assets/273aaf1b-7d45-4e37-98b7-c45bb029363f)

**ChefBelt Items:**
![](https://github.com/user-attachments/assets/ab229353-d893-422b-b497-c43037b96d07)

**Fixed Condiment Station Anchoring:**
![](https://github.com/user-attachments/assets/01d921db-970b-4b37-9f06-c2e8f278e02e)

## Breaking changes
the microwave "cookTimeMultiplier" YML field has been changed to "baseCookTimeMultiplier", because the parts upgrade system determines cookTimeMultiplier dynamically

**Changelog**
:cl:
- add: Waiter and waitress uniforms can now be found in the ChefDrobe.
- add: Mustard bottles, damp rags, and towels can now be stored on the chef belt.
- add: Pig in a blanket has a new recipe, and is more nutritious now to boot!
- tweak: Boiled spaghetti now requires olive oil instead of butter to make.
- tweak: The recipe for the chicken nugget box is less stressful.
- tweak: The ChefDrobe now holds 2 of the original chef uniform instead of just 1.
- tweak: Sausage bread now requires actual sausage to make, instead of regular meat.
- fix: The condiment station can now be moved onto tables and anchored on top of them.
- fix: Advanced Microwaves now properly take 1/2 the time to cook things.
