### PR TITLE
QOL changes to X Card

### DIFF
--- a/Content.Client/_Floof/Consent/UI/Windows/ConsentWindow.xaml
+++ b/Content.Client/_Floof/Consent/UI/Windows/ConsentWindow.xaml
@@ -52,18 +52,28 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
                     </controls:NeoTabContainer>
                 </ScrollContainer>
             </BoxContainer>
-            <BoxContainer Name="ConsentCardsTab" Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True" Margin="5">
-                <ui:CardButton
-                    Name="XCard"
-                    Access="Internal"
-                    Icon="{xe:Tex '/Textures/_AS/Interface/x.svg.96dpi.png'}"
-                    Description="I am uncomfortable\nwith this scene."
-                    BackgroundColor="#FF2D2D38"
-                    HoverColor="#FF3D3D48"
-                    PressedColor="#FF4D4D58"
-                    MinSize="0 200"
-                    HorizontalExpand="True"
-                />
+            <BoxContainer Name="ConsentCardsTab" Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True" Margin="15">
+                <BoxContainer Name="XCardSection" Orientation="Vertical" HorizontalExpand="True" VerticalExpand="True"
+                    SeparationOverride="10">
+                    <ui:CardButton
+                        Name="XCard"
+                        Access="Internal"
+                        Icon="{xe:Tex '/Textures/_AS/Interface/x.svg.96dpi.png'}"
+                        Description="{Loc 'consent-window-cards-x-card-text'}"
+                        BackgroundColor="#FF2D2D38"
+                        HoverColor="#FF3D3D48"
+                        PressedColor="#FF4D4D58"
+                        MinSize="0 200"
+                        MaxWidth="450"
+                        HorizontalExpand="True"
+                    />
+                    <RichTextLabel
+                        Text="{Loc 'consent-window-cards-x-card-description'}"
+                        HorizontalExpand="True"
+                        HorizontalAlignment="Center"
+                        MaxWidth="650"/>
+                </BoxContainer>
+
             </BoxContainer>
         </controls:NeoTabContainer>
     </BoxContainer>

--- a/Content.Client/_Floof/Consent/UI/Windows/ConsentWindow.xaml.cs
+++ b/Content.Client/_Floof/Consent/UI/Windows/ConsentWindow.xaml.cs
@@ -72,11 +72,7 @@ public sealed partial class ConsentWindow : FancyWindow
         ConsentFreetext.OnTextChanged += _ => UnsavedChanges();
 
         // Aurora - Add consent cards
-        XCard.OnPressed += _ =>
-        {
-            if (_player.LocalSession is {} player)
-                _card.RaiseConsentCard(player.UserId, "XCard");
-        };
+        XCard.OnPressed += _ => { RaiseConsentCard("XCard"); };
     }
 
     private void InitializeCategories()
@@ -243,6 +239,12 @@ public sealed partial class ConsentWindow : FancyWindow
 
             AddConsentEntry(category, toggle);
         }
+    }
+
+    private void RaiseConsentCard(string cardName)
+    {
+        if (_player.LocalSession is { } player)
+            _card.RaiseConsentCard(player.UserId, cardName);
     }
 
     private void ButtonOnPress(Button currentButton, Button otherbutton)

--- a/Resources/Locale/en-US/Blep/consent.ftl
+++ b/Resources/Locale/en-US/Blep/consent.ftl
@@ -12,7 +12,12 @@ consent-window-title = OOC Consent & Preferences
 consent-window-text = This information is shown to other players to help with RP and used to opt-in or out of certain gameplay systems.
 consent-window-freetext-label = Freetext
 consent-window-toggles-label = Toggles
+
 consent-window-cards-label = I Am Uncomfortable
+consent-window-cards-x-card-text = I am uncomfortable
+    with this scene.
+consent-window-cards-x-card-description = [italic]This card informs online admins that the current scene you are in is making you uncomfortable. Do not hesitate to use this button when you feel uncomfortable or trapped - server admins will ensure you are able to leave a situation safely with as little fuss as possible. You will NEVER be "in trouble" for raising a card in good faith, even if the situation resolves itself, seems "minor", or the card was raised in error.[/italic]
+
 consent-window-freetext-placeholder = Put your ERP info here, such as:
     Sub/Dom/Switch
     If you are okay with IC noncon

--- a/Resources/Locale/en-US/_AS/consent/consent-cards.ftl
+++ b/Resources/Locale/en-US/_AS/consent/consent-cards.ftl
@@ -1,4 +1,7 @@
-unknown-consent-card-admin-message = CONSENT: {$player} raised a {$type} consent card. Please assist if needed.
-x-consent-card-admin-message = CONSENT: {$player} raised a {$type}. Please ensure they are able to exit the scene.
+# I tried to make this use INDEFINITE(), but the arguments wouldn't parse
+consent-card-raised = You have raised an {$card}.
 
+unknown-consent-card-admin-message = CONSENT: {$player} raised a {$type} consent card. Please assist if needed.
+
+x-consent-card-admin-message = CONSENT: {$player} raised a {$type}. Please ensure they are able to exit the scene.
 x-consent-card-popup-message = Player is uncomfortable with the scene and wants to exit.


### PR DESCRIPTION
## About the PR
There is now a lengthy description for the X-card.
When you click the X-card, it will send you a chat message.

## Why / Balance
The purpose of the card was unclear and gave users no feedback; this is fixing that

## Technical details
Mostly some XAML adjustments, added a chat message to the server side of consent cards, more locales

## Media
<img width="677" height="352" alt="image" src="https://github.com/user-attachments/assets/62556324-8100-4d84-8e2b-719e848501c8" />
<img width="234" height="27" alt="image" src="https://github.com/user-attachments/assets/b0d6c7c3-007f-49b5-964f-044086afbbdb" />

**Changelog**
:cl:
- tweak: The X Card in the Consent menu has been given a clearer description, and you will now be sent a message when the card is raised.
