### PR TITLE
Fixed Surgery Healing

### DIFF
--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -151,7 +151,7 @@ public sealed class SurgerySystem : SharedSurgerySystem
     {
         var damageChange = ent.Comp.Damage;
         if (HasComp<ForcedSleepingComponent>(args.Body))
-            damageChange = damageChange * ent.Comp.SleepModifier;
+            damageChange *= ent.Comp.SleepModifier;
 
         SetDamage(args.Body, damageChange, 0.5f, args.User, args.Part);
     }

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -348,16 +348,14 @@ public abstract partial class SharedSurgerySystem
     {
         var group = ent.Comp.MainGroup == "Brute" ? BruteDamageTypes : BurnDamageTypes;
 
-        if (!HasDamageGroup(args.Body, group, out var damageable)
-            && !HasDamageGroup(args.Part, group, out var _)
+        if (!HasDamageGroup(args.Part, group, out var damageable)
+            && !HasDamageGroup(args.Body, group, out var _)
             || damageable == null) // This shouldnt be possible but the compiler doesn't shut up.
             return;
 
-
-        // Right now the bonus is based off the body's total damage, maybe we could make it based off each part in the future.
         var bonus = ent.Comp.HealMultiplier * damageable.DamagePerGroup[ent.Comp.MainGroup];
         if (_mobState.IsDead(args.Body))
-            bonus *= 0.2;
+            bonus *= 0.1;
 
         var adjustedDamage = new DamageSpecifier(ent.Comp.Damage);
 
@@ -372,8 +370,7 @@ public abstract partial class SharedSurgerySystem
     {
         var group = ent.Comp.MainGroup == "Brute" ? BruteDamageTypes : BurnDamageTypes;
 
-        if (HasDamageGroup(args.Body, group, out var _)
-            || HasDamageGroup(args.Part, group, out var _))
+        if (HasDamageGroup(args.Part, group, out var _))
             args.Cancelled = true;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
The healing done by Surgery TendWounds is 10 brute/burn + 7% of the general damage. Half of that healing is transferred to the targetted limb.
I changed that it's now 10 brute/burn + 7% of the limb's damage. Half of that is transferred to the targetted limb.
This will have the effect that treating a badly damaged limb is more beneficial for the general damage than treating a lightly damaged limb.

Dead people have a debuff that decreases the procentual healing by 5 times. So, 7% * 0.2 is 1.4%.
I increased that debuff to decrease healing by 10 times, so it'll be 0.07%. Get that patient alive, doc.

Also made it that you cannot treat wounds on a limb that doesn't have the damage. If the head is fine, you cannot treat bruise wounds on it even if the General Damage has it.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, if you have a burn victim, treating the patient's torso would be quick and easy - The procentual healing would make quick work of anything. So, you end up with a fine torso and all general damage healed.
However, after that, every other limb takes years, because you are effectively healing it 1.66 damage (10 Brute / 3 Brute Types / 2 Limb transferral ratio) per action, since it's missing the procentual healing of the general damage.
This is nonsenical and leads to patients being alive, but unable to do anything for a very long time.

It makes more sense that the general damage profits from the treatment of the limb, not other way around.
However, since limbs take half of the damage that the general damage takes, this is a decrease of the procentual healing 7% -> 3.5%
To make it more clear:
Taking 100 blunt damage leads to 50 blunt damage for the torso.
If you heal 7% of the General damage, then that's 7. If you heal 7% of the torso's damage, that's 3.5. Changing the healing to be dependent on the limb effictively halved the healing.

I further nerfed the healing by strengthening the debuff on dead patients. That means instead of healing 0.14% (previosu value) of the damage on dead patients, you heal 0.07% now.

Despite all numericals being nerfs, this is a heavy buff. Doctors can very quickly heal the limbs of a patient, IF the patient has been brought back to life, resulting in the patient getting out of medical way sooner instead of having to wait years for a slow recovery made by pyrazine or inefficient surgery.
If the recovery is too quick, one can change the value of the procentual healing.

Also made simply sense to not be able to heal a fine limb. Target on the injured limbs if you wanna heal the patient.
## Technical details
<!-- Summary of code changes for easier review. -->
Changed a variable so the limbs damage is being calculated instead of the general damage.
Removed the general damage from the check that decides if you can do tend wounds on a limb.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Tending wounds via surgery will now heal according to the damage of the limb instead of the general damage - No longer will your surgery speed decrease after having healed the general damage!
- tweak: Nerfed Surgery Effectiveness on dead patients from 0.2 to 0.1. Get your patient back to life as quickly as possible if you want to be efficient!
- tweak: You can no longer treat wounds on limbs that have no injuries.