### PR TITLE
Fix Not Allowed to Colon Three in Subtle OOC

### DIFF
--- a/Content.Server/Chat/Commands/SubtleOOCCommand.cs
+++ b/Content.Server/Chat/Commands/SubtleOOCCommand.cs
@@ -58,8 +58,17 @@ namespace Content.Server.Chat.Commands
                 return;
 
             var entitySystemManager = IoCManager.Resolve<IEntitySystemManager>();
-                var chatSystem = entitySystemManager.GetEntitySystem<ChatSystem>();
-                .TrySendInGameICMessage(playerEntity, message, InGameICChatType.SubtleOOC, ChatTransmitRange.NoGhosts, false, shell, player, color: SubtleOOCColor);
+            var chatSystem = entitySystemManager.GetEntitySystem<ChatSystem>();
+
+            chatSystem.TrySendInGameICMessage(playerEntity,
+                message,
+                InGameICChatType.SubtleOOC,
+                ChatTransmitRange.NoGhosts,
+                false,
+                shell,
+                player,
+                color: SubtleOOCColor,
+                checkRadioPrefix: false);
         }
     }
 }


### PR DESCRIPTION
I can :3 in subtle OOC now.

:cl:
- fix: You can colon three in subtle OOC now.