### PR TITLE
Roundstart Highcap Kill

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -336,6 +336,7 @@
   - type: Appearance
   - type: HandheldLight
     addPrefix: true
+    wattage: 0.5
     blinkingBehaviourId: blinking
     radiatingBehaviourId: radiating
   - type: LightBehaviour

--- a/Resources/Prototypes/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translators.yml
@@ -69,7 +69,7 @@
 - type: entity
   categories: [ HideSpawnMenu ]
   id: TranslatorForeigner
-  parent: [ PowerCellSlotHighItem, TranslatorPoweredBase ]
+  parent: [ PowerCellMedium, TranslatorPoweredBase ]
   name: foreigner's translator
   description: A special-issue translator that helps foreigner's speak and understand this station's primary language.
 

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -208,7 +208,7 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellHigh
+        startingItem: PowerCellMedium
   - type: GenericVisualizer
     visuals:
       enum.FlashVisuals.Burnt:

--- a/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/flashlights.yml
@@ -146,9 +146,10 @@
     slots:
       cell_slot:
         name: power-cell-slot-component-slot-name-default
-        startingItem: PowerCellHigh
+        startingItem: PowerCellMedium
   - type: HandheldLight
     addPrefix: false
+    wattage: 0.5
   - type: ToggleableLightVisuals
     inhandVisuals:
       left:

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
@@ -46,7 +46,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 6
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: PrisonGuardGear

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -95,7 +95,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 8
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: CaptainGear

--- a/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
@@ -42,7 +42,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 10
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: CentcomGear

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -119,7 +119,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 8
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: HoPGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -87,7 +87,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 8
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: CMOGear

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -118,7 +118,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 8
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: ResearchDirectorGear

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -55,7 +55,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 6
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: DetectiveGear

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -86,7 +86,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 8
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: HoSGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -63,7 +63,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 6
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: SecurityCadetGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -72,7 +72,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 6
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: SecurityOfficerGear

--- a/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/senior_officer.yml
@@ -48,7 +48,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 6
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: SeniorOfficerGear

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -78,7 +78,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 6
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: WardenGear

--- a/Resources/Prototypes/_DV/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Security/brigmedic.yml
@@ -54,7 +54,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 6
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: CorpsmanGear # see Prototypes/Roles/Jobs/Fun/misc_startinggear.yml for "BrigmedicGear"

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -48,7 +48,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 8
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: BlueshieldOfficerGear

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/magistrate.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/magistrate.yml
@@ -40,7 +40,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 8
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: MagistrateGear

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -38,7 +38,7 @@
   - !type:ModifyEnvirosuitSpecial
     charges: 8
   - !type:ModifyEnvirohelmSpecial
-    powerCell: PowerCellHigh
+    powerCell: PowerCellMedium
 
 - type: startingGear
   id: NanotrasenRepresentativeGear


### PR DESCRIPTION
## About the PR
Removed high caps from seclites and envirohelms (and other stuff) and adjusted their wattage to be more efficient (should last the same amount of time as they did with high caps, but now with med caps. 
Direction pre-approved.

## Why / Balance
You should not be coming up to security and bully them to give you a high cap from their seclite, and you should not as sec harvest seclites for their highcaps. It's a research unlock and should not be available roundstart.

## Technical details
-

## Media
-

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
-

**Changelog**
:cl: MajorMoth
- remove: Removed high caps from seclites and envirohelms among other things. Ask epi about getting a few, them being a research unlock has not changed, and it was always the intended way to get them.
- tweak: The wattage of items that have had their high caps removed has been adjusted to make them more efficient - they should last about the same amount of time as they did with high caps, but they will have med caps in them now.