### PR TITLE
Make Translator Drain 0 Until They Are Fixed

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translators.yml
@@ -51,7 +51,7 @@
   components:
   - type: ItemToggle
   - type: PowerCellDraw
-    drawRate: 1.2
+    drawRate: 0 # The Den: make it not 0 when the issues with them are fixed
   - type: ToggleCellDraw
   - type: ItemSlots
     slots:


### PR DESCRIPTION
## About the PR
what it says on the tin

## Why / Balance
With an easy roundstart source of high-capacity batteries removed in [this pr](https://github.com/TheDenSS14/TheDen/pull/1493) people will surely complain about translators if we don't do this. 

## Technical details
-

## Media
-

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
-

**Changelog**
:cl: MajorMoth
- tweak: Temporarily made translators not drain any power until the issues with them are fixed. They still need a battery with even a minimal charge to turn on, though. Happy yapping!