### PR TITLE
Fix and Buff Shadowkins Psionics

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/shadowkin.yml
@@ -190,7 +190,6 @@
         types:
           Asphyxiation: -1.0
     - type: Psionic
-      canReroll: false
       mindbreakingFeedback: shadowkin-blackeye
     - type: InnatePsionicPowers
       powersToAdd:
@@ -203,7 +202,7 @@
         - TauCetiBasic
         - Marish
     - type: PotentiaModifier
-      potentiaMultiplier: 1.25
+      potentiaMultiplier: 1.5
     - type: Tag
       tags:
       - CanPilot

--- a/Resources/Prototypes/Traits/mental.yml
+++ b/Resources/Prototypes/Traits/mental.yml
@@ -26,9 +26,6 @@
         - MedicalBorg
     - !type:CharacterLogicOrRequirement
       requirements:
-        - !type:CharacterSpeciesRequirement
-          species:
-            - Shadowkin # Innate Psionics
         - !type:CharacterTraitRequirement
           traits:
             - LatentPsychic
@@ -52,6 +49,7 @@
       species:
         - Oni
         - Kitsune # Floof - M3739 - #937 - They already have an equivalent.
+        - Shadowkin
     - !type:CharacterTraitRequirement
       inverted: true
       traits:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I buffed Shadowkin's psionic abilities. Currently, they were weaker than any other species, even though they are the defacto psionic species.
I gave them the free reroll every other species has and buffed their potentia gain to 1.5x, like Kitsunes and locked them out of getting the high potentia trait.
This fixes them not being able to roll any psionic power in the future that doesn't originate from telepathy, as having the no reroll would avoid calling the method that gives them available powers in the future.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I'm getting paid for this.
Also, Shadowkins should have psionics if they're advertised as psionically gifted.
## Technical details
<!-- Summary of code changes for easier review. -->
Added Shadowkin blockers to the High potentia trait.
Removed the YML line that took away shadowkins free reroll from their species YML.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1219" height="416" alt="grafik" src="https://github.com/user-attachments/assets/f5bee067-fbf9-4e0b-b407-235422a9e5e8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Shadowkins not getting proper psionic powers and being stuck with basic ones.
- tweak: Shadowkins now get a free psionic roundstart like everyone else.
- tweak: Increased Shadowkin's potentia modifier to the level of a kitsune. They cannot take the high potentia trait anymore.

