### PR TITLE
Schedulermaxxing

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -313,9 +313,10 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: RampingStationEventScheduler
-    chaosModifier: 2 # By default, one event each 30-10 seconds after two hours. Changing CVars will cause this to deviate.
+    chaosModifier: 5 # By default, one event each 30-10 seconds after two hours. Changing CVars will cause this to deviate.
     startingChaosRatio: 0.1
     shiftLengthModifier: 2.5
+    eventDelayModifier: 1.5
 
 - type: entity
   id: IrregularStationEventScheduler

--- a/Resources/Prototypes/_DEN/random_presets.yml
+++ b/Resources/Prototypes/_DEN/random_presets.yml
@@ -6,8 +6,9 @@
 - type: presetPicker
   id: HighDanger
   possibleWeightedPresets:
-    Survival: 0.60
-    SurvivalHellshift: 0.40
+    Survival: 0.70
+    SurvivalHellshift: 0.20
+    Zombie: 0.10
     # Nukeops: 0.25
 
 - type: presetPicker

--- a/Resources/Prototypes/_DEN/random_presets.yml
+++ b/Resources/Prototypes/_DEN/random_presets.yml
@@ -6,9 +6,8 @@
 - type: presetPicker
   id: HighDanger
   possibleWeightedPresets:
-    Survival: 0.70
+    Survival: 0.80
     SurvivalHellshift: 0.20
-    Zombie: 0.10
     # Nukeops: 0.25
 
 - type: presetPicker


### PR DESCRIPTION
each screenshot is simulating 40 players in a 180 minute round
<img width="868" height="357" alt="image" src="https://github.com/user-attachments/assets/93afc1da-b879-48fb-b63d-f2e816abedd4" />
<img width="983" height="338" alt="image" src="https://github.com/user-attachments/assets/28a5fa12-dc7e-4062-950a-595ef71f7e04" />

:cl:
- tweak: Denified Hellshift, it is now about 1 event every 6 minutes with a higher percentage of things like Carp Vents rather than replicators or dragons