### PR TITLE
These Things Should Not Be 6 Points for Crowbars

### DIFF
--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -676,7 +676,7 @@
 - type: trait
   id: BionicArm
   category: TraitsPhysicalAugmentations
-  points: -6
+  points: -3
   requirements:
     - !type:CharacterTraitRequirement
       inverted: true
@@ -710,7 +710,7 @@
 - type: trait
   id: BionicArmNoVisuals
   category: TraitsPhysicalAugmentations
-  points: -6
+  points: -3
   requirements:
     - !type:CharacterTraitRequirement
       inverted: true


### PR DESCRIPTION
## About the PR
Bionic arms are no longer 6 points for Crowbars

## Why / Balance
before when these were Jaws Of Life arms, 6 point cost made sense, now that they are Not jaws of life, the cost should probably come down as well

## Technical details
we love 2 line yml changes here

## Media
no media, unless you want screenshots of numbers

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
N/A

**Changelog**
:cl: Jadrek
- tweak: Bionic arms are 3 points cheaper!

