### PR TITLE
No ID in Conscription Kit

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Fills/Items/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Items/Backpacks/duffelbag.yml
@@ -18,7 +18,6 @@
     - id: ClothingUniformJumpsuitSalvageSpecialist
     - id: EncryptionKeyCargo
     - id: ClothingMaskGasExplorer
-    - id: SalvageIDCard
     - id: WeaponProtoKineticAccelerator
     - id: SurvivalKnife
     - id: FlashlightSeclite


### PR DESCRIPTION
talk to your local LO about conscripting your friends today

:cl:
- remove: Removed the salvage ID from the conscription kit. Talk to your local LO today about making your friend a salvager.