### PR TITLE
Fax Logging Start Position Correction

### DIFF
--- a/Content.Server/_DEN/Fax/FaxLoggingSystem.cs
+++ b/Content.Server/_DEN/Fax/FaxLoggingSystem.cs
@@ -69,7 +69,8 @@ public sealed class FaxLoggingSystem : EntitySystem
         {
             var remaining = contentLeft.Length - 1;
             var slicesToTake = Math.Min(DiscordMaxMessageLength - 1, remaining);
-            var slice = content.Substring(lastSliceIndex + 1, slicesToTake);
+            var startPos = lastSliceIndex == 0 ? 0 : lastSliceIndex + 1;
+            var slice = content.Substring(startPos, slicesToTake);
             slices.Add(slice);
 
             if (contentLeft.Length - slicesToTake + 1 > 0)


### PR DESCRIPTION
fixes fax contents starting at index 1, not 0