### PR TITLE
Mute People Can Now Scream

### DIFF
--- a/Content.Server/Abilities/Mime/MimePowersSystem.cs
+++ b/Content.Server/Abilities/Mime/MimePowersSystem.cs
@@ -76,7 +76,9 @@ namespace Content.Server.Abilities.Mime
 
         private void OnComponentInit(EntityUid uid, MimePowersComponent component, ComponentInit args)
         {
-            EnsureComp<MutedComponent>(uid);
+            var mutedComponent = EnsureComp<MutedComponent>(uid); // IMP
+            mutedComponent.MutedScream = false; // IMP
+
             _alertsSystem.ShowAlert(uid, component.VowAlert);
             _actionsSystem.AddAction(uid, ref component.InvisibleWallActionEntity, component.InvisibleWallAction, uid);
         }

--- a/Content.Server/Speech/Muting/MutingSystem.cs
+++ b/Content.Server/Speech/Muting/MutingSystem.cs
@@ -39,7 +39,7 @@ namespace Content.Server.Speech.Muting
 
         private void OnEmote(EntityUid uid, MutedComponent component, ref EmoteEvent args)
         {
-            if (args.Handled)
+            if (args.Handled || !component.MutedEmotes) // IMP Change:MutedEmotes
                 return;
 
             //still leaves the text so it looks like they are pantomiming a laugh
@@ -49,7 +49,7 @@ namespace Content.Server.Speech.Muting
 
         private void OnScreamAction(EntityUid uid, MutedComponent component, ScreamActionEvent args)
         {
-            if (args.Handled || !_config.GetCVar(CCVars.AllowScreamAction))
+            if (args.Handled || !_config.GetCVar(CCVars.AllowScreamAction) || !component.MutedScream) // IMP Change:MutedScream
                 return;
 
             if (HasComp<MimePowersComponent>(uid))
@@ -66,6 +66,9 @@ namespace Content.Server.Speech.Muting
             var language = _languages.GetLanguage(uid);
             if (!language.SpeechOverride.RequireSpeech)
                 return; // Cannot mute if there's no speech involved
+
+            if (!component.MutedSpeech) // IMP
+                return;
 
             if (HasComp<MimePowersComponent>(uid))
                 _popupSystem.PopupEntity(Loc.GetString("mime-cant-speak"), uid, uid);

--- a/Content.Shared/Speech/Muting/MutedComponent.cs
+++ b/Content.Shared/Speech/Muting/MutedComponent.cs
@@ -12,6 +12,24 @@ namespace Content.Shared.Speech.Muting
     [RegisterComponent, NetworkedComponent]
     public sealed partial class MutedComponent : Component
     {
+        // IMP start
+        /// <summary>
+        /// Whether the affected entity can speak.
+        /// </summary>
+        [DataField(serverOnly: true)]
+        public bool MutedSpeech = true;
 
+        /// <summary>
+        /// Whether the affected entity emotes will have sound.
+        /// </summary>
+        [DataField(serverOnly: true)]
+        public bool MutedEmotes = true;
+
+        /// <summary>
+        /// Whether the affected entity will be able to use the scream action.
+        /// </summary>
+        [DataField(serverOnly: true)]
+        public bool MutedScream = true;
+        // IMP end
     }
 }

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -170,6 +170,7 @@
     - !type:TraitAddComponent
       components:
         - type: Muted
+          mutedScream: false # IMP
     - !type:TraitModifyLanguages
       languagesSpoken:
         - Sign

--- a/Resources/Prototypes/_DEN/Traits/disabilities.yml
+++ b/Resources/Prototypes/_DEN/Traits/disabilities.yml
@@ -50,6 +50,7 @@
     - !type:TraitAddComponent
       components:
         - type: Muted
+          mutedScream: false # IMP
 
 # Amputee traits
 


### PR DESCRIPTION
## About the PR
Ports the changes I made to the muted component on IMP to allow mute people to use the scream action (https://github.com/impstation/imp-station-14/pull/3038, https://github.com/impstation/imp-station-14/pull/2168). Just to be clear this doesn't make the scream have sound it just allows the action to be used (currently it gives the muted message as if you were trying to speak).

## Why / Balance
Mute people should be allowed to express their fear too.

## Technical details
Adds three variables to the muted component which allows you to change what the muted component affects.
I tested this on the two mute components, mimes, and tested various parts of the language system and everything seems to work as intended.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Oberonics
- tweak: Mute people can now express their fear.
