### PR TITLE
Make Shadowkin Eyes Glow Again

### DIFF
--- a/Resources/Locale/en-US/_DEN/markings/shadowkin.ftl
+++ b/Resources/Locale/en-US/_DEN/markings/shadowkin.ftl
@@ -1,0 +1,2 @@
+marking-EyesShadowkin = Shadowkin Eyes
+marking-EyesShadowkinUnshaded = Glowing Shadowkin Eyes

--- a/Resources/Locale/en-US/markings/shadowkin.ftl
+++ b/Resources/Locale/en-US/markings/shadowkin.ftl
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
-marking-EyesShadowkin = Shadowkin
+# marking-EyesShadowkin = Shadowkin # den, moved to _DEN/marking/shadowkin.ftl
 
 marking-TailShadowkin = Shadowkin
 marking-TailShadowkinBig = Shadowkin (Big)

--- a/Resources/Prototypes/Species/shadowkin.yml
+++ b/Resources/Prototypes/Species/shadowkin.yml
@@ -74,6 +74,10 @@
       points: 1
       required: true
       defaultMarkings: [EarsShadowkin]
+    Head: # den edit start, giving shadowkin their glowing eyes back
+      points: 1
+      required: true
+      defaultMarkings: [EyesShadowkinUnshaded] # den edit end
     Chest:
       points: 6
       required: false

--- a/Resources/Prototypes/_DEN/Mobs/Customization/Markings/shadowkinmarks.yml
+++ b/Resources/Prototypes/_DEN/Mobs/Customization/Markings/shadowkinmarks.yml
@@ -1,0 +1,31 @@
+# Eyes
+
+- type: marking
+  id: EyesShadowkin
+  bodyPart: Eyes
+  markingCategory: Head
+  speciesRestriction: [ Shadowkin ]
+  coloring:
+    default:
+      type:
+        !type:EyeColoring
+  forcedColoring: true
+  sprites:
+  - sprite: Mobs/Species/Shadowkin/parts.rsi
+    state: eyes
+
+- type: marking
+  id: EyesShadowkinUnshaded
+  bodyPart: Eyes
+  markingCategory: Head
+  speciesRestriction: [ Shadowkin ]
+  coloring:
+    default:
+      type:
+        !type:EyeColoring
+          negative: false
+  forcedColoring: true
+  sprites:
+  - sprite: Mobs/Species/Shadowkin/parts.rsi
+    state: eyes
+  shader: unshaded


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Added a marking for unshaded eyes, as well as an unshaded eye marking for those who wish not to have their eyes glow.

## Why / Balance
More customization, bounty.

## Technical details
As above. YML only.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="222" height="284" alt="image" src="https://github.com/user-attachments/assets/6db3e8e4-d001-4f02-9267-4611e4904989" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Shadowkin eyes glow now! Make sure to grab the not-glowy marking if you don't want yours to.
