### PR TITLE
Add Heirloom Examine Text

### DIFF
--- a/Content.Server/Traits/Assorted/HeirloomSystem.cs
+++ b/Content.Server/Traits/Assorted/HeirloomSystem.cs
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 using System.Linq;
+using Content.Shared.Examine;
 using Content.Shared.Mood;
 using Content.Shared.Traits.Assorted.Components;
 using Robust.Shared.Timing;
@@ -12,7 +13,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Server.Traits.Assorted;
 
-public sealed class HeirloomSystem : EntitySystem
+public sealed partial class HeirloomSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _gameTiming = default!;
 
@@ -25,6 +26,9 @@ public sealed class HeirloomSystem : EntitySystem
         base.Initialize();
 
         _nextUpdate = _gameTiming.CurTime;
+
+        // DEN: Heirloom examine text
+        SubscribeLocalEvent<HeirloomComponent, ExaminedEvent>(OnExamined);
     }
 
     public override void Update(float frameTime)

--- a/Content.Server/_DEN/Traits/Assorted/HeirloomSystem.cs
+++ b/Content.Server/_DEN/Traits/Assorted/HeirloomSystem.cs
@@ -1,0 +1,30 @@
+using Content.Shared.Examine;
+using Content.Shared.Traits.Assorted.Components;
+
+namespace Content.Server.Traits.Assorted;
+
+public sealed partial class HeirloomSystem
+{
+    private void OnExamined(Entity<HeirloomComponent> ent, ref ExaminedEvent args)
+    {
+        if (IsHeirloomOf(args.Examiner, args.Examined))
+            args.PushMarkup(Loc.GetString("heirloom-component-own-heirloom"));
+        else
+            args.PushMarkup(Loc.GetString("heirloom-component-other-heirloom", ("ent", ent)));
+    }
+
+    /// <summary>
+    /// Checks if a given entity is another entity's heirloom.
+    /// </summary>
+    /// <param name="haver">The potential owner of the heirloom.</param>
+    /// <param name="heirloom">The potential heirloom entity.</param>
+    /// <returns>Whether or not the given entity is the haver's heirloom.</returns>
+    /// <remarks>
+    /// This only checks the owner's component, because this is what is used to refresh the moodlet.
+    /// </remarks>
+    public bool IsHeirloomOf(Entity<HeirloomHaverComponent?> haver, EntityUid heirloom)
+    {
+        return Resolve(haver.Owner, ref haver.Comp, logMissing: false)
+            && haver.Comp.Heirloom == heirloom;
+    }
+}

--- a/Resources/Locale/en-US/_DEN/traits/heirloom.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/heirloom.ftl
@@ -1,0 +1,2 @@
+heirloom-component-own-heirloom = [color=#f2a9c8]This item is sentimental to me... I better keep it safe.[/color]
+heirloom-component-other-heirloom = [color=gray]{CAPITALIZE(SUBJECT($ent))} looks like {SUBJECT($ent)} has sentimental value.[/color]


### PR DESCRIPTION
## About the PR
Adds an examine text to heirlooms for both the heirloom owner and other players examining the item.

## Why / Balance
As far as I know you cannot tell if an item is an heirloom, which makes the moodlet seem kind of inexplicable
I also feel like this opens up roleplay opportunities

## Technical details
Small extension to HeirloomSystem that adds an ExaminedEvent. It will check if the examiner has HeirloomHaverComponent that points to the examined item. The heirloom component of the heirloom itself is not checked because it's irrelevant to the moodlet

## Media
<img width="466" height="244" alt="image" src="https://github.com/user-attachments/assets/f85ae3d5-217c-4c55-bf16-379ae1319de1" />
<img width="490" height="212" alt="image" src="https://github.com/user-attachments/assets/cce028b5-6d59-4539-b85b-c30231b0c8ae" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
Nada

**Changelog**
:cl:
- add: Heirloom items now have examination text for both the owner and other players.
