### PR TITLE
Airlock Service Doors Hotfix, Using Wrong Sprite

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -39,7 +39,7 @@
 
 # Airlocks
 - type: entity
-  parent: Airlock
+  parent: AirlockService # The Den - airlock resprite
   id: AirlockServiceLocked
   suffix: Service, Locked
   components:
@@ -462,7 +462,7 @@
 
 # Glass Airlocks
 - type: entity
-  parent: AirlockGlass
+  parent: AirlockServiceGlass # The Den - airlock resprite
   id: AirlockServiceGlassLocked
   suffix: Service, Locked
   components:

--- a/Resources/Prototypes/_DEN/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_DEN/Entities/Structures/Doors/Airlocks/access.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
-  parent: AirlockMaint
+  parent: AirlockMaintScience
   id: AirlockMaintMantisLocked
   suffix: Mantis, Locked
   components:
@@ -12,7 +12,7 @@
       board: [ DoorElectronicsMantis ]
 
 - type: entity
-  parent: AirlockMaint
+  parent: AirlockMaintSecurity
   id: AirlockMaintCorpsmanLocked
   suffix: Corpsman, Locked
   components:
@@ -21,7 +21,7 @@
       board: [ DoorElectronicsCorpsman ]
 
 - type: entity
-  parent: AirlockMaint
+  parent: AirlockMaintCommand
   id: AirlockMaintBSOLocked
   suffix: BSO, Locked
   components:
@@ -30,7 +30,7 @@
       board: [ DoorElectronicsBSO ]
 
 - type: entity
-  parent: AirlockMaint
+  parent: AirlockMaintCommand
   id: AirlockMaintNTRLocked
   suffix: NTR, Locked
   components:
@@ -39,7 +39,7 @@
       board: [ DoorElectronicsNTR ]
 
 - type: entity
-  parent: AirlockMaint
+  parent: AirlockMaintCommand
   id: AirlockMaintMAGLocked
   suffix: Magistrate, Locked
   components:

--- a/Resources/Prototypes/_DEN/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/_DEN/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -299,7 +299,7 @@
       sprite: _DEN/Structures/Doors/Airlocks/Standard/maint_syndicate.rsi
       
 - type: entity
-  parent: AirlockMaintScience # The Den - airlock resprite
+  parent: AirlockMaintScience
   id: AirlockMaintRnDMed
   name: mysta/medical maintenance access
   components:

--- a/Resources/Prototypes/_DV/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Doors/Airlocks/access.yml
@@ -185,7 +185,7 @@
 
 #Add airlocks from upstream roles
 - type: entity
-  parent: Airlock
+  parent: AirlockService # The Den - airlock resprite
   id: AirlockBoxerLocked
   suffix: Boxer, Locked
   components:
@@ -194,7 +194,7 @@
       board: [ DoorElectronicsBoxer ]
 
 - type: entity
-  parent: Airlock
+  parent: AirlockService # The Den - airlock resprite
   id: AirlockClownLocked
   suffix: Clown, Locked
   components:
@@ -203,7 +203,7 @@
       board: [ DoorElectronicsClown ]
 
 - type: entity
-  parent: Airlock
+  parent: AirlockService # The Den - airlock resprite
   id: AirlockMimeLocked
   suffix: Mime, Locked
   components:
@@ -212,7 +212,7 @@
       board: [ DoorElectronicsMime ]
 
 - type: entity
-  parent: Airlock
+  parent: AirlockService # The Den - airlock resprite
   id: AirlockMusicianLocked
   suffix: Musician, Locked
   components:
@@ -221,7 +221,7 @@
       board: [ DoorElectronicsMusician ]
 
 - type: entity
-  parent: Airlock
+  parent: AirlockService # The Den - airlock resprite
   id: AirlockReporterLocked
   suffix: Reporter, Locked
   components:
@@ -239,7 +239,7 @@
       board: [ DoorElectronicsLibrary ]
 
 - type: entity
-  parent: Airlock
+  parent: AirlockService # The Den - airlock resprite
   id: AirlockZookeeperLocked
   suffix: Zookeeper, Locked
   components:
@@ -267,7 +267,7 @@
 
 # Glass Airlocks
 - type: entity
-  parent: AirlockGlass
+  parent: AirlockServiceGlass # The Den - airlock resprite
   id: AirlockBoxerGlassLocked
   suffix: Boxer, Locked
   components:
@@ -276,7 +276,7 @@
       board: [ DoorElectronicsBoxer ]
 
 - type: entity
-  parent: AirlockGlass
+  parent: AirlockServiceGlass # The Den - airlock resprite
   id: AirlockClownGlassLocked
   suffix: Clown, Locked
   components:
@@ -285,7 +285,7 @@
       board: [ DoorElectronicsClown ]
 
 - type: entity
-  parent: AirlockGlass
+  parent: AirlockServiceGlass # The Den - airlock resprite
   id: AirlockMimeGlassLocked
   suffix: Mime, Locked
   components:
@@ -294,7 +294,7 @@
       board: [ DoorElectronicsMime ]
 
 - type: entity
-  parent: AirlockGlass
+  parent: AirlockServiceGlass # The Den - airlock resprite
   id: AirlockMusicianGlassLocked
   suffix: Musician, Locked
   components:
@@ -303,7 +303,7 @@
       board: [ DoorElectronicsMusician ]
 
 - type: entity
-  parent: AirlockGlass
+  parent: AirlockServiceGlass # The Den - airlock resprite
   id: AirlockReporterGlassLocked
   suffix: Reporter, Locked
   components:
@@ -321,7 +321,7 @@
       board: [ DoorElectronicsLibrary ]
 
 - type: entity
-  parent: AirlockGlass
+  parent: AirlockServiceGlass # The Den - airlock resprite
   id: AirlockZookeeperGlassLocked
   suffix: Zookeeper, Locked
   components:


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
small update to the accesses for service, clown, mime, theater, musician, and zoologist to use the service door sprite instead of the generic one. Also fixed NTR, MAG, and BSO maints doors to use the command maints one 

## Why / Balance
Just missed it during the big one

## Technical details
mostly a few access.yml changes to the new protoypes. I think there was a small edit in the airlocks too

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Corrected service, clown, mime, theater, musician, and zoologist airlocks to use the service door instead of generic
- fix: Corrected NTR, MAG, and BSO maints doors to use command maints

