### PR TITLE
Fix Instant Thieving

### DIFF
--- a/Content.Shared/Strip/Components/StrippableComponent.cs
+++ b/Content.Shared/Strip/Components/StrippableComponent.cs
@@ -61,7 +61,7 @@ namespace Content.Shared.Strip.Components
         public TimeSpan Additive = TimeSpan.Zero;
         public ThievingStealth Stealth = stealth;
 
-        public TimeSpan Time => TimeSpan.FromSeconds(MathF.Max(InitialTime.Seconds * Multiplier + Additive.Seconds, 0f));
+        public TimeSpan Time => TimeSpan.FromSeconds(Math.Round(Math.Max(InitialTime.TotalSeconds * Multiplier + Additive.TotalSeconds, 0.5f), 3, MidpointRounding.ToZero));
 
         public SlotFlags TargetSlots { get; } = SlotFlags.GLOVES;
     }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Made Strip Attempts have a minimum time of 0.5 seconds.
Also fixed a parsing error that caused nearly full seconds to be rounded down on stripping time - Which exarcerbated the issue.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Instant Thieving shouldn't be a thing. Just shouldn't. How did you take my gun out of my hand without me knowing?
## Technical details
<!-- Summary of code changes for easier review. -->
Changed the calculation from MathF to Math, and made the numbers parse into doubles instead of integers to preserve decimals.
2.667 seconds will stay 2.667 and not become 2, lmao.
Made the same calculation use 0.5 seconds if the number is lower.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Nerfed Thieving - No instant theft. You'll always need at least half a second to steal something.
- fix: Fixed a rounding error in thieving attempts sometimes causing whole seconds to be shaved off.