### PR TITLE
Remove Nearsighted Requirement From Prescription Medhud

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Medical/uncategorized.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/uncategorized.yml
@@ -208,9 +208,9 @@
     - !type:CharacterDepartmentRequirement
       departments:
         - Medical
-    - !type:CharacterTraitRequirement
-      traits:
-        - Nearsighted
+#    - !type:CharacterTraitRequirement
+#      traits:
+#        - Nearsighted
   items:
     - ClothingEyesPrescriptionMedHud
 

--- a/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/corpsman.yml
@@ -152,9 +152,9 @@
     - !type:CharacterJobRequirement
       jobs:
         - Brigmedic
-    - !type:CharacterTraitRequirement
-      traits:
-        - Nearsighted
+#    - !type:CharacterTraitRequirement
+#      traits:
+#        - Nearsighted
   items:
     - ClothingEyesPrescriptionMedHud
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Removed the need to have the "nearsighted" trait to take prescription medhuds

## Why / Balance
I personally roleplay a far-sighted character, so it wouldnt make sense to take that trait with them. Plus im traitmaxxed.

## Technical details
Commented out a few lines

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Swiss_Fox
- tweak: Prescription medhuds no longer require you to have "nearsighted" to take them.
