### PR TITLE
Fix Standing up when Exiting Critical State

### DIFF
--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 using Content.Shared.Bed.Sleep;
+using Content.Shared.Buckle;
 using Content.Shared.Buckle.Components;
 using Content.Shared.CCVar;
 using Content.Shared.CombatMode.Pacification;
@@ -126,19 +127,11 @@ public partial class MobStateSystem
                 //unused
                 break;
             case MobState.Critical:
-                if (component.CurrentState is not MobState.Alive)
-                    break;
-                _standing.Stand(target);
                 break;
             case MobState.SoftCritical:
-                if (component.CurrentState is not MobState.Alive)
-                    break;
-                _standing.Stand(target);
                 break;
             case MobState.Dead:
                 RemComp<CollisionWakeComponent>(target);
-                if (component.CurrentState is MobState.Alive)
-                    _standing.Stand(target);
 
                 if (!_standing.IsDown(target) && TryComp<PhysicsComponent>(target, out var physics))
                     _physics.SetCanCollide(target, true, body: physics);

--- a/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
+++ b/Content.Shared/Mobs/Systems/MobStateSystem.Subscribers.cs
@@ -156,7 +156,9 @@ public partial class MobStateSystem
         switch (state)
         {
             case MobState.Alive:
-                _standing.Stand(target);
+                if (!TryComp(target, out BuckleComponent? buckle)
+                    || !buckle.Buckled)
+                    _standing.Stand(target);
                 _appearance.SetData(target, MobStateVisuals.State, MobState.Alive);
                 break;
             case MobState.Critical:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Made buckled Entities not stand up when recovering from critical state.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Just generally annoying having to buckle your patient again - Or have them unbuckle from your rollerbed as you ferry them.
## Technical details
<!-- Summary of code changes for easier review. -->
Removed redunancies and inserted a check for being buckled before calling the method to stand up when entering the Alive state.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="104" height="148" alt="grafik" src="https://github.com/user-attachments/assets/c26009f1-e46e-46ae-bd2e-f89f7431dc07" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed buckled patients standing up when recovering from crit. Now they'll stay seated.