### PR TITLE
Small Trait Max Width Increase

### DIFF
--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -386,7 +386,7 @@
     - !type:CharacterHeightRequirement
       max: 150
     - !type:CharacterWidthRequirement
-      max: 32
+      max: 36
   functions:
     - !type:TraitAddComponent
       components:
@@ -414,7 +414,7 @@
     - !type:CharacterHeightRequirement
       max: 160 # Looser requirement because thaven minHeight is 5'3" (160cm) but it's a fun trait
     - !type:CharacterWidthRequirement
-      max: 36 # Looser requirement so thaven don't have to be crackhead skinny to take it, they're already narrow
+      max: 36
   functions:
     - !type:TraitAddComponent
       components:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Increased the Small trait to let you be up to 36 cm wide.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Shortstack justice.
## Technical details
<!-- Summary of code changes for easier review. -->
One line change.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Shaman
- tweak: Increased the max width of the Small trait to 36 cm