### PR TITLE
Hardsuit Helmets Are Breath Masks

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -164,6 +164,7 @@
   components:
   - type: Item
     size: Normal
+  - type: BreathMask # TheDen
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
@@ -197,6 +198,7 @@
   components:
   - type: Item
     size: Normal
+  - type: BreathMask # TheDen
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
@@ -238,6 +240,7 @@
     unequipSound: /Audio/Mecha/mechmove03.ogg
     quickEquip: false
     slots: [ HEAD ]
+  - type: BreathMask # TheDen
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -533,6 +533,7 @@
   name: red wizard hat
   description: Strange-looking red hat-wear that most certainly belongs to a real magic user.
   components:
+  - type: BreathMask # TheDen - All pressure-resistant headwear should have built-in internals. A wizard did it
   - type: Sprite
     sprite: Clothing/Head/Hats/redwizard.rsi
   - type: Clothing

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -533,7 +533,6 @@
   name: red wizard hat
   description: Strange-looking red hat-wear that most certainly belongs to a real magic user.
   components:
-  - type: BreathMask # TheDen - All pressure-resistant headwear should have built-in internals. A wizard did it
   - type: Sprite
     sprite: Clothing/Head/Hats/redwizard.rsi
   - type: Clothing
@@ -541,6 +540,7 @@
   - type: PressureProtection # DeltaV - Make real wizard clothes space proof
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
+  - type: BreathMask # TheDen - All pressure-resistant headwear should have built-in internals
   - type: TemperatureProtection
     heatingCoefficient: 0.2
     coolingCoefficient: 0.2
@@ -665,6 +665,7 @@
   - type: PressureProtection # DeltaV - Make real wizard clothes space proof
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
+  - type: BreathMask # TheDen - All pressure-resistant headwear should have built-in internals
   - type: TemperatureProtection
     heatingCoefficient: 0.2
     coolingCoefficient: 0.2
@@ -737,6 +738,7 @@
   - type: PressureProtection # DeltaV - Make real wizard clothes space proof
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
+  - type: BreathMask # TheDen - All pressure-resistant headwear should have built-in internals
   - type: TemperatureProtection
     heatingCoefficient: 0.2
     coolingCoefficient: 0.2

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -300,6 +300,7 @@
   name: atmos fire helmet
   description: An atmos fire helmet, able to keep the user cool in any situation.
   components:
+  - type: BreathMask # TheDen - All pressure-resistant helmets should have built-in internals
   - type: Sprite
     sprite: _DEN/Clothing/Head/Helmets/atmos_firehelmet.rsi #Den
   - type: Clothing

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -300,7 +300,6 @@
   name: atmos fire helmet
   description: An atmos fire helmet, able to keep the user cool in any situation.
   components:
-  - type: BreathMask # TheDen - All pressure-resistant helmets should have built-in internals
   - type: Sprite
     sprite: _DEN/Clothing/Head/Helmets/atmos_firehelmet.rsi #Den
   - type: Clothing
@@ -311,6 +310,7 @@
   - type: PressureProtection
     highPressureMultiplier: 0.25
     lowPressureMultiplier: 1000
+  - type: BreathMask # TheDen - All pressure-resistant headwear should have built-in internals
 
 #Chitinous Helmet
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -238,7 +238,6 @@
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
-  - type: BreathMask # TheDen - All pressure-resistant headwear should have built-in internals
   - type: TemperatureProtection
     heatingCoefficient: 0.2
     coolingCoefficient: 0.2

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -238,6 +238,7 @@
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
+  - type: BreathMask # TheDen - All pressure-resistant headwear should have built-in internals
   - type: TemperatureProtection
     heatingCoefficient: 0.2
     coolingCoefficient: 0.2

--- a/Resources/Prototypes/Maps/lighthouse.yml
+++ b/Resources/Prototypes/Maps/lighthouse.yml
@@ -15,7 +15,7 @@
 # SPDX-FileCopyrightText: 2025 VMSolidus
 # SPDX-FileCopyrightText: 2025 sleepyyapril
 #
-# SPDX-License-Identifier: MIT AND AGPL-3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 - type: gameMap
   id: Lighthouse

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/modsuit.yml
@@ -10,6 +10,7 @@
   name: base modsuit helmet
   categories: [ HideSpawnMenu ]
   components:
+  - type: BreathMask # TheDen
   - type: Sprite
     state: icon
   - type: Clickable


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Gave three base helmets with PressureProtection the BreathMask component.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
WHAT DO YOU MEAN my spacefaring civilization made a space helmet that doesn't have breathing tubes in it, so that you have to wear a breath mask under it to breathe in space.
## Technical details
<!-- Summary of code changes for easier review. -->
Made `BaseClothingModsuitHelmet`, `ClothingHeadHardsuitBase`, `ClothingHeadEVAHelmetBase`, and `ClothingHeadEVAHelmetNoIngestionBlocker` have `- type: BreathMask`.

Also did a quick skim of items with `PressureProtection` and gave internals to helmets that had it, including the atmos fire helmet and the _real_ wizard hats (yes really, they're spaceproof).
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Tried to do this last night playing sec.  Didn't work.  I didn't even have a breath mask.  Now it works.

https://github.com/user-attachments/assets/20b60541-63eb-42c5-98af-ae99b3ac6f83


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Shaman
- tweak: Spaceproof helmets now have built-in internals (hardsuits, EVA helmets, atmos fire gear, etc)