### PR TITLE
[TWEAK]: Minor Dragon Buffs

### DIFF
--- a/Content.Server/Dragon/Components/DragonComponent.cs
+++ b/Content.Server/Dragon/Components/DragonComponent.cs
@@ -53,7 +53,7 @@ namespace Content.Server.Dragon
         /// <summary>
         /// Maximum time the dragon can go without spawning a rift before they die.
         /// </summary>
-        [ViewVariables(VVAccess.ReadWrite), DataField("maxAccumulator")] public float RiftMaxAccumulator = 420f;
+        [ViewVariables(VVAccess.ReadWrite), DataField("maxAccumulator")] public float RiftMaxAccumulator = 300f;
 
         [DataField("spawnRiftAction", customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
         public string SpawnRiftAction = "ActionSpawnRift";

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -146,7 +146,7 @@
       enum.SurgeryUIKey.Key:
         type: SurgeryBui
   - type: Bloodstream
-    maxBleedAmount: 450
+    maxBleedAmount: 100
     bloodMaxVolume: 650
     bloodReagent: ShimmeringBlood # Imp - Gives dragon drug blood.
   - type: GhostRole
@@ -377,7 +377,7 @@
   description: For dragon's breathing.
   components:
   - type: RechargeBasicEntityAmmo
-    rechargeCooldown: 15
+    rechargeCooldown: 7
     rechargeSound:
       path: /Audio/Animals/space_dragon_roar.ogg
   - type: BasicEntityAmmoProvider
@@ -470,7 +470,7 @@
       sprite: _Goobstation/Actions/dragon.rsi
       state: carp_horde
     event: !type:DragonSpawnCarpHordeActionEvent
-    useDelay: 90
+    useDelay: 60
     priority: 4
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -146,7 +146,7 @@
       enum.SurgeryUIKey.Key:
         type: SurgeryBui
   - type: Bloodstream
-    maxBleedAmount: 100
+    maxBleedAmount: 150
     bloodMaxVolume: 650
     bloodReagent: ShimmeringBlood # Imp - Gives dragon drug blood.
   - type: GhostRole


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Swung a little too far in the other direction with dragon nerfs. This should be a decent compromise, might be a touch too strong but we shall see!

Carp Rifts: Take 5 minutes to fully form again (7 => 5)
Dragon: Bleeding max damage reduced 450 => 150 
Dragon Lungs: Fireball cooldown reduced 15 => 7 seconds
Summon Carp Horde: Cooldown reduced 90 => 60 seconds

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The bleeding damage and fireball cooldown are a rough combo, this should still let them lose to attrition fights but not be totally unable to push either.

Rifts taking longer to form was part of tying them to their rifts. Since we scrapped that, this isn't needed either.
Fireball did need a cooldown increase but 5 => 15 seconds is rough. 7 is probably what it should've been.
We reduced the number of carps spawned from summon horde from 3 => 2. Shaving 30 seconds off is reasonable as a result.


## Technical details
<!-- Summary of code changes for easier review. -->
.yml tweaks

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Jakumba
- tweak: Carp Rifts: Take 5 minutes to fully form again (7 => 5)
- tweak: Dragon: Bleeding max damage reduced 450 => 150 (500 max hp)
- tweak:  Dragon Lungs: Fireball cooldown reduced 15 => 7 seconds
- tweak: Summon Carp Horde: Cooldown reduced 90 => 60 seconds


