### PR TITLE
Entity Spawn Menu Cleanup

### DIFF
--- a/Content.IntegrationTests/Tests/_DEN/Entities/EntitySpawnMenuTest.cs
+++ b/Content.IntegrationTests/Tests/_DEN/Entities/EntitySpawnMenuTest.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.Client.Clickable;
+using Content.Client.Markers;
+using Content.Server.Explosion.Components;
+using Content.Server.Humanoid.Components;
+using Content.Server.Spawners.Components;
+using Content.Shared.Prototypes;
+using Content.Shared.Wall;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Spawners;
+
+namespace Content.IntegrationTests.Tests._DEN.Entities;
+
+/// <summary>
+///     Tests if all entities (that are not hidden from the spawn menu) are things that reasonably should be allowed to
+///     be spawned in from the menu.
+/// </summary>
+[TestFixture]
+[TestOf(typeof(EntityPrototype))]
+public sealed class EntitySpawnMenuTest
+{
+    private readonly HashSet<Type> _allowedServerComponents = new()
+    {
+        typeof(PhysicsComponent),
+        typeof(RandomHumanoidSpawnerComponent),
+        typeof(TriggerOnSpawnComponent),
+        typeof(EntityTableSpawnerComponent),
+        typeof(RandomSpawnerComponent),
+        typeof(TimedDespawnComponent),
+        typeof(SpawnOnDespawnComponent),
+        typeof(WallMountComponent),
+    };
+
+    private readonly HashSet<Type> _allowedClientComponents = new()
+    {
+        typeof(MarkerComponent),
+        typeof(ClickableComponent),
+    };
+
+    private readonly HashSet<string> _ignoredPrototypes = ["PointingArrow", "Audio"];
+
+    [Test]
+    public async Task AllNonWorldEntitiesHidden()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var client = pair.Client;
+        var serverCompFac = server.ResolveDependency<IComponentFactory>();
+        var clientCompFac = client.ResolveDependency<IComponentFactory>();
+        var failingPrototypes = new List<string>();
+
+        foreach (var p in server.ProtoMan.EnumeratePrototypes<EntityPrototype>()
+                    .Where(p => !(p.Abstract
+                        || pair.IsTestPrototype(p)
+                        || p.HideSpawnMenu
+                        || p.Categories.Any(c => c.ID == "Debug")
+                        || _ignoredPrototypes.Contains(p.ID))))
+        {
+            // presumably anything that has a defined "placement mode" is supposed to be placeable
+            if (p.PlacementMode != "PlaceFree"
+                || _allowedServerComponents.Any(allowedType => p.HasComponent(allowedType, serverCompFac))
+                || _allowedClientComponents.Any(allowedType => p.HasComponent(allowedType, clientCompFac)))
+                continue;
+
+            failingPrototypes.Add(p.ID);
+        }
+
+        Assert.That(failingPrototypes,
+            Is.Empty,
+            "The following prototypes lack common 'world entity' components - do they need [HideSpawnMenu] or [Debug]?"
+            + "\n  " + string.Join("\n  ", failingPrototypes));
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Resources/Prototypes/Entities/Debugging/clicktest.yml
+++ b/Resources/Prototypes/Entities/Debugging/clicktest.yml
@@ -14,7 +14,7 @@
 # These dots' texture detection should not interfere with the actual bounding box being tested.
 
 - type: entity
-  categories: [ HideSpawnMenu ]
+  categories: [ HideSpawnMenu, Debug ]
   id: ClickTestBase
   suffix: DEBUG
   components:

--- a/Resources/Prototypes/Entities/Debugging/options_visualizer.yml
+++ b/Resources/Prototypes/Entities/Debugging/options_visualizer.yml
@@ -6,6 +6,7 @@
 - type: entity
   id: OptionsVisualizerTest
   suffix: DEBUG
+  categories: [ Debug ]
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Debugging/stress_test.yml
+++ b/Resources/Prototypes/Entities/Debugging/stress_test.yml
@@ -8,6 +8,7 @@
   id: StressTest
   name: stress test
   suffix: DEBUG
+  categories: [ Debug ]
   components:
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/dwarf.yml
@@ -117,6 +117,7 @@
 - type: entity
   parent: BaseSpeciesDummy
   id: MobDwarfDummy
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     scale: 1, 0.8

--- a/Resources/Prototypes/Entities/Mobs/Species/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/human.yml
@@ -138,6 +138,7 @@
 - type: entity
   parent: BaseSpeciesDummy
   id: MobHumanDummy
+  categories: [ HideSpawnMenu ]
   components:
   - type: Inventory
     femaleDisplacements:

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -168,6 +168,7 @@
 - type: entity
   parent: [BaseVoxAppearance, BaseSpeciesDummy]
   id: MobVoxDummy
+  categories: [ HideSpawnMenu ]
   components:
   - type: HumanoidAppearance
     species: Vox

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -704,6 +704,7 @@
 - type: entity
   id: SnakeSpawn
   parent: BaseVentCritterSpawn
+  categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
     startAnnouncement: true

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -112,6 +112,7 @@
 - type: entity
   parent: BaseNukeopsRule
   id: Nukeops
+  categories: [ HideSpawnMenu ]
   components:
   - type: GameRule
     minPlayers: 15

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -50,7 +50,7 @@
 - type: entity
   id: XenoVentsWeak
   parent: XenoVents
-  # categories: [ HideSpawnMenu ]
+  categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
     startAnnouncement: true

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -9,6 +9,7 @@
   name: organic space helmet
   description: A spaceworthy biomass of pressure and temperature resistant tissue.
   suffix: Unremoveable
+  categories: [ HideSpawnMenu ]
   components:
   - type: Item
   - type: Sprite

--- a/Resources/Prototypes/_Goobstation/Entities/Debugging/nukiestealth.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Debugging/nukiestealth.yml
@@ -53,6 +53,7 @@
   suffix: DEBUG, DO NOT MAP, stealth
   name: syndicate stealth hardsuit helmet
   description: A helmet with plating for stealth operations.
+  categories: [ Debug ]
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/syndicate.rsi

--- a/Resources/Prototypes/_Impstation/GameRules/replicator_event.yml
+++ b/Resources/Prototypes/_Impstation/GameRules/replicator_event.yml
@@ -9,6 +9,7 @@
 - type: entity
   id: ReplicatorSpawn
   parent: BaseGameRule
+  categories: [ HideSpawnMenu ]
   components:
   - type: StationEvent
     earliestStart: 120


### PR DESCRIPTION
## About the PR
added a new test that checks for entities that exist in the spawn menu and probably shouldn't

added HideSpawnMenu to entities that needed it

## Why / Balance
sometimes you get so bored you want to write a new integration test

## Technical details
the integration test just checks all spawnmenu entities that lack certain components that imply the entity should exist in the world. entities with physics, spawners, markers, among others. entities with the `Debug` category are excluded as they are assumed to need to be spawnable for one reason for another 

## Media
i dont wanna

## Requirements
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
if for some reason you need to spawn the Nukeops entity event in the fucking world instead of using `addgamerule`, uhhhh

**Changelog**
- remove: Admins have less things to spawn now. (They weren't important)