### PR TITLE
Stop Robotic Arms From Flickering Lights

### DIFF
--- a/Content.Shared/_Goobstation/Factory/RoboticArmComponent.cs
+++ b/Content.Shared/_Goobstation/Factory/RoboticArmComponent.cs
@@ -145,6 +145,8 @@ public sealed partial class RoboticArmComponent : Component
 
     #region Power
 
+    // IMP / DEN - the below power draws are not presently in use, robotic arms have a static 300 power draw
+
     /// <summary>
     /// Power used when idle.
     /// </summary>

--- a/Content.Shared/_Goobstation/Factory/RoboticArmSystem.cs
+++ b/Content.Shared/_Goobstation/Factory/RoboticArmSystem.cs
@@ -407,23 +407,14 @@ public sealed class RoboticArmSystem : EntitySystem
 
     private void StartMoving(Entity<RoboticArmComponent> ent)
     {
-        SetPowerDraw(ent, ent.Comp.MovingPowerDraw);
         ent.Comp.NextMove = _timing.CurTime + ent.Comp.MoveDelay;
         DirtyField(ent, ent.Comp, nameof(RoboticArmComponent.NextMove));
     }
 
     private void StopMoving(Entity<RoboticArmComponent> ent)
     {
-        SetPowerDraw(ent, ent.Comp.IdlePowerDraw);
         ent.Comp.NextMove = null;
         DirtyField(ent, ent.Comp, nameof(RoboticArmComponent.NextMove));
-    }
-
-    private void SetPowerDraw(EntityUid uid, float draw)
-    {
-        SharedApcPowerReceiverComponent? receiver = null;
-        if (_power.ResolveApc(uid, ref receiver))
-            _power.SetLoad(receiver, draw);
     }
 
     public EntityCoordinates OutputPosition(EntityUid uid)

--- a/Content.Shared/_Goobstation/Factory/RoboticArmSystem.cs
+++ b/Content.Shared/_Goobstation/Factory/RoboticArmSystem.cs
@@ -405,6 +405,7 @@ public sealed class RoboticArmSystem : EntitySystem
             _turf.IsTileBlocked(turf, CollisionGroup.MachineMask);
     }
 
+    // DEN / IMP ported from Darkmajia's Impstation PR #2526 - removal of SetPowerDraw's usage and definition
     private void StartMoving(Entity<RoboticArmComponent> ent)
     {
         ent.Comp.NextMove = _timing.CurTime + ent.Comp.MoveDelay;

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/robotic_arm.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/robotic_arm.yml
@@ -114,7 +114,7 @@
     range: 5
   # Power
   - type: ApcPowerReceiver
-    powerLoad: 50 # Idle power usage, increases when active
+    powerLoad: 300 # Den / IMP, static 300 power draw instead of idle 50 / active 3000
   - type: PowerSwitch
   # Guide
   - type: GuideHelp

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/robotic_arm.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/robotic_arm.yml
@@ -114,7 +114,7 @@
     range: 5
   # Power
   - type: ApcPowerReceiver
-    powerLoad: 300 # Den / IMP, static 300 power draw instead of idle 50 / active 3000
+    powerLoad: 300 # Den / IMP, static 300 power draw instead of idle 50 / active 3000. via Darkmajia's Impstation PR #2526
   - type: PowerSwitch
   # Guide
   - type: GuideHelp

--- a/Resources/Prototypes/_Goobstation/Recipes/Crafting/filters.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Crafting/filters.yml
@@ -63,7 +63,7 @@
   id: AutomationFilterCombined
   graph: AutomationFilter
   startNode: start
-  targetNode: label
+  targetNode: combined
   category: construction-category-misc
   description: A filter that can be installed in a robotic arm. This one uses a logic gate to combine 2 installed item filters.
   icon:

--- a/Resources/Prototypes/_Goobstation/Recipes/Crafting/filters.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Crafting/filters.yml
@@ -63,7 +63,7 @@
   id: AutomationFilterCombined
   graph: AutomationFilter
   startNode: start
-  targetNode: combined
+  targetNode: combined # DEN
   category: construction-category-misc
   description: A filter that can be installed in a robotic arm. This one uses a logic gate to combine 2 installed item filters.
   icon:


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
based on this PR from imp: https://github.com/impstation/imp-station-14/pull/2526
updates robotic arms to not change their power draw anymore, now just costing 300 passively.
formerly, they had a baseline of 50 and would jump up to 3000 power for a split second every time they moved one thing, spiking any APC they were attached to.

also fixes a broken automation filter recipe that was making a "label filter" instead of a "combined filter"

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1) doesn't really make sense for this thing to spike power, there's no balance justification for it
2) the 3000 jump caused a really unpleasant light flickering, which formerly demanded that every setup use its own APC lest passersby be forced to endure the flickering lights

## Technical details
<!-- Summary of code changes for easier review. -->
changed some numbers, got rid of some function calls, and removed a function that'd be otherwise unused.
also changed one crafting reference

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Content Client_7xP97Luuk4](https://github.com/user-attachments/assets/0385b191-9f69-4910-8e95-21507d6f2403)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Robotic Arm machines no longer cause the lights to flicker by drawing so much power!
- fix: The craft menu Combined Filter recipe now works!
