### PR TITLE
Removing Involuntary Gasping

### DIFF
--- a/Content.Server/Body/Components/RespiratorComponent.cs
+++ b/Content.Server/Body/Components/RespiratorComponent.cs
@@ -23,9 +23,7 @@
 // SPDX-License-Identifier: MIT AND AGPL-3.0-or-later
 
 using Content.Server.Body.Systems;
-using Content.Shared.Chat.Prototypes;
 using Content.Shared.Damage;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.Body.Components
@@ -76,16 +74,10 @@ namespace Content.Server.Body.Components
         public DamageSpecifier DamageRecovery = default!;
 
         [DataField]
-        public TimeSpan GaspEmoteCooldown = TimeSpan.FromSeconds(8);
+        public TimeSpan GaspPopupCooldown = TimeSpan.FromSeconds(8);
 
         [ViewVariables]
-        public TimeSpan LastGaspEmoteTime;
-
-        /// <summary>
-        ///     The emote when gasps
-        /// </summary>
-        [DataField]
-        public ProtoId<EmotePrototype> GaspEmote = "Gasp";
+        public TimeSpan LastGaspPopupTime;
 
         /// <summary>
         ///     How many cycles in a row has the mob been under-saturated?

--- a/Content.Server/Body/Systems/RespiratorSystem.cs
+++ b/Content.Server/Body/Systems/RespiratorSystem.cs
@@ -32,6 +32,7 @@ using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Server.EntityEffects.EffectConditions;
 using Content.Server.EntityEffects.Effects;
 using Content.Shared._Goobstation.MartialArts.Components; // Goobstation - Martial Arts
+using Content.Server.Popups;
 using Content.Shared._DEN.Bed.Components;
 using Content.Shared._Shitmed.Body.Components;
 using Content.Shared.Alert;
@@ -64,6 +65,7 @@ public sealed class RespiratorSystem : EntitySystem
     [Dependency] private readonly BodySystem _bodySystem = default!;
     [Dependency] private readonly DamageableSystem _damageableSys = default!;
     [Dependency] private readonly LungSystem _lungSystem = default!;
+    [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
@@ -141,10 +143,10 @@ public sealed class RespiratorSystem : EntitySystem
 
             if (!CanBreathe(uid, respirator)) // Goobstation edit
             {
-                if (_gameTiming.CurTime >= respirator.LastGaspEmoteTime + respirator.GaspEmoteCooldown)
+                if (_gameTiming.CurTime >= respirator.LastGaspPopupTime + respirator.GaspPopupCooldown)
                 {
-                    respirator.LastGaspEmoteTime = _gameTiming.CurTime;
-                    _chat.TryEmoteWithChat(uid, respirator.GaspEmote, ignoreActionBlocker: true);
+                    respirator.LastGaspPopupTime = _gameTiming.CurTime;
+                    _popupSystem.PopupEntity(Loc.GetString("lung-behavior-gasp"), uid);
                 }
 
                 if (TryComp<StabilizeOnBuckleComponent>(uid, out var stabilizedComp) // Den - Stabilizing Rollerbeds


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Rolled back the involuntary gasping action any time someone sustains asphyxiation damage (spacing, bad atmos, crit) from its emote counterpart to the popup text. This changes nothing else regarding the emote in question.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- Harpies.
- It's a sound that you'll otherwise have to hear a lot. It diminishes the actual use of the emote as a deliberate gesture in an RP situation.
- It would generally be better for everyone behind or beyond bolted doors not to have to listen to repeated gasping from any party. 
- Think of the harpies.
- Though the crit gasping is good situational awareness for emergency response, you can already speak in critical condition.
- This doesn't remove clear tells of someone in critical condition or suffering asphyxiation. The popup text is still visible for all players within sight.
- I'm doing this for the harpies.
## Technical details
<!-- Summary of code changes for easier review. -->
Rolling back RespiratorComponent.cs and RespiratorSystem.cs changes in  #1684 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

Anything using GaspPopupCooldown can be changed to GaspEmoteCooldown, LastGaspPopupTime to LastGaspEmoteTime.
Anything using PopupSystem or Content.Server.Popups in the RespiratorSystem.cs file.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: You are in full control of your gasping (no involuntary gasp emoting on crit/asphyx)
