### PR TITLE
Kinetic Claw and Machete Fixes

### DIFF
--- a/Content.Shared/_Lavaland/Weapons/Block/SharedBlockChargeSystem.cs
+++ b/Content.Shared/_Lavaland/Weapons/Block/SharedBlockChargeSystem.cs
@@ -52,8 +52,8 @@ public abstract partial class SharedBlockChargeSystem : EntitySystem
     {
         if (!TryComp<BlockChargeComponent>(component.BlockingWeapon, out var blockComp)
             || !HasComp<FaunaComponent>(args.Origin)
-            || !blockComp.HasCharge
-            || !args.CanEvade)
+            || !blockComp.HasCharge)
+            // || !args.CanEvade) | Den Change: Fix kinetic Machete
             return;
 
         _popup.PopupPredicted(Loc.GetString("block-attack-notice", ("user", uid), ("blocked", args.Origin)), uid, null);

--- a/Content.Shared/_Lavaland/Weapons/Block/SharedBlockChargeSystem.cs
+++ b/Content.Shared/_Lavaland/Weapons/Block/SharedBlockChargeSystem.cs
@@ -52,8 +52,8 @@ public abstract partial class SharedBlockChargeSystem : EntitySystem
     {
         if (!TryComp<BlockChargeComponent>(component.BlockingWeapon, out var blockComp)
             || !HasComp<FaunaComponent>(args.Origin)
-            || !blockComp.HasCharge
-            || !args.CanEvade)
+            || !blockComp.HasCharge)
+            // || !args.CanEvade) Den Change: Kinetic Machete fix
             return;
 
         _popup.PopupPredicted(Loc.GetString("block-attack-notice", ("user", uid), ("blocked", args.Origin)), uid, null);

--- a/Content.Shared/_Lavaland/Weapons/Block/SharedBlockChargeSystem.cs
+++ b/Content.Shared/_Lavaland/Weapons/Block/SharedBlockChargeSystem.cs
@@ -52,8 +52,8 @@ public abstract partial class SharedBlockChargeSystem : EntitySystem
     {
         if (!TryComp<BlockChargeComponent>(component.BlockingWeapon, out var blockComp)
             || !HasComp<FaunaComponent>(args.Origin)
-            || !blockComp.HasCharge)
-            // || !args.CanEvade) Den Change: Kinetic Machete fix
+            || !blockComp.HasCharge
+            || !args.CanEvade)
             return;
 
         _popup.PopupPredicted(Loc.GetString("block-attack-notice", ("user", uid), ("blocked", args.Origin)), uid, null);

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
@@ -153,7 +153,7 @@
 - type: entity
   parent: [LavalandWeaponKineticBase, ClothingHandsBase]
   id: LavalandWeaponKineticClaws
-  name: kinetic claws
+  name: kinetic claw # Den Change: Kinetic Claws to Kinetic Claw
   description: Unleash your inner edgelord with this one-handed claw small enough to fit in your backpack. Deals a lot more damage when backstabbing marked targets.
   components:
   - type: Sprite
@@ -177,7 +177,7 @@
     angle: 0
     animation: WeaponArcThrust
     range: 1.6
-    mustBeEquippedToUse: true
+    # mustBeEquippedToUse: true | Den Change: Fix kinetic claw
   - type: Item
     size: Normal
     sprite: _Lavaland/Objects/Weapons/Crushers/crusher_claws-inhands.rsi

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
@@ -153,7 +153,7 @@
 - type: entity
   parent: [LavalandWeaponKineticBase, ClothingHandsBase]
   id: LavalandWeaponKineticClaws
-  name: kinetic claws
+  name: kinetic claw # Den Change: Kinetic Claws to Kinetic Claw
   description: Unleash your inner edgelord with this one-handed claw small enough to fit in your backpack. Deals a lot more damage when backstabbing marked targets.
   components:
   - type: Sprite
@@ -177,7 +177,7 @@
     angle: 0
     animation: WeaponArcThrust
     range: 1.6
-    mustBeEquippedToUse: true
+    # mustBeEquippedToUse: true | Den Change: Kinetic Claw fix
   - type: Item
     size: Normal
     sprite: _Lavaland/Objects/Weapons/Crushers/crusher_claws-inhands.rsi

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/crushers.yml
@@ -153,7 +153,7 @@
 - type: entity
   parent: [LavalandWeaponKineticBase, ClothingHandsBase]
   id: LavalandWeaponKineticClaws
-  name: kinetic claw # Den Change: Kinetic Claws to Kinetic Claw
+  name: kinetic claws
   description: Unleash your inner edgelord with this one-handed claw small enough to fit in your backpack. Deals a lot more damage when backstabbing marked targets.
   components:
   - type: Sprite
@@ -177,7 +177,7 @@
     angle: 0
     animation: WeaponArcThrust
     range: 1.6
-    # mustBeEquippedToUse: true | Den Change: Kinetic Claw fix
+    mustBeEquippedToUse: true
   - type: Item
     size: Normal
     sprite: _Lavaland/Objects/Weapons/Crushers/crusher_claws-inhands.rsi


### PR DESCRIPTION
## About the PR
Some really minor code changes to make it so the Kinetic Claw can be used without it being equipped to the glove slot  and a change to a check in the block charge system which I found to be preventing the block function on the kinetic machete from working.

## Technical details
From what I can tell the CanEvade argument isn't changed from its default any where so it's always false, even for simple attacks from fauna which is why I decided to comment out the check (also because the check includes a check for the fauna component so it will only block stuff it is intended to fight and not like bullets).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**
:cl: oberonics
- fix: You can now attack with the Kinetic Claw.
- fix: The Kinetic Machete's block function now works.

