### PR TITLE
Revert and fix translator drain

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translators.yml
@@ -53,7 +53,7 @@
   components:
   - type: ItemToggle
   - type: PowerCellDraw
-    drawRate: 1.2
+    drawRate: 0.6
   - type: ToggleCellDraw
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/translators.yml
@@ -53,7 +53,7 @@
   components:
   - type: ItemToggle
   - type: PowerCellDraw
-    drawRate: 0 # The Den: make it not 0 when the issues with them are fixed
+    drawRate: 1.2
   - type: ToggleCellDraw
   - type: ItemSlots
     slots:


### PR DESCRIPTION
The drain was removed in #1494 due to a concern with high-capacity cells being removed in #1493, though there they halved the usage in flashlights by half so the same is done here to translators.

**Changelog**
:cl:
- tweak: Returned translator drain
- tweak: Translators use half the wattage they used to
