### PR TITLE
Magistrate Loadout and Locker Additions

### DIFF
--- a/Resources/Locale/en-US/loadouts/itemgroups.ftl
+++ b/Resources/Locale/en-US/loadouts/itemgroups.ftl
@@ -151,6 +151,7 @@ character-item-group-LoadoutMagistrateMask = Magistrate Masks
 character-item-group-LoadoutMagistrateOuter = Magistrate Outerwear
 character-item-group-LoadoutMagistrateShoes = Magistrate Shoes
 character-item-group-LoadoutMagistrateUniforms = Magistrate Uniforms
+character-item-group-LoadoutMagistrateWeapon = Magistrate Weapon
 
 # Dignitary - Nanotrasen Representative
 character-item-group-LoadoutNanorepBackpacks = Nanotrasen Representative Backpacks

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Command/magistrate.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Command/magistrate.yml
@@ -4,6 +4,22 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 - type: characterItemGroup
+  id: LoadoutMagistrateWeapon
+  maxItems: 1
+  items:
+  - type: loadout
+    id: LoadoutMagistrateDisabler
+
+- type: characterItemGroup
+  id: LoadoutMagistrateGloves
+  maxItems: 1
+  items:
+  - type: loadout
+    id: LoadoutMagistrateGlovesHoP
+  - type: loadout
+    id: LoadoutMagistrateGlovesInspection
+
+- type: characterItemGroup
   id: LoadoutMagistrateHead
   maxItems: 1
   items:

--- a/Resources/Prototypes/Loadouts/Jobs/Command/magistrate.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/magistrate.yml
@@ -17,6 +17,37 @@
 
 # Gloves
 
+- type: loadout
+  id: LoadoutMagistrateGlovesHoP
+  category: JobsCommandMagistrate
+  cost: 0
+  exclusive: true
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutMagistrateGloves
+  - !type:CharacterJobRequirement
+    jobs:
+    - Magistrate
+    - ChiefJustice
+  items:
+  - ClothingHandsGlovesHop
+
+- type: loadout
+  id: LoadoutMagistrateGlovesInspection
+  category: JobsCommandMagistrate
+  cost: 0
+  exclusive: true
+  customColorTint: true
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutMagistrateGloves
+  - !type:CharacterJobRequirement
+    jobs:
+    - Magistrate
+    - ChiefJustice
+  items:
+  - ClothingHandsGlovesInspection
+
 # Head
 - type: loadout
   id: LoadoutClothingHeadChiefJustice

--- a/Resources/Prototypes/Loadouts/Jobs/Command/magistrate.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/magistrate.yml
@@ -17,37 +17,6 @@
 
 # Gloves
 
-- type: loadout
-  id: LoadoutMagistrateGlovesHoP
-  category: JobsCommandMagistrate
-  cost: 0
-  exclusive: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutMagistrateGloves
-  - !type:CharacterJobRequirement
-    jobs:
-    - Magistrate
-    - ChiefJustice
-  items:
-  - ClothingHandsGlovesHop
-
-- type: loadout
-  id: LoadoutMagistrateGlovesInspection
-  category: JobsCommandMagistrate
-  cost: 0
-  exclusive: true
-  customColorTint: true
-  requirements:
-  - !type:CharacterItemGroupRequirement
-    group: LoadoutMagistrateGloves
-  - !type:CharacterJobRequirement
-    jobs:
-    - Magistrate
-    - ChiefJustice
-  items:
-  - ClothingHandsGlovesInspection
-
 # Head
 - type: loadout
   id: LoadoutClothingHeadChiefJustice

--- a/Resources/Prototypes/_DEN/Loadouts/Jobs/Command/magistrate.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Jobs/Command/magistrate.yml
@@ -3,6 +3,55 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
+# Equipment
+
+- type: loadout
+  id: LoadoutMagistrateDisabler
+  category: JobsCommandMagistrate
+  cost: 0
+  canBeHeirloom: true
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutMagistrateWeapon
+  - !type:CharacterJobRequirement
+    jobs:
+    - Magistrate
+  items:
+  - WeaponCCDisabler
+
+# Gloves
+- type: loadout
+  id: LoadoutMagistrateGlovesHoP
+  category: JobsCommandMagistrate
+  cost: 0
+  exclusive: true
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutMagistrateGloves
+  - !type:CharacterJobRequirement
+    jobs:
+    - Magistrate
+    - ChiefJustice
+  items:
+  - ClothingHandsGlovesHop
+
+- type: loadout
+  id: LoadoutMagistrateGlovesInspection
+  category: JobsCommandMagistrate
+  cost: 0
+  exclusive: true
+  customColorTint: true
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutMagistrateGloves
+  - !type:CharacterJobRequirement
+    jobs:
+    - Magistrate
+    - ChiefJustice
+  items:
+  - ClothingHandsGlovesInspection
+
+
 - type: loadout
   id: LoadoutTowelMaroonCJ
   category: JobsCommandMagistrate

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
@@ -70,4 +70,12 @@
     - id: WeaponDisabler
     - id: BriefcaseBrownFilled
     - id: RubberStampMagistrate
+    - id: RubberStampApproved
+    - id: RubberStampDenied
     - id: ClothingHeadHatPwig
+    - id: PrinterDocFlatpack
+    - id: RubberStampNotary
+    - id: SecurityWhistle
+    - id: Gavel
+    - id: GavelBlock
+    - id: WeaponCaseShortDocuments

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets.yml
@@ -13,12 +13,8 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - EncryptionKeyCommand
       - EncryptionKeyCentCom
-      - EncryptionKeyJustice
-      - EncryptionKeyPrison
-      - EncryptionKeySecurity
-      - EncryptionKeyCommon
+      - EncryptionKeyStationMaster
   - type: Sprite
     sprite: _DV/Clothing/Ears/Headsets/justice.rsi
     state: icon_alt

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Ears/headsets.yml
@@ -7,7 +7,7 @@
 - type: entity
   parent: ClothingHeadset
   id: ClothingHeadsetMagistrate
-  name: magistrate's headset
+  name: magistrate's over-ear headset
   description: The headset used by the magistrate.
   components:
   - type: ContainerFill
@@ -20,3 +20,4 @@
     state: icon_alt
   - type: Clothing
     sprite: _DV/Clothing/Ears/Headsets/justice.rsi
+  - type: FlashSoundSuppression

--- a/Resources/Prototypes/_NF/Entities/Objects/Storage/weapon_cases.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Storage/weapon_cases.yml
@@ -107,11 +107,13 @@
 
 - type: entity
   name: document case
-  parent: WeaponCaseShortExplosives
+  parent: [ WeaponCaseShortExplosives, ContentsExplosionResistanceBase, ContentsIgnitionPreventionBase ]
   id: WeaponCaseShortDocuments
   description: A reinforced casing for storing important documents.
   suffix: Short
   components:
+  - type: ExplosionResistance
+    damageCoefficient: 0
   - type: Sprite
     sprite: _NF/Objects/Storage/Cases/documentcaseshort.rsi
   - type: Item
@@ -119,11 +121,12 @@
   - type: Storage
     maxItemSize: Normal
     grid:
-    - 0,0,3,0 # fits a 4x1 blueprint
+    - 0,0,3,2 # fits a 4x3 blueprint
     whitelist:
       tags:
       - Document
       - Paper
+      - Folder
 
 - type: entity
   name: weapon case


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Changed Magistrate headset to have station master encryption key and have flashbang protection. Added stamps (Approved, Denied, Notary), gavel and block, security whistle, and reinforced document case to Magistrate locker. Added Papercut Proof Gloves, Inspection Gloves, and CentComm Disabler as Magistrate loadout options. Buffed the reinforced document case.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Headset: Changed to mirror other dignitaries having station master keys. Now magistrate can answer SOP questions about why the roboticist is doing surgery. Flashbang protection added since all other command and dignitary headsets have it.

Loadout: Gloves added because they had none. Just copied HoP/Admin Assistant's options. CentComm Disabler added since they already got a disabler in their locker. Seemed to make sense that a CC dignitary would have a CentComm disabler.

Locker: Approved/Denied stamps and document printer flatpack seemed obvious additions. I've had Magistrates from CC use the Notary stamp before, and it can be given to newly promoted clerks on stations without clerk lockers. Whistle seemed like a fun addition, and maybe one of the only roles that would actually use it. Gavel and gavel block added because many maps are missing one or both. Reinforced document case added because I love the clonky sound it makes, even if it's a bit impractical.

Reinforced document case: Increased storage capacity from 4 to 12 (It takes up 8 inventory spaces). Added the fireproof and explosionproof properties so that it actually protects its contents. Allowed folders to be placed inside it.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Kelaris

add: Added gloves and a CentComm disabler to Magistrate loadout options.
add: Added a few stamps, gavel, document printer, whistle, and reinforced document case to Magistrate's locker.
tweak: Tweaked the Magistrate headset to have more radio channels and provide flashbang protection.
tweak: Made the reinforced document case slightly larger, can hold folders, and now protects its contents better.