### PR TITLE
Changes AAC to Prevent Vowed Mimes From Sending Messages

### DIFF
--- a/Content.Server/_DV/AACTablet/AACTabletSystem.cs
+++ b/Content.Server/_DV/AACTablet/AACTabletSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.IdentityManagement;
 using Robust.Server.GameObjects; // starcup
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Content.Server.Popups; // den
 
 namespace Content.Server._DV.AACTablet;
 
@@ -28,8 +29,8 @@ public sealed partial class AACTabletSystem : EntitySystem // starcup: made part
     [Dependency] private readonly ChatSystem _chat = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
-    [Dependency] private readonly MimePowersSystem _mimePowers = default!;
     [Dependency] private readonly UserInterfaceSystem _userInterface = default!; // starcup
+    [Dependency] private readonly PopupSystem _popupSystem = default!; // den
 
     private readonly List<string> _localisedPhrases = [];
 
@@ -69,8 +70,13 @@ public sealed partial class AACTabletSystem : EntitySystem // starcup: made part
         if (_localisedPhrases.Count <= 0)
             return;
 
-        if (HasComp<MimePowersComponent>(message.Actor))
-            _mimePowers.BreakVow(message.Actor);
+        // begin den: mime needs to break their vow before using
+        if (TryComp<MimePowersComponent>(message.Actor, out var mimePowers) && !mimePowers.VowBroken)
+        {
+            _popupSystem.PopupEntity(Loc.GetString("mime-cant-speak"), message.Actor, message.Actor);
+            return;
+        }
+        // end den
 
         EnsureComp<VoiceOverrideComponent>(ent).NameOverride = speakerName;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
LICENSE: MIT
## About the PR
Changed the AAC to give the 'mime-cant-speak' popup instead of instantly breaking their vow.

## Why / Balance
Speaking and the scream action require the user to decide to break their vow rather than breaking it for them. If the AAC tablet is going to be restricted by the mime's vow of silence then it should follow the same rules.

## Technical details
Changed onSendPhrase to show 'mime-cant-speak' and return for mimes with active vows instead of breaking the vow and sending the message.

## Media
https://github.com/user-attachments/assets/b875203c-ca59-462b-8738-cd5d82fa789e

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: The AAC tablet will no longer break your vow of silence for you. You'll still have to do that in order to use it though!
