### PR TITLE
Set Integration Test Parallelism to 2

### DIFF
--- a/Content.IntegrationTests/AssemblyInfo.cs
+++ b/Content.IntegrationTests/AssemblyInfo.cs
@@ -10,4 +10,4 @@
 // https://github.com/dotnet/runtime/issues/107197
 // So we can't really parallelize integration tests harder either until the runtime fixes that,
 // *or* we fix serv3 to not spam expression trees.
-[assembly: LevelOfParallelism(3)]
+[assembly: LevelOfParallelism(2)]


### PR DESCRIPTION


LICENSE: MIT

because this is a wizden change ported and i didn't feel like cherry-picking the exact commit for full history. it's probably fine it's one number and it's already attributed

## About the PR
less integration tests running at the same time = faster and no ooms. proven by 
https://github.com/space-wizards/space-station-14/pull/39566

## Why / Balance


## Technical details
number - 1

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
