### PR TITLE
Fixing the Explosive Pen so It Can Explode

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/pen.yml
@@ -26,6 +26,8 @@
   - type: OnUseTimerTrigger
     delay: 4
     examinable: false
+  - type: EmitSoundOnUse
+    handle: false
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
I added a single component to the exploding pen which without it, it wasn't working, I assume cause sound was preventing the explosion? I have no idea, but it's working now.

## Why / Balance
Bug fix.

## Technical details
Added:
```
  - type: EmitSoundOnUse
    handle: false
```
as a component to the exploding pen so it can function.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None that I'm aware of.

**Changelog**
:cl: LilNutters
- fix: Fixed the exploding pen, it can now explode again.

