### PR TITLE
Give Vox A Full Tank Option To Spawn WIth

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Generic/outerwearGroup.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Generic/outerwearGroup.yml
@@ -187,8 +187,8 @@
       id: LoadoutClothingOuterShackles
     - type: loadout
       id: LoadoutClothingOuterApronChef
-    - type: loadout
-      id: LoadoutSpeciesTankHarness
+#    - type: loadout
+#      id: LoadoutSpeciesTankHarness
     - type: loadout
       id: LoadoutOuterLongCoatAL
     - type: loadout

--- a/Resources/Prototypes/_DEN/Loadouts/Generic/species.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Generic/species.yml
@@ -48,7 +48,7 @@
       group: LoadoutAirTank
   items:
     - DoubleEmergencyWaterVaporTankFilled
-    
+
 # Feroxi Extra Water
 - type: loadout
   id: LoadoutSpeciesExtraWater
@@ -60,7 +60,7 @@
         - Feroxi
   items:
     - DrinkWaterBottleFull
-    
+
 - type: loadout
   id: LoadoutSpeciesWaterjug
   category: Species
@@ -85,5 +85,15 @@
         - Vox
         - Feroxi
         - SlimePerson
-    - !type:CharacterItemGroupRequirement
-      group: LoadoutOuter
+
+# Vox Full Tank
+- type: loadout
+  id: LoadoutSpeciesNitrogenTank
+  category: Species
+  cost: 0
+  items:
+    - NitrogenTankFilled
+  requirements:
+    - !type:CharacterSpeciesRequirement
+      species:
+        - Vox


### PR DESCRIPTION
## About the PR
Adds a full nitrogen tank for vox as a freebie in the species specific loadout category. Still gotta spend a few points for a spare double emergency tank and whatnot. Also removed the tank harness being exclusive outerwear, as you should be able to select it and have it in your inventory in case you remove your coat.

I can't get it to not spawn in the bag and actually go onto the armor/back slot on spawn but whatever. Beats having nothing at all.

## Why / Balance
Spawning without a full tank is miserable. Vox already get so little, so make the two of us who play a vox a bit better.

## Technical details
Only modifies Den-specific species loadout YAML and general outerwear group YAML. Adds single prototype for the nitrogen tank; removes a line or two from tank harness to make it not outerwear exclusive (and removes it from the group).

## Media
<img width="1015" height="609" alt="image" src="https://github.com/user-attachments/assets/e65cc2c0-75ea-44f6-8215-b6e4393585ef" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- add: Vox are no longer forced into extra agony and can now select a full nitrogen tank in the loadout.