### PR TITLE
Paperwork Belt Tweaks - More Whitelisted Items

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Devices/tape_recorder.yml
@@ -57,6 +57,9 @@
     interfaces:
       enum.TapeRecorderUIKey.Key:
         type: TapeRecorderBoundUserInterface
+  - type: Tag
+    tags:
+    - TapeRecorder
 
 - type: entity
   parent: TapeRecorder
@@ -103,6 +106,9 @@
     available:
     - enum.DamageStateVisualLayers.Base:
         tape_greyscale: Rainbow
+  - type: Tag
+    tags:
+    - CassetteTape
 
 - type: entity
   suffix: Interview with Garry Smosh

--- a/Resources/Prototypes/_DV/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Belt/belts.yml
@@ -145,6 +145,9 @@
       - Radio
       - HandLabeler
       - Write
+      - TapeRecorder
+      - CassetteTape
+      - BoxReamClassic
       components:
       - FitsInDispenser
       - Stamp

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
@@ -290,6 +290,9 @@
       amount: 4
     - id: PaperDyedBrown
       amount: 4
+  - type: Tag
+    tags:
+    - BoxReamClassic
 
 - type: entity
   parent: BoxReamClassic

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1892,3 +1892,13 @@
 
 - type: Tag
   id: Wakizashi
+
+- type: Tag
+  id: TapeRecorder
+
+- type: Tag
+  id: CassetteTape
+
+- type: Tag
+  id: BoxReamClassic
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Tape recorders, cassette tapes and reams can now fit inside the paperwork belt.

## Why / Balance
I generally use tape recorders when working as justice and I figured it would fit the theme of the paperwork belt quite nicely, same thing for the reams, it's a nice place to store them in to free up some bag space.

## Technical details
Just a couple of edits to add tag components for storage whitelisting.

## Media
<img width="288" height="174" alt="image" src="https://github.com/user-attachments/assets/5385f480-0850-4df9-8498-a9be49d2a277" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: LilNutters
- tweak: Tape recorders, cassette tapes and papermoon reams can now fit inside the paperwork belt.
