### PR TITLE
Make Bluespace Parts Craftable Once Reverse Engineered

### DIFF
--- a/Content.Server/Nyanotrasen/ReverseEngineering/ReverseEngineeringSystem.cs
+++ b/Content.Server/Nyanotrasen/ReverseEngineering/ReverseEngineeringSystem.cs
@@ -346,6 +346,10 @@ public sealed class ReverseEngineeringSystem : EntitySystem
         if (!TryComp<TechnologyDiskComponent>(disk, out var diskComponent))
             return;
 
+        // DEN note - this changes the recipe, which is reflected in the examine text
+        // But it won't update the name with the recipe. Need to somehow raise a NameModifier event
+        // not enough of a C# warrior to figure that out
+        // everything works otherwise though
         diskComponent.Recipes = recipes;
     }
 

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/protolathe.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/protolathe.yml
@@ -120,6 +120,10 @@
   - EnergyScalpel
   - EnergyCautery
   - AdvancedRetractor
+  # DEN - Reverse Engineering
+  - BluespaceMatterBinStockPart
+  - BluespaceManipulatorStockPart
+  - BluespaceCapacitorStockPart
 
 - type: latheRecipePack
   id: ProtolatheDynamicEmagAwfulDen


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
added bluespace parts to the dynamic recipe list for protolathes! you could always get the recipe by reverse engineering, but no lathe actually had the ability to print them.

bonus: I also pointed out an error/inconsistency in the C# code that results in this weird naming thing that confuses everyone whenever you reverse engineer anything. I don't actually know enough about the systems to properly fix it (need to raise a name modifier event but idk how to do that), I just know it has to go where I commented.
<img width="484" height="219" alt="image" src="https://github.com/user-attachments/assets/83c6c08d-3004-4895-8286-cf96fa7f007d" />
this PR does NOT fix this problem. I just spotted it and marked it in my journey as I was trying to figure out why you couldn't print these.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it seems it was always intended that you could get more bluespace parts by reverse engineering, as they have a crafting recipe. this just completes the vision

## Technical details
<!-- Summary of code changes for easier review. -->
added BS parts to the protolathe list
added a comment to where a change needs to happen to fix the technology disk name bug, for a future brave soul

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="579" height="203" alt="image" src="https://github.com/user-attachments/assets/4276c946-5f64-4d91-9dfc-e8fb60d1c64f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: You can now print reverse engineered bluespace parts!
