### PR TITLE
Medical Loadout Items + Add Prescription Meds To Loadouts

### DIFF
--- a/Content.Client/_DEN/Lobby/UI/Controls/LoadoutItemButton.xaml.cs
+++ b/Content.Client/_DEN/Lobby/UI/Controls/LoadoutItemButton.xaml.cs
@@ -294,7 +294,7 @@ public sealed partial class LoadoutItemButton : StyledButtonGroup
 
     private string GetName()
     {
-        var locId = $"loadout-name-{Loadout.ID}";
+        var locId = Loadout.Name ?? $"loadout-name-{Loadout.ID}";
         var name = Loc.GetString(locId);
 
         if (name == locId && PreviewEntity != null)
@@ -312,7 +312,7 @@ public sealed partial class LoadoutItemButton : StyledButtonGroup
 
     private string GetDescription()
     {
-        var locId = $"loadout-description-{_preference?.LoadoutName}";
+        var locId = Loadout.Description ?? $"loadout-description-{_preference?.LoadoutName}";
         var description = Loc.GetString(locId);
 
         if (description == locId && PreviewEntity != null)

--- a/Content.Shared/Clothing/Loadouts/Prototypes/LoadoutPrototype.cs
+++ b/Content.Shared/Clothing/Loadouts/Prototypes/LoadoutPrototype.cs
@@ -63,6 +63,14 @@ public sealed partial class LoadoutPrototype : IPrototype
 
     [DataField(serverOnly: true)]
     public LoadoutFunction[] Functions { get; private set; } = Array.Empty<LoadoutFunction>();
+
+    // DEN - Add name and description fields.
+    [DataField]
+    public LocId? Name = null;
+
+    [DataField]
+    public LocId? Description = null;
+    // End DEN
 }
 
 /// This serves as a hook for loadout functions to modify one or more entities upon spawning in.

--- a/Resources/Locale/en-US/_DEN/loadouts/categories.ftl
+++ b/Resources/Locale/en-US/_DEN/loadouts/categories.ftl
@@ -4,3 +4,4 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 loadout-category-GeneralTowels = Towels
+loadout-category-GeneralMedical = Medical

--- a/Resources/Locale/en-US/_DEN/loadouts/items.ftl
+++ b/Resources/Locale/en-US/_DEN/loadouts/items.ftl
@@ -59,3 +59,7 @@ loadout-name-LoadoutItemCaneWalkingQuad = quad cane (colorable)
 
 loadout-name-LoadoutServiceItemGoldenPlunger = golden plunger
 
+character-item-group-LoadoutPrescriptions = Prescription Medications
+character-item-group-LoadoutPrescriptionPainkiller = Painkillers
+character-item-group-LoadoutPrescriptionAnxiolytic = Anxiolytics
+character-item-group-LoadoutPrescriptionAntidepressant = Antidepressants

--- a/Resources/Locale/en-US/_DEN/mood/drugs.ftl
+++ b/Resources/Locale/en-US/_DEN/mood/drugs.ftl
@@ -1,0 +1,23 @@
+mood-effect-name-AntidepressantBenefitNonAddictive = mild antidepressant properties
+mood-effect-AntidepressantBenefitNonAddictive = I have more energy and motivation to do things.
+
+mood-effect-name-AntidepressantBenefitStrongNonAddictive = antidepressant properties
+mood-effect-AntidepressantBenefitStrongNonAddictive = I feel like I can function without the world getting in the way.
+
+mood-effect-name-AnxiolyticBenefitNonAddictive = anxiety relief
+mood-effect-AnxiolyticBenefitNonAddictive = My worries feel a lot less urgent.
+
+mood-effect-name-AnxiolyticBenefitTranquilNonAddictive = tranquility
+mood-effect-AnxiolyticBenefitTranquilNonAddictive = My mind feels quieter, and the world feels lighter.
+
+mood-effect-name-AnxiolyticBenefitStrongNonAddictive = anxiety suppression
+mood-effect-AnxiolyticBenefitStrongNonAddictive = I don't feel worried. There is no need to panic.
+
+mood-effect-name-PainRelief = mild pain relief
+mood-effect-PainRelief = My body hurts less. I can focus on other things.
+
+mood-effect-name-PainReliefStrong = pain relief
+mood-effect-PainReliefStrong = My body hurts a lot less. I feel deep relief.
+
+mood-effect-name-PainReliefVeryStrong = pain numbness
+mood-effect-PainReliefVeryStrong = I feel detached from my body - no pain at all, just numbness.

--- a/Resources/Prototypes/Loadouts/Categories/categories.yml
+++ b/Resources/Prototypes/Loadouts/Categories/categories.yml
@@ -46,6 +46,7 @@
     - GeneralItems
     - GeneralInstruments
     - ItemsLewd
+    - GeneralMedical # DEN - Medical items
     - GeneralTowels
     - GeneralToys
 

--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -482,14 +482,14 @@
 
 - type: loadout
   id: LoadoutEmergencyMedipen
-  category: GeneralItems
+  category: GeneralMedical # DEN - Medical items
   cost: 1
   items:
     - EmergencyMedipen
 
 - type: loadout
   id: LoadoutSpaceMedipen
-  category: GeneralItems
+  category: GeneralMedical # DEN - Medical items
   cost: 1
   items:
     - SpaceMedipen
@@ -681,7 +681,7 @@
 # Medkits
 - type: loadout
   id: LoadoutMedkitFilled
-  category: GeneralItems
+  category: GeneralMedical # DEN - Medical items
   cost: 2
   items:
     - MedkitFilled
@@ -927,7 +927,7 @@
 
 - type: loadout
   id: LoadoutItemAACTablet
-  category: GeneralItems
+  category: GeneralMedical # DEN - Medical items
   cost: 2
   items:
     - AACTablet
@@ -937,7 +937,7 @@
 
 - type: loadout
   id: LoadoutItemAACTablet_SAS
-  category: GeneralItems
+  category: GeneralMedical # DEN - Medical items
   cost: 2
   items:
     - AACTablet_SAS
@@ -947,14 +947,14 @@
 
 - type: loadout
   id: LoadoutItemCaneBlind
-  category: GeneralItems
+  category: GeneralMedical # DEN - Medical items
   cost: 0 # It shouldnt cost points to be able to function.
   items:
     - WhiteCane
 
 - type: loadout
   id: LoadoutItemCaneWalking
-  category: GeneralItems
+  category: GeneralMedical # DEN - Medical items
   cost: 0 # It shouldnt cost points to be able to function.
   requirements:
     - !type:CharacterItemGroupRequirement

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1365,6 +1365,12 @@
         - "psicodine-effect-anxieties-wash-away"
         - "psicodine-effect-at-peace"
         probability: 0.2
+      - !type:ChemAddMoodlet # DEN - Add moodlets for non-addictive roleplay chems
+        moodPrototype: AnxiolyticBenefitNonAddictive
+        guidebookShowEffectName: true
+        conditions:
+          - !type:ReagentThreshold
+            min: 0.5
 
 - type: reagent
   id: PotassiumIodide

--- a/Resources/Prototypes/_CD/Reagents/medicine.yml
+++ b/Resources/Prototypes/_CD/Reagents/medicine.yml
@@ -35,15 +35,22 @@
         damage:
           types:
             Poison: 0.01
-      - !type:PopupMessage
-        type: Local
-        visualType: Small
-        messages:
-          - "reagent-effect-antidepressant-fade" # A decent chance to notify the player when their meds run out, but could happen silently.
-        probability: 0.4
+      ## DEN - Replace the "fading" messages with moodlets to encourage players to space out medication doses
+      # - !type:PopupMessage
+      #   type: Local
+      #   visualType: Small
+      #   messages:
+      #     - "reagent-effect-antidepressant-fade" # A decent chance to notify the player when their meds run out, but could happen silently.
+      #   probability: 0.4
+      #   conditions:
+      #     - !type:ReagentThreshold
+      #       max: 0.1
+      - !type:ChemAddMoodlet # DEN - Add moodlets for non-addictive roleplay chems
+        moodPrototype: AntidepressantBenefitNonAddictive
+        guidebookShowEffectName: true
         conditions:
           - !type:ReagentThreshold
-            max: 0.1
+            min: 0.5
 
 - type: reagent
   id: Neurozenium
@@ -91,7 +98,7 @@
         - !type:ReagentThreshold
           reagent: Ethanol # Alcohol makes it really easy to overdose by increasing your body's absorption of the medicine.
           min: 1
-        reagent: Neurozenium 
+        reagent: Neurozenium
         amount: 0.15
       - !type:AdjustReagent
         conditions:
@@ -100,15 +107,22 @@
           min: 10
         reagent: Serenitol
         amount: -7.5
-      - !type:PopupMessage
-        type: Local
-        visualType: Medium
-        messages:
-          - "reagent-effect-antidepressant-fade" # A decent chance to notify the player when their meds run out, but could happen silently.
-        probability: 0.4
+      ## DEN - Replace the "fading" messages with moodlets to encourage players to space out medication doses
+      # - !type:PopupMessage
+      #   type: Local
+      #   visualType: Medium
+      #   messages:
+      #     - "reagent-effect-antidepressant-fade" # A decent chance to notify the player when their meds run out, but could happen silently.
+      #   probability: 0.4
+      #   conditions:
+      #     - !type:ReagentThreshold
+      #       max: 0.1
+      - !type:ChemAddMoodlet # DEN - Add moodlets for non-addictive roleplay chems
+        moodPrototype: AntidepressantBenefitStrongNonAddictive
+        guidebookShowEffectName: true
         conditions:
           - !type:ReagentThreshold
-            max: 0.1
+            min: 0.5
 
 - type: reagent
   id: Blissifylovene
@@ -167,10 +181,10 @@
           min: 5.1
       - !type:GenericStatusEffect
         conditions:
-        - !type:ReagentThreshold 
+        - !type:ReagentThreshold
           min: 5.1
         key: SeeingRainbows # hallucinations set in after 40 seconds, meaning ~0.40u overdose untreated.
-        component: SeeingRainbows 
+        component: SeeingRainbows
         type: Add
         time: 1.1
         refresh: false
@@ -179,7 +193,7 @@
         - !type:ReagentThreshold
           reagent: Ethanol # Alcohol makes it really easy to overdose by increasing your body's absorption of the medicine.
           min: 1
-        reagent: Blissifylovene 
+        reagent: Blissifylovene
         amount: 0.15
       - !type:AdjustReagent
         conditions:
@@ -267,6 +281,12 @@
         conditions:
           - !type:ReagentThreshold
             max: 0.1
+      - !type:ChemAddMoodlet # DEN - Add moodlets for roleplay chems (this one's addictive but also an antidepressant)
+        moodPrototype: AntidepressantBenefitStrongNonAddictive
+        guidebookShowEffectName: true
+        conditions:
+          - !type:ReagentThreshold
+            min: 0.1
 
 
 - type: reagent
@@ -297,15 +317,22 @@
           min: 30
         reagent: Calmafluxine
         amount: -1.2
-      - !type:PopupMessage
-        type: Local
-        visualType: Small
-        messages:
-          - "reagent-effect-anxietymed-fade" # A decent chance to notify the player when their meds run out, but could happen silently.
-        probability: 0.35
+      ## DEN - Replace the "fading" messages with moodlets to encourage players to space out medication doses
+      # - !type:PopupMessage
+      #   type: Local
+      #   visualType: Small
+      #   messages:
+      #     - "reagent-effect-anxietymed-fade" # A decent chance to notify the player when their meds run out, but could happen silently.
+      #   probability: 0.35
+      #   conditions:
+      #     - !type:ReagentThreshold
+      #       max: 0.1
+      - !type:ChemAddMoodlet # DEN - Add moodlets for non-addictive roleplay chems
+        moodPrototype: AnxiolyticBenefitNonAddictive
+        guidebookShowEffectName: true
         conditions:
           - !type:ReagentThreshold
-            max: 0.1
+            min: 0.5
 
 - type: reagent
   id: Tranquinase
@@ -382,15 +409,22 @@
         damage:
           types:
             Poison: 1
-      - !type:PopupMessage
-        type: Local
-        visualType: Small
-        messages:
-          - "reagent-effect-anxietymed-fade" # A decent chance to notify the player when their meds run out, but could happen silently.
-        probability: 0.32
+      ## DEN - Replace the "fading" messages with moodlets to encourage players to space out medication doses
+      # - !type:PopupMessage
+      #   type: Local
+      #   visualType: Small
+      #   messages:
+      #     - "reagent-effect-anxietymed-fade" # A decent chance to notify the player when their meds run out, but could happen silently.
+      #   probability: 0.32
+      #   conditions:
+      #     - !type:ReagentThreshold
+      #       max: 0.1
+      - !type:ChemAddMoodlet # DEN - Add moodlets for non-addictive roleplay chems
+        moodPrototype: AnxiolyticBenefitTranquilNonAddictive
+        guidebookShowEffectName: true
         conditions:
           - !type:ReagentThreshold
-            max: 0.1
+            min: 0.5
 
 - type: reagent
   id: Equilibrazine
@@ -458,15 +492,22 @@
       - !type:AdjustReagent
         reagent: Tranquinase # purges Tranquinase
         amount: -1.5
-      - !type:PopupMessage
-        type: Local
-        visualType: Small
-        messages:
-          - "reagent-effect-anxietymed-fade" # A decent chance to notify the player when their meds run out, but could happen silently.
-        probability: 0.2
+      ## DEN - Replace the "fading" messages with moodlets to encourage players to space out medication doses
+      # - !type:PopupMessage
+      #   type: Local
+      #   visualType: Small
+      #   messages:
+      #     - "reagent-effect-anxietymed-fade" # A decent chance to notify the player when their meds run out, but could happen silently.
+      #   probability: 0.2
+      #   conditions:
+      #     - !type:ReagentThreshold
+      #       max: 0.1
+      - !type:ChemAddMoodlet # DEN - Add moodlets for non-addictive roleplay chems
+        moodPrototype: AnxiolyticBenefitStrongNonAddictive
+        guidebookShowEffectName: true
         conditions:
           - !type:ReagentThreshold
-            max: 0.1
+            min: 0.5
 
 # Floof section - Replace addictine with mood-system addiction.
 #- type: reagent
@@ -556,7 +597,7 @@
       - !type:SatiateHunger # causes digestion inefficiency during overdose
         factor: -1.2
         conditions:
-          - !type:ReagentThreshold 
+          - !type:ReagentThreshold
             min: 14
       - !type:ChemVomit
         probability: 0.8
@@ -567,18 +608,25 @@
       - !type:SatiateHunger # causes digestion inefficiency if you drink alcohol
         factor: -2.0
         conditions:
-          - !type:ReagentThreshold 
+          - !type:ReagentThreshold
             reagent: Ethanol
             min: 2
-      - !type:PopupMessage
-        type: Local
-        visualType: Small
-        messages:
-          - "reagent-effect-painkiller-fade" # A decent chance to notify the player when their meds run out
-        probability: 0.35
+      ## DEN - Replace the "fading" messages with moodlets to encourage players to space out medication doses
+      # - !type:PopupMessage
+      #   type: Local
+      #   visualType: Small
+      #   messages:
+      #     - "reagent-effect-painkiller-fade" # A decent chance to notify the player when their meds run out
+      #   probability: 0.35
+      #   conditions:
+      #     - !type:ReagentThreshold
+      #       max: 0.2
+      - !type:ChemAddMoodlet # DEN - Add moodlets for non-addictive roleplay chems
+        moodPrototype: PainRelief
+        guidebookShowEffectName: true
         conditions:
           - !type:ReagentThreshold
-            max: 0.2
+            min: 0.5
 
 - type: reagent
   id: Soretizone
@@ -651,15 +699,22 @@
         - !type:ReagentThreshold
           min: 5
 # Floof section end
-      - !type:PopupMessage
-        type: Local
-        visualType: Medium # stronger painkiller = more noticable fading
-        messages:
-          - "reagent-effect-painkiller-fade" # A decent chance to notify the player when their meds run out
-        probability: 0.4
+      ## DEN - Replace the "fading" messages with moodlets to encourage players to space out medication doses
+      # - !type:PopupMessage
+      #   type: Local
+      #   visualType: Medium # stronger painkiller = more noticable fading
+      #   messages:
+      #     - "reagent-effect-painkiller-fade" # A decent chance to notify the player when their meds run out
+      #   probability: 0.4
+      #   conditions:
+      #     - !type:ReagentThreshold
+      #       max: 0.1
+      - !type:ChemAddMoodlet # DEN - Add moodlets for roleplay chems (this one /is/ addictive but it's still a painkiller)
+        moodPrototype: PainReliefStrong
+        guidebookShowEffectName: true
         conditions:
           - !type:ReagentThreshold
-            max: 0.1
+            min: 0.5
 
 - type: reagent
   id: Agonolexyne
@@ -744,12 +799,19 @@
         damage:
           types:
             Asphyxiation: 1 # your lungs relax so much you can't breathe, suffocating you on OD
-      - !type:PopupMessage
-        type: Local
-        visualType: Large # stronger painkiller = more noticable fading
-        messages:
-          - "reagent-effect-painkiller-fade" # A decent chance to notify the player when their meds run out
-        probability: 0.5
+      ## DEN - Replace the "fading" messages with moodlets to encourage players to space out medication doses
+      # - !type:PopupMessage
+      #   type: Local
+      #   visualType: Large # stronger painkiller = more noticable fading
+      #   messages:
+      #     - "reagent-effect-painkiller-fade" # A decent chance to notify the player when their meds run out
+      #   probability: 0.5
+      #   conditions:
+      #     - !type:ReagentThreshold
+      #       max: 0.1
+      - !type:ChemAddMoodlet # DEN - Add moodlets for roleplay chems (this one /is/ addictive but it's still a painkiller)
+        moodPrototype: PainReliefVeryStrong
+        guidebookShowEffectName: true
         conditions:
           - !type:ReagentThreshold
-            max: 0.1
+            min: 0.1

--- a/Resources/Prototypes/_DEN/CharacterItemGroups/Loadouts/miscItems.yml
+++ b/Resources/Prototypes/_DEN/CharacterItemGroups/Loadouts/miscItems.yml
@@ -70,7 +70,9 @@
   - type: loadout
     id: LoadoutPillCanisterEthyloxyephedrine
   - type: loadout
-    id: LoadoutPillCanisterSaline
+    id: LoadoutPillCanisterIron
+  - type: loadout
+    id: LoadoutPillCanisterCopper
 
 - type: characterItemGroup
   id: LoadoutPrescriptionPainkiller

--- a/Resources/Prototypes/_DEN/CharacterItemGroups/Loadouts/miscItems.yml
+++ b/Resources/Prototypes/_DEN/CharacterItemGroups/Loadouts/miscItems.yml
@@ -67,6 +67,8 @@
   - type: loadout
     id: LoadoutPillCanisterSerenitolLowDose
   # Miscellaneous
+  - type: loadout
+    id: LoadoutPillCanisterEthyloxyephedrine
 
 - type: characterItemGroup
   id: LoadoutPrescriptionPainkiller

--- a/Resources/Prototypes/_DEN/CharacterItemGroups/Loadouts/miscItems.yml
+++ b/Resources/Prototypes/_DEN/CharacterItemGroups/Loadouts/miscItems.yml
@@ -69,6 +69,8 @@
   # Miscellaneous
   - type: loadout
     id: LoadoutPillCanisterEthyloxyephedrine
+  - type: loadout
+    id: LoadoutPillCanisterSaline
 
 - type: characterItemGroup
   id: LoadoutPrescriptionPainkiller

--- a/Resources/Prototypes/_DEN/CharacterItemGroups/Loadouts/miscItems.yml
+++ b/Resources/Prototypes/_DEN/CharacterItemGroups/Loadouts/miscItems.yml
@@ -17,3 +17,106 @@
       id: LoadoutItemCaneWalkingQuad
     - type: loadout
       id: LoadoutItemWalkingCaneImp
+
+# Prescription medicines - primarily RP chems.
+# I am excluding the HRT medications from this list on purpose.
+
+- type: characterItemGroup
+  id: LoadoutPrescriptions
+  maxItems: 2
+  items:
+  # Painkillers
+  - type: loadout
+    id: LoadoutPillCanisterAgonolexyneLowDose
+  - type: loadout
+    id: LoadoutPillCanisterAgonolexyneHighDose
+  - type: loadout
+    id: LoadoutPillCanisterSoretizoneLowDose
+  - type: loadout
+    id: LoadoutPillCanisterSoretizoneHighDose
+  - type: loadout
+    id: LoadoutPillCanisterStubantazineLowDose
+  - type: loadout
+    id: LoadoutPillCanisterStubantazineHighDose
+  # Anxiolytics
+  - type: loadout
+    id: LoadoutPillCanisterEquilibrazineHighDose
+  - type: loadout
+    id: LoadoutPillCanisterEquilibrazineLowDose
+  - type: loadout
+    id: LoadoutPillCanisterTranquinaseHighDose
+  - type: loadout
+    id: LoadoutPillCanisterTranquinaseLowDose
+  - type: loadout
+    id: LoadoutPillCanisterCalmafluxineHighDose
+  - type: loadout
+    id: LoadoutPillCanisterCalmafluxineLowDose
+  - type: loadout
+    id: LoadoutPillCanisterPsicodineHighDose
+  # Antidepressants
+  - type: loadout
+    id: LoadoutPillCanisterBlissifyloveneHighDose
+  - type: loadout
+    id: LoadoutPillCanisterBlissifyloveneLowDose
+  - type: loadout
+    id: LoadoutPillCanisterNeurozeniumHighDose
+  - type: loadout
+    id: LoadoutPillCanisterNeurozeniumLowDose
+  - type: loadout
+    id: LoadoutPillCanisterSerenitolHighDose
+  - type: loadout
+    id: LoadoutPillCanisterSerenitolLowDose
+  # Miscellaneous
+
+- type: characterItemGroup
+  id: LoadoutPrescriptionPainkiller
+  maxItems: 1
+  items:
+  - type: loadout
+    id: LoadoutPillCanisterAgonolexyneLowDose
+  - type: loadout
+    id: LoadoutPillCanisterAgonolexyneHighDose
+  - type: loadout
+    id: LoadoutPillCanisterSoretizoneLowDose
+  - type: loadout
+    id: LoadoutPillCanisterSoretizoneHighDose
+  - type: loadout
+    id: LoadoutPillCanisterStubantazineLowDose
+  - type: loadout
+    id: LoadoutPillCanisterStubantazineHighDose
+
+- type: characterItemGroup
+  id: LoadoutPrescriptionAnxiolytic
+  maxItems: 1
+  items:
+  - type: loadout
+    id: LoadoutPillCanisterEquilibrazineHighDose
+  - type: loadout
+    id: LoadoutPillCanisterEquilibrazineLowDose
+  - type: loadout
+    id: LoadoutPillCanisterTranquinaseHighDose
+  - type: loadout
+    id: LoadoutPillCanisterTranquinaseLowDose
+  - type: loadout
+    id: LoadoutPillCanisterCalmafluxineHighDose
+  - type: loadout
+    id: LoadoutPillCanisterCalmafluxineLowDose
+  - type: loadout
+    id: LoadoutPillCanisterPsicodine
+
+- type: characterItemGroup
+  id: LoadoutPrescriptionAntidepressant
+  maxItems: 1
+  items:
+  - type: loadout
+    id: LoadoutPillCanisterBlissifyloveneHighDose
+  - type: loadout
+    id: LoadoutPillCanisterBlissifyloveneLowDose
+  - type: loadout
+    id: LoadoutPillCanisterNeurozeniumHighDose
+  - type: loadout
+    id: LoadoutPillCanisterNeurozeniumLowDose
+  - type: loadout
+    id: LoadoutPillCanisterSerenitolHighDose
+  - type: loadout
+    id: LoadoutPillCanisterSerenitolLowDose

--- a/Resources/Prototypes/_DEN/Entities/Objects/Specific/Medical/pills.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Specific/Medical/pills.yml
@@ -405,9 +405,24 @@
 ## Non-addictive, overdose > 6.7u
 
 - type: entity
-  suffix: Equilibrazine 5u
+  suffix: Equilibrazine 2.5u
   parent: Pill
   id: PillEquilibrazineLowDose
+  components:
+  - type: Label
+    currentLabel: equilibrazine 2.5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Equilibrazine
+          Quantity: 2.5
+
+- type: entity
+  suffix: Equilibrazine 5u
+  parent: Pill
+  id: PillEquilibrazineHighDose
   components:
   - type: Label
     currentLabel: equilibrazine 5u
@@ -420,27 +435,12 @@
           Quantity: 5
 
 - type: entity
-  suffix: Equilibrazine 10u
-  parent: Pill
-  id: PillEquilibrazineHighDose
-  components:
-  - type: Label
-    currentLabel: equilibrazine 10u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Equilibrazine
-          Quantity: 10
-
-- type: entity
   parent: PillCanister
   id: PillCanisterEquilibrazineLowDose
-  suffix: Equilibrazine, 5u x5
+  suffix: Equilibrazine, 2.5u x5
   components:
   - type: Label
-    currentLabel: equilibrazine 5u
+    currentLabel: equilibrazine 2.5u
   - type: StorageFill
     contents:
     - id: PillEquilibrazineLowDose
@@ -449,7 +449,7 @@
 - type: entity
   parent: PillCanister
   id: PillCanisterEquilibrazineHighDose
-  suffix: Equilibrazine, 10u x5
+  suffix: Equilibrazine, 5u x5
   components:
   - type: Label
     currentLabel: equilibrazine 5u

--- a/Resources/Prototypes/_DEN/Entities/Objects/Specific/Medical/pills.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Specific/Medical/pills.yml
@@ -289,9 +289,24 @@
 ## Addictive > 9u, abates withdrawal > 5u, overdose was 14.5u until DV removed that.
 
 - type: entity
-  suffix: Soretizone 5u
+  suffix: Soretizone 2.5u
   parent: Pill
   id: PillSoretizoneLowDose
+  components:
+  - type: Label
+    currentLabel: soretizone 2.5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Soretizone
+          Quantity: 2.5
+
+- type: entity
+  suffix: Soretizone 5u
+  parent: Pill
+  id: PillSoretizoneHighDose
   components:
   - type: Label
     currentLabel: soretizone 5u
@@ -304,27 +319,12 @@
           Quantity: 5
 
 - type: entity
-  suffix: Soretizone 10u
-  parent: Pill
-  id: PillSoretizoneHighDose
-  components:
-  - type: Label
-    currentLabel: soretizone 10u
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 20
-        reagents:
-        - ReagentId: Soretizone
-          Quantity: 10
-
-- type: entity
   parent: PillCanister
   id: PillCanisterSoretizoneLowDose
-  suffix: Soretizone, 5u x5
+  suffix: Soretizone, 2.5u x5
   components:
   - type: Label
-    currentLabel: soretizone 5u
+    currentLabel: soretizone 2.5u
   - type: StorageFill
     contents:
     - id: PillSoretizoneLowDose
@@ -333,10 +333,10 @@
 - type: entity
   parent: PillCanister
   id: PillCanisterSoretizoneHighDose
-  suffix: Soretizone, 10u x5
+  suffix: Soretizone, 5u x5
   components:
   - type: Label
-    currentLabel: soretizone 10u
+    currentLabel: soretizone 5u
   - type: StorageFill
     contents:
     - id: PillSoretizoneHighDose

--- a/Resources/Prototypes/_DEN/Entities/Objects/Specific/Medical/pills.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Specific/Medical/pills.yml
@@ -812,3 +812,34 @@
     contents:
     - id: PillSaline
       amount: 5
+
+## Ethyloxyephedrine
+## Stimulant that can stave off narcolepsy and reduce drowsiness.
+## Only 5u is needed to reset the narcolepsy timer (5-10 minutes).
+
+- type: entity
+  suffix: Ethyloxyephedrine 10u
+  parent: Pill
+  id: PillEthyloxyephedrine
+  components:
+  - type: Label
+    currentLabel: ethyloxyephedrine 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Ethyloxyephedrine
+          Quantity: 10
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterEthyloxyephedrine
+  suffix: Ethyloxyephedrine, 10u x5
+  components:
+  - type: Label
+    currentLabel: ethyloxyephedrine 10u
+  - type: StorageFill
+    contents:
+    - id: PillEthyloxyephedrine
+      amount: 5

--- a/Resources/Prototypes/_DEN/Entities/Objects/Specific/Medical/pills.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Specific/Medical/pills.yml
@@ -224,3 +224,590 @@
               Quantity: 15
     - type: Label
       currentLabel: testosterone
+
+## Agonolexyne
+## Very strong opioid painkiller.
+## These have a lower dose because they have an incredibly low addiction and overdose threshold.
+## Addictive > 0.25u, overdose > 5u
+
+- type: entity
+  suffix: Agonolexyne 1u
+  parent: Pill
+  id: PillAgonolexyneLowDose
+  components:
+  - type: Label
+    currentLabel: agonolexyne 1u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Agonolexyne
+          Quantity: 1
+
+- type: entity
+  suffix: Agonolexyne 2u
+  parent: Pill
+  id: PillAgonolexyneHighDose
+  components:
+  - type: Label
+    currentLabel: agonolexyne 2u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Agonolexyne
+          Quantity: 2
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterAgonolexyneLowDose
+  suffix: Agonolexyne, 1u x5
+  components:
+  - type: Label
+    currentLabel: agonolexyne 1u
+  - type: StorageFill
+    contents:
+    - id: PillAgonolexyneLowDose
+      amount: 5
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterAgonolexyneHighDose
+  suffix: Agonolexyne, 2u x5
+  components:
+  - type: Label
+    currentLabel: agonolexyne 2u
+  - type: StorageFill
+    contents:
+    - id: PillAgonolexyneHighDose
+      amount: 5
+
+## Soretizone
+## Chronic pain medication for things that Stubantazine won't solve.
+## Addictive > 9u, abates withdrawal > 5u, overdose was 14.5u until DV removed that.
+
+- type: entity
+  suffix: Soretizone 5u
+  parent: Pill
+  id: PillSoretizoneLowDose
+  components:
+  - type: Label
+    currentLabel: soretizone 5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Soretizone
+          Quantity: 5
+
+- type: entity
+  suffix: Soretizone 10u
+  parent: Pill
+  id: PillSoretizoneHighDose
+  components:
+  - type: Label
+    currentLabel: soretizone 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Soretizone
+          Quantity: 10
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterSoretizoneLowDose
+  suffix: Soretizone, 5u x5
+  components:
+  - type: Label
+    currentLabel: soretizone 5u
+  - type: StorageFill
+    contents:
+    - id: PillSoretizoneLowDose
+      amount: 5
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterSoretizoneHighDose
+  suffix: Soretizone, 10u x5
+  components:
+  - type: Label
+    currentLabel: soretizone 10u
+  - type: StorageFill
+    contents:
+    - id: PillSoretizoneHighDose
+      amount: 5
+
+## Stubantazine
+## Mild painkiller for temporary stents of pain.
+## Non-addictive, overdose > 14u
+
+- type: entity
+  suffix: Stubantazine 5u
+  parent: Pill
+  id: PillStubantazineLowDose
+  components:
+  - type: Label
+    currentLabel: stubantazine 5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Stubantazine
+          Quantity: 5
+
+- type: entity
+  suffix: Stubantazine 10u
+  parent: Pill
+  id: PillStubantazineHighDose
+  components:
+  - type: Label
+    currentLabel: stubantazine 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Stubantazine
+          Quantity: 10
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterStubantazineLowDose
+  suffix: Stubantazine, 5u x5
+  components:
+  - type: Label
+    currentLabel: stubantazine 5u
+  - type: StorageFill
+    contents:
+    - id: PillStubantazineLowDose
+      amount: 5
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterStubantazineHighDose
+  suffix: Stubantazine, 10u x5
+  components:
+  - type: Label
+    currentLabel: stubantazine 10u
+  - type: StorageFill
+    contents:
+    - id: PillStubantazineHighDose
+      amount: 5
+
+## Equilibrazine
+## Anxiety and panic attack medication that is incompatible with most antidepressants.
+## Non-addictive, overdose > 6.7u
+
+- type: entity
+  suffix: Equilibrazine 5u
+  parent: Pill
+  id: PillEquilibrazineLowDose
+  components:
+  - type: Label
+    currentLabel: equilibrazine 5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Equilibrazine
+          Quantity: 5
+
+- type: entity
+  suffix: Equilibrazine 10u
+  parent: Pill
+  id: PillEquilibrazineHighDose
+  components:
+  - type: Label
+    currentLabel: equilibrazine 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Equilibrazine
+          Quantity: 10
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterEquilibrazineLowDose
+  suffix: Equilibrazine, 5u x5
+  components:
+  - type: Label
+    currentLabel: equilibrazine 5u
+  - type: StorageFill
+    contents:
+    - id: PillEquilibrazineLowDose
+      amount: 5
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterEquilibrazineHighDose
+  suffix: Equilibrazine, 10u x5
+  components:
+  - type: Label
+    currentLabel: equilibrazine 5u
+  - type: StorageFill
+    contents:
+    - id: PillEquilibrazineLowDose
+      amount: 5
+
+## Tranquinase
+## Standard anxiety medication with a tranquilizing effect.
+## Non-addictive. Slows you dont above 16.5u, overdose at 30u.
+
+- type: entity
+  suffix: Tranquinase 5u
+  parent: Pill
+  id: PillTranquinaseLowDose
+  components:
+  - type: Label
+    currentLabel: tranquinase 5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Tranquinase
+          Quantity: 5
+
+- type: entity
+  suffix: Tranquinase 10u
+  parent: Pill
+  id: PillTranquinaseHighDose
+  components:
+  - type: Label
+    currentLabel: tranquinase 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Tranquinase
+          Quantity: 10
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterTranquinaseLowDose
+  suffix: Tranquinase, 5u x5
+  components:
+  - type: Label
+    currentLabel: tranquinase 5u
+  - type: StorageFill
+    contents:
+    - id: PillTranquinaseLowDose
+      amount: 5
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterTranquinaseHighDose
+  suffix: Tranquinase, 10u x5
+  components:
+  - type: Label
+    currentLabel: tranquinase 10u
+  - type: StorageFill
+    contents:
+    - id: PillTranquinaseHighDose
+      amount: 5
+
+## Calmafluxine
+## Mild over-the-counter anxiety med.
+## Non-addictive, impossible to overdose on - >30u will simply drain from your system.
+## Increasing the number you get for these because it's mild and runs out fast
+
+- type: entity
+  suffix: Calmafluxine 5u
+  parent: Pill
+  id: PillCalmafluxineLowDose
+  components:
+  - type: Label
+    currentLabel: calmafluxine 5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Calmafluxine
+          Quantity: 5
+
+- type: entity
+  suffix: Calmafluxine 10u
+  parent: Pill
+  id: PillCalmafluxineHighDose
+  components:
+  - type: Label
+    currentLabel: calmafluxine 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Calmafluxine
+          Quantity: 10
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterCalmafluxineLowDose
+  suffix: Calmafluxine, 5u x10
+  components:
+  - type: Label
+    currentLabel: calmafluxine 5u
+  - type: StorageFill
+    contents:
+    - id: PillCalmafluxineLowDose
+      amount: 10
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterCalmafluxineHighDose
+  suffix: Calmafluxine, 10u x10
+  components:
+  - type: Label
+    currentLabel: calmafluxine 10u
+  - type: StorageFill
+    contents:
+    - id: PillCalmafluxineHighDose
+      amount: 10
+
+## Blissifylovene
+## These have a lower dose because they have an incredibly low addiction and overdose threshold.
+## (1.5u addiction, 5u OD)
+
+- type: entity
+  suffix: Blissifylovene 1u
+  parent: Pill
+  id: PillBlissifyloveneLowDose
+  components:
+  - type: Label
+    currentLabel: blissifylovene 1u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Blissifylovene
+          Quantity: 1
+
+- type: entity
+  suffix: Blissifylovene 2u
+  parent: Pill
+  id: PillBlissifyloveneHighDose
+  components:
+  - type: Label
+    currentLabel: blissifylovene 2u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Blissifylovene
+          Quantity: 2
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterBlissifyloveneLowDose
+  suffix: Blissifylovene, 1u x5
+  components:
+  - type: Label
+    currentLabel: blissifylovene 1u
+  - type: StorageFill
+    contents:
+    - id: PillBlissifyloveneLowDose
+      amount: 5
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterBlissifyloveneHighDose
+  suffix: Blissifylovene, 2u x5
+  components:
+  - type: Label
+    currentLabel: blissifylovene 2u
+  - type: StorageFill
+    contents:
+    - id: PillBlissifyloveneHighDose
+      amount: 5
+
+## Neurozenium
+## Strong antidepressant
+## Non-addictive, overdose > 15.1u
+
+- type: entity
+  suffix: Neurozenium 5u
+  parent: Pill
+  id: PillNeurozeniumLowDose
+  components:
+  - type: Label
+    currentLabel: neurozenium 5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Neurozenium
+          Quantity: 5
+
+- type: entity
+  suffix: Neurozenium 10u
+  parent: Pill
+  id: PillNeurozeniumHighDose
+  components:
+  - type: Label
+    currentLabel: neurozenium 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Neurozenium
+          Quantity: 10
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterNeurozeniumLowDose
+  suffix: Neurozenium, 5u x5
+  components:
+  - type: Label
+    currentLabel: neurozenium 5u
+  - type: StorageFill
+    contents:
+    - id: PillNeurozeniumLowDose
+      amount: 5
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterNeurozeniumHighDose
+  suffix: Neurozenium, 10u x5
+  components:
+  - type: Label
+    currentLabel: neurozenium 10u
+  - type: StorageFill
+    contents:
+    - id: PillNeurozeniumHighDose
+      amount: 5
+
+## Serenitol
+## Mild antidepressant - fairly safe and used in grief treatment
+## Non-addictive, overdose > 22.5u
+
+- type: entity
+  suffix: Serenitol 5u
+  parent: Pill
+  id: PillSerenitolLowDose
+  components:
+  - type: Label
+    currentLabel: serenitol 5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Serenitol
+          Quantity: 5
+
+- type: entity
+  suffix: Serenitol 10u
+  parent: Pill
+  id: PillSerenitolHighDose
+  components:
+  - type: Label
+    currentLabel: serenitol 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Serenitol
+          Quantity: 10
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterSerenitolLowDose
+  suffix: Serenitol, 5u x5
+  components:
+  - type: Label
+    currentLabel: serenitol 5u
+  - type: StorageFill
+    contents:
+    - id: PillSerenitolLowDose
+      amount: 5
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterSerenitolHighDose
+  suffix: Serenitol, 10u x5
+  components:
+  - type: Label
+    currentLabel: serenitol 10u
+  - type: StorageFill
+    contents:
+    - id: PillSerenitolHighDose
+      amount: 5
+
+## Psicodine
+## Anxiety suppressant, reduces jittering and drunkenness.
+## Overdose > 30u
+
+- type: entity
+  suffix: Psicodine 5u
+  parent: Pill
+  id: PillPsicodine
+  components:
+  - type: Label
+    currentLabel: psicodine 5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Psicodine
+          Quantity: 5
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterPsicodine
+  suffix: Psicodine, 5u x5
+  components:
+  - type: Label
+    currentLabel: psicodine 5u
+  - type: StorageFill
+    contents:
+    - id: PillPsicodine
+      amount: 5
+
+## Saline
+## Raises blood levels - useful for the blood deficiency trait.
+## 0.5u saline raises blood level by 6, so 5u is 60.
+## Keep in mind a baseline Urist has 300u of blood, so this is about 20% if my math is right.
+
+- type: entity
+  suffix: Saline 5u
+  parent: Pill
+  id: PillSaline
+  components:
+  - type: Label
+    currentLabel: saline 5u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Saline
+          Quantity: 5
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterSaline
+  suffix: Saline, 5u x5
+  components:
+  - type: Label
+    currentLabel: saline 5u
+  - type: StorageFill
+    contents:
+    - id: PillSaline
+      amount: 5

--- a/Resources/Prototypes/_DEN/Entities/Objects/Specific/Medical/pills.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Specific/Medical/pills.yml
@@ -576,6 +576,7 @@
       amount: 10
 
 ## Blissifylovene
+## Strong antidepressant.
 ## These have a lower dose because they have an incredibly low addiction and overdose threshold.
 ## (1.5u addiction, 5u OD)
 

--- a/Resources/Prototypes/_DEN/Loadouts/Categories/categories.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Categories/categories.yml
@@ -5,3 +5,6 @@
 
 - type: loadoutCategory
   id: GeneralTowels
+
+- type: loadoutCategory
+  id: GeneralMedical

--- a/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
@@ -283,3 +283,14 @@
     group: LoadoutPrescriptions
   items:
   - PillCanisterEthyloxyephedrine
+
+- type: loadout
+  id: LoadoutPillCanisterSaline # Blood level medication
+  category: GeneralMedical
+  description: reagent-desc-saline
+  cost: 2
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  items:
+  - PillCanisterSaline

--- a/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
@@ -1,0 +1,255 @@
+# Painkillers
+
+## Agonolexyne
+
+- type: loadout
+  id: LoadoutPillCanisterAgonolexyneLowDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionPainkiller
+  items:
+  - PillCanisterAgonolexyneLowDose
+
+- type: loadout
+  id: LoadoutPillCanisterAgonolexyneHighDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionPainkiller
+  items:
+  - PillCanisterAgonolexyneHighDose
+
+## Soretizone
+
+- type: loadout
+  id: LoadoutPillCanisterSoretizoneLowDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionPainkiller
+  items:
+  - PillCanisterSoretizoneLowDose
+
+- type: loadout
+  id: LoadoutPillCanisterSoretizoneHighDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionPainkiller
+  items:
+  - PillCanisterSoretizoneHighDose
+
+## Stubantazine
+
+- type: loadout
+  id: LoadoutPillCanisterStubantazineLowDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionPainkiller
+  items:
+  - PillCanisterStubantazineLowDose
+
+- type: loadout
+  id: LoadoutPillCanisterStubantazineHighDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionPainkiller
+  items:
+  - PillCanisterStubantazineHighDose
+
+# Anxiolytics
+
+## Equilibrazine
+
+- type: loadout
+  id: LoadoutPillCanisterEquilibrazineLowDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAnxiolytic
+  items:
+  - PillCanisterEquilibrazineLowDose
+
+- type: loadout
+  id: LoadoutPillCanisterEquilibrazineHighDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAnxiolytic
+  items:
+  - PillCanisterEquilibrazineHighDose
+
+## Tranquinase
+
+- type: loadout
+  id: LoadoutPillCanisterTranquinaseLowDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAnxiolytic
+  items:
+  - PillCanisterTranquinaseLowDose
+
+- type: loadout
+  id: LoadoutPillCanisterTranquinaseHighDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAnxiolytic
+  items:
+  - PillCanisterTranquinaseHighDose
+
+## Calmafluxine
+
+- type: loadout
+  id: LoadoutPillCanisterCalmafluxineLowDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAnxiolytic
+  items:
+  - PillCanisterCalmafluxineLowDose
+
+- type: loadout
+  id: LoadoutPillCanisterCalmafluxineHighDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAnxiolytic
+  items:
+  - PillCanisterCalmafluxineHighDose
+
+## Psicodine
+
+- type: loadout
+  id: LoadoutPillCanisterPsicodine
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAnxiolytic
+  items:
+  - PillCanisterPsicodine
+
+# Antidepressants
+
+## Blissifylovene
+
+- type: loadout
+  id: LoadoutPillCanisterBlissifyloveneLowDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAntidepressant
+  items:
+  - PillCanisterBlissifyloveneLowDose
+
+- type: loadout
+  id: LoadoutPillCanisterBlissifyloveneHighDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAntidepressant
+  items:
+  - PillCanisterBlissifyloveneHighDose
+
+## Neurozenium
+
+- type: loadout
+  id: LoadoutPillCanisterNeurozeniumLowDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAntidepressant
+  items:
+  - PillCanisterNeurozeniumLowDose
+
+- type: loadout
+  id: LoadoutPillCanisterNeurozeniumHighDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAntidepressant
+  items:
+  - PillCanisterNeurozeniumHighDose
+
+## Serenitol
+
+- type: loadout
+  id: LoadoutPillCanisterSerenitolLowDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAntidepressant
+  items:
+  - PillCanisterSerenitolLowDose
+
+- type: loadout
+  id: LoadoutPillCanisterSerenitolHighDose
+  category: GeneralItems
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptionAntidepressant
+  items:
+  - PillCanisterSerenitolHighDose
+
+# Miscellaneous

--- a/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
@@ -92,7 +92,7 @@
   id: LoadoutPillCanisterEquilibrazineLowDose
   category: GeneralItems
   description: reagent-desc-equilibrazine
-  cost: 1
+  cost: 2
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions
@@ -105,7 +105,7 @@
   id: LoadoutPillCanisterEquilibrazineHighDose
   category: GeneralItems
   description: reagent-desc-equilibrazine
-  cost: 2
+  cost: 3
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions

--- a/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
@@ -4,7 +4,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterAgonolexyneLowDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-agonolexyne
   cost: 2
   requirements:
@@ -17,7 +17,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterAgonolexyneHighDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-agonolexyne
   cost: 3
   requirements:
@@ -32,7 +32,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterSoretizoneLowDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-soretizone
   cost: 1
   requirements:
@@ -45,7 +45,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterSoretizoneHighDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-soretizone
   cost: 2
   requirements:
@@ -60,7 +60,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterStubantazineLowDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-stubantazine
   cost: 1
   requirements:
@@ -73,7 +73,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterStubantazineHighDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-stubantazine
   cost: 2
   requirements:
@@ -90,7 +90,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterEquilibrazineLowDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-equilibrazine
   cost: 2
   requirements:
@@ -103,7 +103,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterEquilibrazineHighDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-equilibrazine
   cost: 3
   requirements:
@@ -118,7 +118,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterTranquinaseLowDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-tranquinase
   cost: 1
   requirements:
@@ -131,7 +131,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterTranquinaseHighDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-tranquinase
   cost: 2
   requirements:
@@ -146,7 +146,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterCalmafluxineLowDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-calmafluxine
   cost: 1
   requirements:
@@ -159,7 +159,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterCalmafluxineHighDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-calmafluxine
   cost: 1
   requirements:
@@ -174,7 +174,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterPsicodine
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-psicodine
   cost: 1
   requirements:
@@ -191,7 +191,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterBlissifyloveneLowDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-blissifylovene
   cost: 2
   requirements:
@@ -204,7 +204,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterBlissifyloveneHighDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-blissifylovene
   cost: 3
   requirements:
@@ -219,7 +219,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterNeurozeniumLowDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-neurozenium
   cost: 1
   requirements:
@@ -232,7 +232,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterNeurozeniumHighDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-neurozenium
   cost: 2
   requirements:
@@ -247,7 +247,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterSerenitolLowDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-serenitol
   cost: 1
   requirements:
@@ -260,7 +260,7 @@
 
 - type: loadout
   id: LoadoutPillCanisterSerenitolHighDose
-  category: GeneralItems
+  category: GeneralMedical
   description: reagent-desc-serenitol
   cost: 1
   requirements:

--- a/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
@@ -6,7 +6,7 @@
   id: LoadoutPillCanisterAgonolexyneLowDose
   category: GeneralItems
   description: reagent-desc-agonolexyne
-  cost: 1
+  cost: 2
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions
@@ -19,7 +19,7 @@
   id: LoadoutPillCanisterAgonolexyneHighDose
   category: GeneralItems
   description: reagent-desc-agonolexyne
-  cost: 1
+  cost: 3
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions
@@ -47,7 +47,7 @@
   id: LoadoutPillCanisterSoretizoneHighDose
   category: GeneralItems
   description: reagent-desc-soretizone
-  cost: 1
+  cost: 2
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions
@@ -75,7 +75,7 @@
   id: LoadoutPillCanisterStubantazineHighDose
   category: GeneralItems
   description: reagent-desc-stubantazine
-  cost: 1
+  cost: 2
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions
@@ -105,7 +105,7 @@
   id: LoadoutPillCanisterEquilibrazineHighDose
   category: GeneralItems
   description: reagent-desc-equilibrazine
-  cost: 1
+  cost: 2
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions
@@ -133,7 +133,7 @@
   id: LoadoutPillCanisterTranquinaseHighDose
   category: GeneralItems
   description: reagent-desc-tranquinase
-  cost: 1
+  cost: 2
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions
@@ -193,7 +193,7 @@
   id: LoadoutPillCanisterBlissifyloveneLowDose
   category: GeneralItems
   description: reagent-desc-blissifylovene
-  cost: 1
+  cost: 2
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions
@@ -206,7 +206,7 @@
   id: LoadoutPillCanisterBlissifyloveneHighDose
   category: GeneralItems
   description: reagent-desc-blissifylovene
-  cost: 1
+  cost: 3
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions
@@ -234,7 +234,7 @@
   id: LoadoutPillCanisterNeurozeniumHighDose
   category: GeneralItems
   description: reagent-desc-neurozenium
-  cost: 1
+  cost: 2
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions

--- a/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
@@ -285,12 +285,23 @@
   - PillCanisterEthyloxyephedrine
 
 - type: loadout
-  id: LoadoutPillCanisterSaline # Blood level medication
+  id: LoadoutPillCanisterIron # Blood level medication for non-arachnids
   category: GeneralMedical
-  description: reagent-desc-saline
-  cost: 2
+  description: reagent-desc-iron
+  cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
     group: LoadoutPrescriptions
   items:
-  - PillCanisterSaline
+  - PillCanisterIron
+
+- type: loadout
+  id: LoadoutPillCanisterCopper # Blood level medication for arachnid
+  category: GeneralMedical
+  description: reagent-desc-copper
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  items:
+  - PillCanisterCopper

--- a/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
@@ -272,3 +272,14 @@
   - PillCanisterSerenitolHighDose
 
 # Miscellaneous
+
+- type: loadout
+  id: LoadoutPillCanisterEthyloxyephedrine # Narcolepsy stimulant
+  category: GeneralMedical
+  description: reagent-desc-ethyloxyephedrine
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutPrescriptions
+  items:
+  - PillCanisterEthyloxyephedrine

--- a/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/Generic/Items/medicine.yml
@@ -5,6 +5,7 @@
 - type: loadout
   id: LoadoutPillCanisterAgonolexyneLowDose
   category: GeneralItems
+  description: reagent-desc-agonolexyne
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -17,6 +18,7 @@
 - type: loadout
   id: LoadoutPillCanisterAgonolexyneHighDose
   category: GeneralItems
+  description: reagent-desc-agonolexyne
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -31,6 +33,7 @@
 - type: loadout
   id: LoadoutPillCanisterSoretizoneLowDose
   category: GeneralItems
+  description: reagent-desc-soretizone
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -43,6 +46,7 @@
 - type: loadout
   id: LoadoutPillCanisterSoretizoneHighDose
   category: GeneralItems
+  description: reagent-desc-soretizone
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -57,6 +61,7 @@
 - type: loadout
   id: LoadoutPillCanisterStubantazineLowDose
   category: GeneralItems
+  description: reagent-desc-stubantazine
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -69,6 +74,7 @@
 - type: loadout
   id: LoadoutPillCanisterStubantazineHighDose
   category: GeneralItems
+  description: reagent-desc-stubantazine
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -85,6 +91,7 @@
 - type: loadout
   id: LoadoutPillCanisterEquilibrazineLowDose
   category: GeneralItems
+  description: reagent-desc-equilibrazine
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -97,6 +104,7 @@
 - type: loadout
   id: LoadoutPillCanisterEquilibrazineHighDose
   category: GeneralItems
+  description: reagent-desc-equilibrazine
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -111,6 +119,7 @@
 - type: loadout
   id: LoadoutPillCanisterTranquinaseLowDose
   category: GeneralItems
+  description: reagent-desc-tranquinase
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -123,6 +132,7 @@
 - type: loadout
   id: LoadoutPillCanisterTranquinaseHighDose
   category: GeneralItems
+  description: reagent-desc-tranquinase
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -137,6 +147,7 @@
 - type: loadout
   id: LoadoutPillCanisterCalmafluxineLowDose
   category: GeneralItems
+  description: reagent-desc-calmafluxine
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -149,6 +160,7 @@
 - type: loadout
   id: LoadoutPillCanisterCalmafluxineHighDose
   category: GeneralItems
+  description: reagent-desc-calmafluxine
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -163,6 +175,7 @@
 - type: loadout
   id: LoadoutPillCanisterPsicodine
   category: GeneralItems
+  description: reagent-desc-psicodine
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -179,6 +192,7 @@
 - type: loadout
   id: LoadoutPillCanisterBlissifyloveneLowDose
   category: GeneralItems
+  description: reagent-desc-blissifylovene
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -191,6 +205,7 @@
 - type: loadout
   id: LoadoutPillCanisterBlissifyloveneHighDose
   category: GeneralItems
+  description: reagent-desc-blissifylovene
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -205,6 +220,7 @@
 - type: loadout
   id: LoadoutPillCanisterNeurozeniumLowDose
   category: GeneralItems
+  description: reagent-desc-neurozenium
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -217,6 +233,7 @@
 - type: loadout
   id: LoadoutPillCanisterNeurozeniumHighDose
   category: GeneralItems
+  description: reagent-desc-neurozenium
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -231,6 +248,7 @@
 - type: loadout
   id: LoadoutPillCanisterSerenitolLowDose
   category: GeneralItems
+  description: reagent-desc-serenitol
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement
@@ -243,6 +261,7 @@
 - type: loadout
   id: LoadoutPillCanisterSerenitolHighDose
   category: GeneralItems
+  description: reagent-desc-serenitol
   cost: 1
   requirements:
   - !type:CharacterItemGroupRequirement

--- a/Resources/Prototypes/_DEN/Loadouts/accessibility.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/accessibility.yml
@@ -4,7 +4,7 @@
 
 - type: loadout
   id: LoadoutItemCaneWalkingColorable
-  category: GeneralItems
+  category: GeneralMedical
   cost: 0
   customColorTint: true
   requirements:
@@ -15,7 +15,7 @@
 
 - type: loadout
   id: LoadoutItemCaneWalkingAnatomical
-  category: GeneralItems
+  category: GeneralMedical
   cost: 0
   customColorTint: true
   requirements:
@@ -26,7 +26,7 @@
 
 - type: loadout
   id: LoadoutItemCaneWalkingFoldable
-  category: GeneralItems
+  category: GeneralMedical
   cost: 0
   customColorTint: true
   requirements:
@@ -37,7 +37,7 @@
 
 - type: loadout
   id: LoadoutItemCaneWalkingQuad
-  category: GeneralItems
+  category: GeneralMedical
   cost: 0
   customColorTint: true
   requirements:
@@ -48,7 +48,7 @@
 
 - type: loadout
   id: LoadoutItemWalkingCaneImp
-  category: GeneralItems
+  category: GeneralMedical
   cost: 0
   customColorTint: true
   requirements:

--- a/Resources/Prototypes/_DEN/Loadouts/items.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/items.yml
@@ -363,6 +363,7 @@
 - type: loadout
   id: LoadoutPillCanisterEstradiol
   category: GeneralMedical
+  description: reagent-desc-estradiol
   cost: 0
   items:
     - PillCanisterEstradiol
@@ -370,6 +371,7 @@
 - type: loadout
   id: LoadoutSyringeEstradiol
   category: GeneralMedical
+  description: reagent-desc-estradiol
   cost: 0
   items:
     - SyringeEstradiol
@@ -377,6 +379,7 @@
 - type: loadout
   id: LoadoutPillCanisterTestosterone
   category: GeneralMedical
+  description: reagent-desc-testosterone
   cost: 0
   items:
     - PillCanisterTestosterone
@@ -384,6 +387,7 @@
 - type: loadout
   id: LoadoutSyringeTestosterone
   category: GeneralMedical
+  description: reagent-desc-testosterone
   cost: 0
   items:
     - SyringeTestosterone

--- a/Resources/Prototypes/_DEN/Loadouts/items.yml
+++ b/Resources/Prototypes/_DEN/Loadouts/items.yml
@@ -327,7 +327,7 @@
 
 - type: loadout
   id: LoadoutSyringe
-  category: GeneralItems
+  category: GeneralMedical
   cost: 1
   items:
     - Syringe
@@ -362,35 +362,35 @@
 #Medications
 - type: loadout
   id: LoadoutPillCanisterEstradiol
-  category: GeneralItems
+  category: GeneralMedical
   cost: 0
   items:
     - PillCanisterEstradiol
 
 - type: loadout
   id: LoadoutSyringeEstradiol
-  category: GeneralItems
+  category: GeneralMedical
   cost: 0
   items:
     - SyringeEstradiol
 
 - type: loadout
   id: LoadoutPillCanisterTestosterone
-  category: GeneralItems
+  category: GeneralMedical
   cost: 0
   items:
     - PillCanisterTestosterone
 
 - type: loadout
   id: LoadoutSyringeTestosterone
-  category: GeneralItems
+  category: GeneralMedical
   cost: 0
   items:
     - SyringeTestosterone
 
 - type: loadout
   id: LoadoutBirthControlCanister
-  category: GeneralItems
+  category: GeneralMedical
   cost: 0
   items:
     - BirthControlCanister

--- a/Resources/Prototypes/_DEN/Mood/drugs.yml
+++ b/Resources/Prototypes/_DEN/Mood/drugs.yml
@@ -1,0 +1,68 @@
+# Some non-addictive moodlets for certain drug chemicals. These indicate to the player that some kind of
+# medication has been in their blood stream lately, so they're quite low impact. The actual reason these
+# exist is to encourage players to space out their medication doses instead of popping pills back to back.
+
+- type: moodCategory
+  id: NonAddictiveAntidepressant
+
+- type: moodCategory
+  id: NonAddictiveAnxiolytic # Did you know this is what anxiety reducing meds are called
+
+- type: moodCategory
+  id: NonAddictivePainKiller
+
+# Antidepressants
+
+- type: moodEffect
+  id: AntidepressantBenefitNonAddictive
+  category: NonAddictiveAntidepressant
+  moodChange: 1
+  timeout: 420 #7 minutes
+
+- type: moodEffect
+  id: AntidepressantBenefitStrongNonAddictive
+  category: NonAddictiveAntidepressant
+  moodChange: 3
+  timeout: 720 #12 minutes
+
+# Anxiolytics
+
+- type: moodEffect
+  id: AnxiolyticBenefitNonAddictive
+  category: NonAddictiveAnxiolytic
+  moodChange: 1
+  timeout: 420 #7 minutes
+
+- type: moodEffect
+  id: AnxiolyticBenefitTranquilNonAddictive
+  category: NonAddictiveAnxiolytic
+  moodChange: 2
+  timeout: 720 #12 minutes
+
+- type: moodEffect
+  id: AnxiolyticBenefitStrongNonAddictive
+  category: NonAddictiveAnxiolytic
+  moodletOnEnd: AnxiolyticBenefitNonAddictive # For a total of 12 minutes
+  moodChange: 2
+  timeout: 300 #5 minutes
+
+# Painkillers
+
+- type: moodEffect
+  id: PainRelief
+  category: NonAddictivePainKiller
+  moodChange: 1
+  timeout: 420 #7 minutes
+
+- type: moodEffect
+  id: PainReliefStrong
+  category: NonAddictivePainKiller
+  moodChange: 1
+  timeout: 420 #7 minutes
+
+- type: moodEffect
+  id: PainReliefVeryStrong
+  category: NonAddictivePainKiller
+  moodletOnEnd: PainRelief # For a total of 14 minutes
+  moodChange: 1
+  timeout: 420 #7 minutes


### PR DESCRIPTION
## About the PR
This PR adds a bunch of pill canisters for various common prescription meds (especially the ones from #708) to player loadouts. These canisters are sorted into a new "Medical" loadout category, and a handful of other medically-themed loadout items were also moved to this category.

Meds added to loadout include:
- Painkillers (agonolexyne, soretizone, stubantazine)
- Anxiolytics/anxiety meds (equilibrazine, tranquinase, calmafluxine, psicodine)
- Antidepressants (blissifylovene, neurozenium, serenitol).
- Ethyloxyephedrine (narcolepsy stimulant)
- Iron and copper (blood deficiency medication)

For all of these loadouts, there are 5 pills per can, except for calmafluxine, which has 10 pills per can. Each of these, for the most part, have two dose levels: "high" and "low" dose. Higher-dose canisters generally cost a little more in the loadout.

In addition, a majority of these chemicals were given new moodlets to represent their effects, which last 5 to 17 minutes after the chemical runs out from your blood stream. This is to encourage players to space out their doses instead of taking all of their meds back-to-back. These moodlets are "non-addictive", so they do not result in negative effects after they run out.

## Why / Balance
These are all medications that players can have good roleplay reason to have prescribed and administered out of station. Adding them to loadouts allows these players to have these things roundstart without needing to bug chemistry for them, per se... however, there _are_ only 5 pills per can, so players may still hit up chemistry for a refill, so as to not completely eliminate that roleplay potential.

I took this opportunity to move medical items into a new loadout category, as we're finally accumulating a decent amount of medically-themed items.

~~A concern was brought up in the direction thread for this that giving people roundstart saline may remove RP, but I imagine at such a low dose (each pill only restoring 20% blood) they would run out pretty quick anyway.~~ I decided to change this to iron/copper instead, which restores a lot less blood anyway.

## Technical details
A lot of new pill and pill canister prototype definitions. This also includes saline pills/canisters, which are not added to loadouts but they exist now anyway.

The `LoadoutPrototype` class was extended to take any LocId for the name/description in the UI, which I used to make the pill cans use their reagent description for the loadout selector.

New loadouts and a new loadout category. 

Loadouts are generally 1 point for low-dose meds, and 2 points for high-dose. Higher-severity meds are 2 points low / 3 points high instead, and calmafluxine + serenitol are 1/1 points because of their low severity. You can take up to 2 prescription meds, and you can only take 1 per category.

## Media

Loadouts:

<img width="1047" height="603" alt="image" src="https://github.com/user-attachments/assets/86efd520-eead-4a3a-b49f-ab93d361218e" />

Moodlets:

<img width="377" height="93" alt="image" src="https://github.com/user-attachments/assets/8ebc38fe-ad27-4a36-b63d-f8331e6e8944" />

<img width="371" height="95" alt="image" src="https://github.com/user-attachments/assets/027e09ad-66f1-4b05-80ab-474c2596daf2" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
A handful of loadouts had their categories changed. A lot of these chems no longer have "fade" messages, instead replacing it with new moodlets.

**Changelog**
:cl:
- add: Various pill canisters can now be selected in Loadouts. These include painkillers (agonolexyne, soretizone, stubantazine), anxiety meds (equilibrazine, tranquinase, calmafluxine, psicodine), antidepressants (blissifylovene, neurozenium, serenitol), ethyloxyephedrine (narcolepsy stimulant), iron, and copper.
- add: A lot of the aforementioned (psychological) medications now have moodlets to indicate their effects, rather than telling you when they fade. Remember - you can click the "mood" face icon on your HUD to view all your active moodlets.
- tweak: A handful of medical-themed loadout items (accessibility tools, medication, and first aid namely) have been moved to a new Medical loadout category under Items.
- tweak: Estradiol and testosterone in Loadouts now use the same description as their respective reagents.