### PR TITLE
Generic (Loadout) Clothing Printer

### DIFF
--- a/Resources/Locale/en-US/_DEN/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/_DEN/lathe/lathe-categories.ftl
@@ -7,6 +7,7 @@ lathe-category-towel = Towels
 lathe-category-assistance-devices = Assistance Devices
 lathe-category-carpet = Carpets
 lathe-category-colored-uniforms = Colored Uniforms
+lathe-category-envirosuits = Envirosuits
 lathe-category-loadout-jumpsuits = Cosmetic Uniforms
 lathe-category-loadout-dresses = Dresses
 lathe-category-hygiene-products = Hygiene Products

--- a/Resources/Locale/en-US/_DEN/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/_DEN/lathe/lathe-categories.ftl
@@ -5,6 +5,5 @@
 
 lathe-category-towel = Towels
 lathe-category-assistance-devices = Assistance Devices
+lathe-category-carpet = Carpets
 lathe-category-hygiene-products = Hygiene Products
-
-

--- a/Resources/Locale/en-US/_DEN/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/_DEN/lathe/lathe-categories.ftl
@@ -7,3 +7,4 @@ lathe-category-towel = Towels
 lathe-category-assistance-devices = Assistance Devices
 lathe-category-carpet = Carpets
 lathe-category-hygiene-products = Hygiene Products
+lathe-category-colored-uniforms = Uniform Colors

--- a/Resources/Locale/en-US/_DEN/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/_DEN/lathe/lathe-categories.ftl
@@ -7,4 +7,6 @@ lathe-category-towel = Towels
 lathe-category-assistance-devices = Assistance Devices
 lathe-category-carpet = Carpets
 lathe-category-colored-uniforms = Colored Uniforms
+lathe-category-loadout-jumpsuits = Cosmetic Uniforms
+lathe-category-loadout-dresses = Dresses
 lathe-category-hygiene-products = Hygiene Products

--- a/Resources/Locale/en-US/_DEN/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/_DEN/lathe/lathe-categories.ftl
@@ -6,5 +6,5 @@
 lathe-category-towel = Towels
 lathe-category-assistance-devices = Assistance Devices
 lathe-category-carpet = Carpets
+lathe-category-colored-uniforms = Colored Uniforms
 lathe-category-hygiene-products = Hygiene Products
-lathe-category-colored-uniforms = Uniform Colors

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -110,18 +110,14 @@
 ## Recipes
 # Jumpsuits/skirts
 - type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe # DEN - Add inheritance
   id: ClothingUniformJumpsuitColorGrey # Tide
   result: ClothingUniformJumpsuitColorGrey
-  completetime: 4
-  materials:
-    Cloth: 300
 
 - type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe # DEN - Add inheritance
   id: ClothingUniformJumpskirtColorGrey
   result: ClothingUniformJumpskirtColorGrey
-  completetime: 4
-  materials:
-    Cloth: 300
 
 - type: latheRecipe
   id: ClothingUniformJumpsuitBartender
@@ -547,11 +543,9 @@
     Cloth: 300
 
 - type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe # DEN - Add inheritance
   id: ClothingUniformJumpskirtColorLightBrown #Librarian
   result: ClothingUniformJumpskirtColorLightBrown
-  completetime: 4
-  materials:
-    Cloth: 300
 
 - type: latheRecipe
   id: ClothingUniformJumpsuitMedicalDoctor

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -1384,69 +1384,52 @@
   completetime: 2
   materials:
     Cloth: 200
+
 # Carpets
 - type: latheRecipe
+  parent: CarpetBase # DEN - Add inheritance for category / material consistency
   id: Carpet
   result: FloorCarpetItemRed
-  completetime: 1
-  materials:
-    Cloth: 100
 
 - type: latheRecipe
+  parent: CarpetBase # DEN - Add inheritance for category / material consistency
   id: CarpetBlack
   result: FloorCarpetItemBlack
-  completetime: 1
-  materials:
-    Cloth: 100
 
 - type: latheRecipe
+  parent: CarpetBase # DEN - Add inheritance for category / material consistency
   id: CarpetPink
   result: FloorCarpetItemPink
-  completetime: 1
-  materials:
-    Cloth: 100
 
 - type: latheRecipe
+  parent: CarpetBase # DEN - Add inheritance for category / material consistency
   id: CarpetBlue
   result: FloorCarpetItemBlue
-  completetime: 1
-  materials:
-    Cloth: 100
 
 - type: latheRecipe
+  parent: CarpetBase # DEN - Add inheritance for category / material consistency
   id: CarpetGreen
   result: FloorCarpetItemGreen
-  completetime: 1
-  materials:
-    Cloth: 100
 
 - type: latheRecipe
+  parent: CarpetBase # DEN - Add inheritance for category / material consistency
   id: CarpetOrange
   result: FloorCarpetItemOrange
-  completetime: 1
-  materials:
-    Cloth: 100
 
 - type: latheRecipe
+  parent: CarpetBase # DEN - Add inheritance for category / material consistency
   id: CarpetPurple
   result: FloorCarpetItemPurple
-  completetime: 1
-  materials:
-    Cloth: 100
 
 - type: latheRecipe
+  parent: CarpetBase # DEN - Add inheritance for category / material consistency
   id: CarpetCyan
   result: FloorCarpetItemCyan
-  completetime: 1
-  materials:
-    Cloth: 100
 
 - type: latheRecipe
+  parent: CarpetBase # DEN - Add inheritance for category / material consistency
   id: CarpetWhite
   result: FloorCarpetItemWhite
-  completetime: 1
-  materials:
-    Cloth: 100
 
 # Floofstation - Collars
 - type: latheRecipe

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -1387,47 +1387,47 @@
 
 # Carpets
 - type: latheRecipe
-  parent: CarpetBase # DEN - Add inheritance for category / material consistency
+  parent: BaseCarpetRecipe # DEN - Add inheritance for category / material consistency
   id: Carpet
   result: FloorCarpetItemRed
 
 - type: latheRecipe
-  parent: CarpetBase # DEN - Add inheritance for category / material consistency
+  parent: BaseCarpetRecipe # DEN - Add inheritance for category / material consistency
   id: CarpetBlack
   result: FloorCarpetItemBlack
 
 - type: latheRecipe
-  parent: CarpetBase # DEN - Add inheritance for category / material consistency
+  parent: BaseCarpetRecipe # DEN - Add inheritance for category / material consistency
   id: CarpetPink
   result: FloorCarpetItemPink
 
 - type: latheRecipe
-  parent: CarpetBase # DEN - Add inheritance for category / material consistency
+  parent: BaseCarpetRecipe # DEN - Add inheritance for category / material consistency
   id: CarpetBlue
   result: FloorCarpetItemBlue
 
 - type: latheRecipe
-  parent: CarpetBase # DEN - Add inheritance for category / material consistency
+  parent: BaseCarpetRecipe # DEN - Add inheritance for category / material consistency
   id: CarpetGreen
   result: FloorCarpetItemGreen
 
 - type: latheRecipe
-  parent: CarpetBase # DEN - Add inheritance for category / material consistency
+  parent: BaseCarpetRecipe # DEN - Add inheritance for category / material consistency
   id: CarpetOrange
   result: FloorCarpetItemOrange
 
 - type: latheRecipe
-  parent: CarpetBase # DEN - Add inheritance for category / material consistency
+  parent: BaseCarpetRecipe # DEN - Add inheritance for category / material consistency
   id: CarpetPurple
   result: FloorCarpetItemPurple
 
 - type: latheRecipe
-  parent: CarpetBase # DEN - Add inheritance for category / material consistency
+  parent: BaseCarpetRecipe # DEN - Add inheritance for category / material consistency
   id: CarpetCyan
   result: FloorCarpetItemCyan
 
 - type: latheRecipe
-  parent: CarpetBase # DEN - Add inheritance for category / material consistency
+  parent: BaseCarpetRecipe # DEN - Add inheritance for category / material consistency
   id: CarpetWhite
   result: FloorCarpetItemWhite
 

--- a/Resources/Prototypes/_DEN/Entities/Objects/Devices/Circuitboards/Machines/production.yml
+++ b/Resources/Prototypes/_DEN/Entities/Objects/Devices/Circuitboards/Machines/production.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: AutotailorMachineCircuitboard
+  parent: BaseMachineCircuitboard
+  name: autotailor machine board
+  components:
+  - type: MachineBoard
+    prototype: UniformPrinter
+    requirements:
+      MatterBin: 1
+      Manipulator: 2

--- a/Resources/Prototypes/_DEN/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DEN/Entities/Structures/Machines/lathe.yml
@@ -1,0 +1,32 @@
+- type: entity
+  parent: [BaseLathe, BaseMaterialSiloUtilizer]
+  id: Autotailor
+  name: autotailor
+  description: Produces new, non-job specific clothing and accessories with the press of a button.
+  components:
+  - type: Transform
+    noRot: false
+  - type: Sprite
+    sprite: Structures/Machines/uniform_printer.rsi
+    snapCardinals: false
+    layers:
+    - state: icon
+      map: ["enum.LatheVisualLayers.IsRunning"]
+  - type: Machine
+    board: AutotailorMachineCircuitboard
+  - type: Lathe
+    producingSound: /Audio/Machines/uniformprinter.ogg
+    idleState: icon
+    runningState: building
+    staticPacks:
+    - AutotailorStaticDen
+  - type: MaterialStorage
+    whitelist:
+      tags:
+      - Sheet
+      - RawMaterial
+      - Ingot
+      - Wooden
+      - ClothMade
+      - Gauze
+      - Metal

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
@@ -20,6 +20,8 @@
 - type: latheRecipePack
   id: AutotailorStaticBasicJumpsuits
   recipes:
+  - ClothingUniformJumpsuitColorGrey
+  - ClothingUniformJumpskirtColorGrey
   - ClothingUniformJumpsuitColorWhite
   - ClothingUniformJumpskirtColorWhite
   - ClothingUniformJumpsuitColorBlack

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
@@ -8,6 +8,7 @@
 - type: latheRecipePack
   parent:
   - AutotailorStaticEnvirohelms
+  - AutotailorStaticEnviroslacksHelms
   id: AutotailorStaticHead
 
 - type: latheRecipePack
@@ -15,6 +16,7 @@
   - AutotailorStaticBasicJumpsuits
   - AutotailorStaticDresses
   - AutotailorStaticEnvirosuits
+  - AutotailorStaticEnviroslacks
   - AutotailorStaticGenericUniforms
   - AutotailorStaticKimonos
   - AutotailorStaticNuclearUniforms
@@ -249,6 +251,8 @@
   - ClothingUniformSwimsuitBlue
   - ClothingUniformDressRed
 
+## Envirosuits
+
 - type: latheRecipePack
   id: AutotailorStaticEnvirosuits
   recipes:
@@ -278,6 +282,19 @@
   - ClothingUniformEnvirosuitColorBrown
 
 - type: latheRecipePack
+  id: AutotailorStaticEnviroslacks
+  recipes:
+  - ClothingUniformEnvirosuitEnviroslacks
+  - ClothingUniformEnvirosuitEnviroslacksNegative
+  - ClothingUniformEnvirosuitEnviroslacksColorRed
+  - ClothingUniformEnvirosuitEnviroslacksColorOrange
+  - ClothingUniformEnvirosuitEnviroslacksColorGreen
+  - ClothingUniformEnvirosuitEnviroslacksColorBlue
+  - ClothingUniformEnvirosuitEnviroslacksColorBrown
+  - ClothingUniformEnvirosuitEnviroslacksMNK
+  - ClothingUniformEnvirosuitEnviroslacksMNKAlt
+
+- type: latheRecipePack
   id: AutotailorStaticEnvirohelms
   recipes:
   - ClothingHeadEnvirohelm
@@ -303,3 +320,13 @@
   - ClothingHeadEnvirohelmColorOrange
   - ClothingHeadEnvirohelmColorLightBrown
   - ClothingHeadEnvirohelmColorBrown
+
+- type: latheRecipePack
+  id: AutotailorStaticEnviroslacksHelms
+  recipes:
+  - ClothingHeadEnvirohelmEnviroslacksColorRed
+  - ClothingHeadEnvirohelmEnviroslacksColorOrange
+  - ClothingHeadEnvirohelmEnviroslacksColorGreen
+  - ClothingHeadEnvirohelmEnviroslacksColorBlue
+  - ClothingHeadEnvirohelmEnviroslacksMNK
+  - ClothingHeadEnvirohelmEnviroslacksMNKAlt

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
@@ -1,13 +1,20 @@
 - type: latheRecipePack
   parent:
   - AutotailorStaticCarpets
+  - AutotailorStaticHead
   - AutotailorStaticUniforms
   id: AutotailorStaticDen
 
 - type: latheRecipePack
   parent:
+  - AutotailorStaticEnvirohelms
+  id: AutotailorStaticHead
+
+- type: latheRecipePack
+  parent:
   - AutotailorStaticBasicJumpsuits
   - AutotailorStaticDresses
+  - AutotailorStaticEnvirosuits
   - AutotailorStaticGenericUniforms
   - AutotailorStaticKimonos
   - AutotailorStaticNuclearUniforms
@@ -241,3 +248,58 @@
   - ClothingUniformJumpskirtYellowTurtleneckDress
   - ClothingUniformSwimsuitBlue
   - ClothingUniformDressRed
+
+- type: latheRecipePack
+  id: AutotailorStaticEnvirosuits
+  recipes:
+  - ClothingUniformEnvirosuit
+  - ClothingUniformEnvirosuitBlackPink
+  - ClothingUniformEnvirosuitBlackPinkAlt
+  - ClothingUniformEnvirosuitMartialGi
+  - ClothingUniformEnvirosuitSafari
+  - ClothingUniformEnvirosuitTrans
+  - ClothingUniformEnvirosuitAncientVoid
+  - ClothingHeadEnvirohelmAncientVoid
+  - ClothingUniformEnvirosuitColorWhite
+  - ClothingUniformEnvirosuitColorGrey
+  - ClothingUniformEnvirosuitColorBlack
+  - ClothingUniformEnvirosuitColorRed
+  - ClothingUniformEnvirosuitColorGreen
+  - ClothingUniformEnvirosuitColorDarkGreen
+  - ClothingUniformEnvirosuitColorBlue
+  - ClothingUniformEnvirosuitColorDarkBlue
+  - ClothingUniformEnvirosuitColorTeal
+  - ClothingUniformEnvirosuitColorMaroon
+  - ClothingUniformEnvirosuitColorPink
+  - ClothingUniformEnvirosuitColorYellow
+  - ClothingUniformEnvirosuitColorPurple
+  - ClothingUniformEnvirosuitColorOrange
+  - ClothingUniformEnvirosuitColorLightBrown
+  - ClothingUniformEnvirosuitColorBrown
+
+- type: latheRecipePack
+  id: AutotailorStaticEnvirohelms
+  recipes:
+  - ClothingHeadEnvirohelm
+  - ClothingHeadEnvirohelmBlackPink
+  - ClothingHeadEnvirohelmBlackPinkAlt
+  - ClothingHeadEnvirohelmMartialGi
+  - ClothingHeadEnvirohelmSafari
+  - ClothingHeadEnvirohelmTrans
+  - ClothingHeadEnvirohelmAncientVoid
+  - ClothingHeadEnvirohelmColorWhite
+  - ClothingHeadEnvirohelmColorGrey
+  - ClothingHeadEnvirohelmColorBlack
+  - ClothingHeadEnvirohelmColorRed
+  - ClothingHeadEnvirohelmColorGreen
+  - ClothingHeadEnvirohelmColorDarkGreen
+  - ClothingHeadEnvirohelmColorBlue
+  - ClothingHeadEnvirohelmColorDarkBlue
+  - ClothingHeadEnvirohelmColorTeal
+  - ClothingHeadEnvirohelmColorMaroon
+  - ClothingHeadEnvirohelmColorPink
+  - ClothingHeadEnvirohelmColorYellow
+  - ClothingHeadEnvirohelmColorPurple
+  - ClothingHeadEnvirohelmColorOrange
+  - ClothingHeadEnvirohelmColorLightBrown
+  - ClothingHeadEnvirohelmColorBrown

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
@@ -10,6 +10,7 @@
   - AutotailorStaticDresses
   - AutotailorStaticGenericUniforms
   - AutotailorStaticKimonos
+  - AutotailorStaticNuclearUniforms
   - AutotailorStaticSchoolUniforms
   - AutotailorStaticSuits
   id: AutotailorStaticUniforms
@@ -89,6 +90,50 @@
   - ClothingUniformJumpsuitHawaiBlue
   - ClothingUniformJumpsuitHawaiRed
   - ClothingUniformJumpsuitHawaiYellow
+  - ClothingUniformJumpsuitSuitAmish
+  - ClothingUniformJumpsuitSuitAristocratic
+  - ClothingUniformJumpsuitSuitAristocraticTuxedo
+  - ClothingUniformJumpsuitAscetic
+  - ClothingUniformJumpsuitBarber
+  - ClothingUniformJumpsuitSuitBlueBlazer
+  - ClothingUniformJumpsuitDisheveled
+  - ClothingUniformJumpsuitSuitRegal
+  - ClothingUniformJumpsuitSuitRegalTuxedo
+  - ClothingUniformJumpsuitRippedPunk
+  - ClothingUniformJumpsuitSailor
+  - ClothingUniformJumpsuitSuitStriped
+  - ClothingUniformJumpsuitTrackpants
+  - ClothingUniformJumpsuitTurtleneckGrey
+  - ClothingUniformJumpsuitSuitVictorianRedBlack
+  - ClothingUniformJumpsuitSuitVictorianRedVest
+  - ClothingUniformJumpsuitSuitVictorianVest
+  - ClothingUniformJumpsuitWaiter
+  - ClothingUniformJumpskirtWaitress
+  - ClothingUniformJumpsuitYogaGymBra
+  - ClothingUniformJumpsuitBlackTurtleneck
+  - ClothingUniformJumpsuitBlackTurtleneckFlipped
+  # These might be from N14, but it's hard to tell due to bad namespacing.
+  - ClothingUniformJumpsuitCheckered
+  - ClothingUniformJumpsuitCowboyBrown
+  - ClothingUniformJumpsuitCowboyGrey
+  - ClothingUniformJumpsuitOliveSweater
+  - ClothingUniformJumpsuitLightBlueShirt
+  - ClothingUniformJumpsuitFlannelJeans
+  - ClothingUniformJumpsuitFlannelBlackJeans
+  - ClothingUniformJumpsuitFlannelKhakis
+  - ClothingUniformJumpsuitFlannelBlackKhakis
+  # End possibly N14 list items.
+
+- type: latheRecipePack
+  id: AutotailorStaticNuclearUniforms
+  recipes:
+  - ClothingUniformJumpsuitSuitRolledSleeves
+  - ClothingUniformJumpsuitBartenderGrey
+  - ClothingUniformJumpsuitFlannelOveralls
+  - ClothingUniformJumpsuitCamouflageShirt
+  - ClothingUniformJumpsuitDesertUniform
+  - ClothingUniformJumpsuitLumberjack
+  - ClothingUniformJumpsuitGreyShirt
 
 - type: latheRecipePack
   id: AutotailorStaticKimonos
@@ -192,7 +237,6 @@
   - ClothingUniformJumpskirtRedTurtleneckDress
   - ClothingUniformJumpskirtSailor
   - ClothingUniformJumpskirtSuitBlueBlazer
-  - ClothingUniformJumpskirtWaitress
   - ClothingUniformJumpskirtYellowOldDress
   - ClothingUniformJumpskirtYellowTurtleneckDress
   - ClothingUniformSwimsuitBlue

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
@@ -1,0 +1,53 @@
+- type: latheRecipePack
+  parent:
+  - AutotailorStaticBasicJumpsuits
+  - AutotailorStaticCarpets
+  id: AutotailorStaticDen
+
+- type: latheRecipePack
+  id: AutotailorStaticCarpets
+  recipes:
+  - Carpet
+  - CarpetBlack
+  - CarpetPink
+  - CarpetBlue
+  - CarpetGreen
+  - CarpetOrange
+  - CarpetPurple
+  - CarpetCyan
+  - CarpetWhite
+
+- type: latheRecipePack
+  id: AutotailorStaticBasicJumpsuits
+  recipes:
+  - ClothingUniformJumpsuitColorWhite
+  - ClothingUniformJumpskirtColorWhite
+  - ClothingUniformJumpsuitColorBlack
+  - ClothingUniformJumpskirtColorBlack
+  - ClothingUniformJumpsuitColorBlue
+  - ClothingUniformJumpskirtColorBlue
+  - ClothingUniformJumpsuitColorDarkBlue
+  - ClothingUniformJumpskirtColorDarkBlue
+  - ClothingUniformJumpsuitColorTeal
+  - ClothingUniformJumpskirtColorTeal
+  - ClothingUniformJumpsuitColorGreen
+  - ClothingUniformJumpskirtColorGreen
+  - ClothingUniformJumpsuitColorDarkGreen
+  - ClothingUniformJumpskirtColorDarkGreen
+  - ClothingUniformJumpsuitColorOrange
+  - ClothingUniformJumpskirtColorOrange
+  - ClothingUniformJumpsuitColorPink
+  - ClothingUniformJumpskirtColorPink
+  - ClothingUniformJumpsuitColorRed
+  - ClothingUniformJumpskirtColorRed
+  - ClothingUniformJumpsuitColorYellow
+  - ClothingUniformJumpskirtColorYellow
+  - ClothingUniformJumpsuitColorPurple
+  - ClothingUniformJumpskirtColorPurple
+  - ClothingUniformJumpsuitColorLightBrown
+  - ClothingUniformJumpskirtColorLightBrown
+  - ClothingUniformJumpsuitColorBrown
+  - ClothingUniformJumpskirtColorBrown
+  - ClothingUniformJumpsuitColorMaroon
+  - ClothingUniformJumpskirtColorMaroon
+  - ClothingUniformColorRainbow

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
@@ -153,7 +153,6 @@
   - ClothingUniformJumpskirtDressFlamenco
   - ClothingUniformJumpskirtDressFlowergirl
   - ClothingUniformJumpskirtDressFluffy
-  - ClothingUniformJumpskirtDressFluffy
   - ClothingUniformJumpskirtDressFormalRed
   - ClothingUniformJumpskirtDressGothic
   - ClothingUniformJumpskirtDressLacyGown
@@ -182,7 +181,7 @@
   - ClothingUniformJumpskirtGreenTurtleneckDress
   - ClothingUniformJumpskirtOrangeStripedDress
   - ClothingUniformJumpskirtPencilSkirtGymBra
-  - ClothingUniformJumpskirtPencilSkirtGymBra
+  - ClothingUniformJumpskirtDressPuffy
   - ClothingUniformJumpskirtPinkStripedDress
   - ClothingUniformJumpskirtPurpleElegantDress
   - ClothingUniformJumpskirtPurpleTurtleneckDress

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
@@ -1,8 +1,18 @@
 - type: latheRecipePack
   parent:
-  - AutotailorStaticBasicJumpsuits
   - AutotailorStaticCarpets
+  - AutotailorStaticUniforms
   id: AutotailorStaticDen
+
+- type: latheRecipePack
+  parent:
+  - AutotailorStaticBasicJumpsuits
+  - AutotailorStaticDresses
+  - AutotailorStaticSchoolUniforms
+  - AutotailorStaticSuits
+  id: AutotailorStaticUniforms
+
+## Carpets
 
 - type: latheRecipePack
   id: AutotailorStaticCarpets
@@ -16,6 +26,8 @@
   - CarpetPurple
   - CarpetCyan
   - CarpetWhite
+
+## Uniforms
 
 - type: latheRecipePack
   id: AutotailorStaticBasicJumpsuits
@@ -53,3 +65,101 @@
   - ClothingUniformJumpsuitColorMaroon
   - ClothingUniformJumpskirtColorMaroon
   - ClothingUniformColorRainbow
+
+- type: latheRecipePack
+  id: AutotailorStaticSchoolUniforms
+  recipes:
+  - ClothingUniformSchoolGakuranBlack
+  - UniformSchoolgirlBlack
+  - UniformSchoolgirlBlue
+  - UniformSchoolgirlCyan
+  - UniformSchoolgirlGreen
+  - UniformSchoolgirlOrange
+  - UniformSchoolgirlPink
+  - UniformSchoolgirlPurple
+  - UniformSchoolgirlRed
+  - UniformSchoolgirlDusk
+  - UniformSchoolgirlBlazerTan
+
+- type: latheRecipePack
+  id: AutotailorStaticSuits
+  recipes:
+  - ClothingUniformJumpsuitSuitBlack
+  - ClothingUniformJumpsuitSuitBlackAlt
+  - ClothingUniformJumpsuitSuitBlackMob
+  - ClothingUniformJumpsuitSuitBrown
+  - ClothingUniformJumpsuitSuitBrownAlt
+  - ClothingUniformJumpsuitSuitBrownMob
+  - ClothingUniformJumpsuitSuitWhite
+  - ClothingUniformJumpsuitSuitWhiteAlt
+  - ClothingUniformJumpsuitSuitWhiteMob
+
+- type: latheRecipePack
+  id: AutotailorStaticDresses
+  recipes:
+  - ClothingUniformJumpskirtBlackElegantDress
+  - ClothingUniformJumpskirtBlueElegantDress
+  - ClothingUniformJumpskirtBlueTurtleneckDress
+  - ClothingUniformJumpskirtCyanStripedDress
+  - ClothingUniformJumpskirtDressAsymmetric
+  - ClothingUniformJumpskirtDressBlackAndGold
+  - ClothingUniformJumpskirtDressBlackTango
+  - ClothingUniformJumpskirtDressBlackTangoAlt
+  - ClothingUniformJumpskirtDressBlueSundress
+  - ClothingUniformJumpskirtDressCheongsamBlue
+  - ClothingUniformJumpskirtDressCheongsamGreen
+  - ClothingUniformJumpskirtDressCheongsamPurple
+  - ClothingUniformJumpskirtDressCheongsamRed
+  - ClothingUniformJumpskirtDressCheongsamWhite
+  - ClothingUniformJumpskirtDressClub
+  - ClothingUniformJumpskirtDressCoveter
+  - ClothingUniformJumpskirtDressEvening
+  - ClothingUniformJumpskirtDressFire
+  - ClothingUniformJumpskirtDressFlamenco
+  - ClothingUniformJumpskirtDressFlowergirl
+  - ClothingUniformJumpskirtDressFluffy
+  - ClothingUniformJumpskirtDressFluffy
+  - ClothingUniformJumpskirtDressFormalRed
+  - ClothingUniformJumpskirtDressGothic
+  - ClothingUniformJumpskirtDressLacyGown
+  - ClothingUniformJumpskirtDressLong
+  - ClothingUniformJumpskirtDressLongFlared
+  - ClothingUniformJumpskirtDressLongSleeve
+  - ClothingUniformJumpskirtDressMidi
+  - ClothingUniformJumpskirtDressOpenShoulder
+  - ClothingUniformJumpskirtDressOrange
+  - ClothingUniformJumpskirtDressRedSwept
+  - ClothingUniformJumpskirtDressSariGreen
+  - ClothingUniformJumpskirtDressSariRed
+  - ClothingUniformJumpskirtDressShort
+  - ClothingUniformJumpskirtDressSleeveless
+  - ClothingUniformJumpskirtDressSpider
+  - ClothingUniformJumpskirtDressStriped
+  - ClothingUniformJumpskirtDressSundress
+  - ClothingUniformJumpskirtDressSundressWhite
+  - ClothingUniformJumpskirtDressTea
+  - ClothingUniformJumpskirtDressVictorianBlack
+  - ClothingUniformJumpskirtDressVictorianRed
+  - ClothingUniformJumpskirtDressYellow
+  - ClothingUniformJumpskirtDressYellowSwoop
+  - ClothingUniformJumpskirtGreenElegantDress
+  - ClothingUniformJumpskirtGreenStripedDress
+  - ClothingUniformJumpskirtGreenTurtleneckDress
+  - ClothingUniformJumpskirtKimonoColor
+  - ClothingUniformJumpskirtOrangeStripedDress
+  - ClothingUniformJumpskirtPencilSkirtGymBra
+  - ClothingUniformJumpskirtPencilSkirtGymBra
+  - ClothingUniformJumpskirtPinkStripedDress
+  - ClothingUniformJumpskirtPurpleElegantDress
+  - ClothingUniformJumpskirtPurpleTurtleneckDress
+  - ClothingUniformJumpskirtQipao
+  - ClothingUniformJumpskirtQipaoSlim
+  - ClothingUniformJumpskirtRedElegantDress
+  - ClothingUniformJumpskirtRedStripedDress
+  - ClothingUniformJumpskirtRedTurtleneckDress
+  - ClothingUniformJumpskirtSailor
+  - ClothingUniformJumpskirtSuitBlueBlazer
+  - ClothingUniformJumpskirtWaitress
+  - ClothingUniformJumpskirtYellowOldDress
+  - ClothingUniformJumpskirtYellowTurtleneckDress
+  - ClothingUniformSwimsuitBlue

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/autotailor.yml
@@ -8,6 +8,8 @@
   parent:
   - AutotailorStaticBasicJumpsuits
   - AutotailorStaticDresses
+  - AutotailorStaticGenericUniforms
+  - AutotailorStaticKimonos
   - AutotailorStaticSchoolUniforms
   - AutotailorStaticSuits
   id: AutotailorStaticUniforms
@@ -65,6 +67,39 @@
   - ClothingUniformJumpsuitColorMaroon
   - ClothingUniformJumpskirtColorMaroon
   - ClothingUniformColorRainbow
+
+- type: latheRecipePack
+  id: AutotailorStaticGenericUniforms
+  recipes:
+  - ClothingUniformJumpsuitFlannel
+  - ClothingUniformJumpsuitCasualBlue
+  - ClothingUniformJumpskirtCasualBlue
+  - ClothingUniformJumpsuitCasualPurple
+  - ClothingUniformJumpskirtCasualPurple
+  - ClothingUniformJumpsuitCasualRed
+  - ClothingUniformJumpskirtCasualRed
+  - ClothingUniformJumpsuitTshirtJeans
+  - ClothingUniformJumpsuitTshirtJeansGray
+  - ClothingUniformJumpsuitTshirtJeansPeach
+  - ClothingUniformJumpsuitJeansGreen
+  - ClothingUniformJumpsuitJeansRed
+  - ClothingUniformJumpsuitJeansBrown
+  - ClothingUniformJumpsuitLostTourist
+  - ClothingUniformJumpsuitHawaiBlack
+  - ClothingUniformJumpsuitHawaiBlue
+  - ClothingUniformJumpsuitHawaiRed
+  - ClothingUniformJumpsuitHawaiYellow
+
+- type: latheRecipePack
+  id: AutotailorStaticKimonos
+  recipes:
+  - ClothingUniformJumpskirtKimonoColor
+  - ClothingUniformJumpsuitKimono
+  - ClothingKimonoBlue
+  - ClothingKimonoPink
+  - ClothingKimonoPurple
+  - ClothingKimonoSky
+  - ClothingKimonoGreen
 
 - type: latheRecipePack
   id: AutotailorStaticSchoolUniforms
@@ -145,7 +180,6 @@
   - ClothingUniformJumpskirtGreenElegantDress
   - ClothingUniformJumpskirtGreenStripedDress
   - ClothingUniformJumpskirtGreenTurtleneckDress
-  - ClothingUniformJumpskirtKimonoColor
   - ClothingUniformJumpskirtOrangeStripedDress
   - ClothingUniformJumpskirtPencilSkirtGymBra
   - ClothingUniformJumpskirtPencilSkirtGymBra
@@ -163,3 +197,4 @@
   - ClothingUniformJumpskirtYellowOldDress
   - ClothingUniformJumpskirtYellowTurtleneckDress
   - ClothingUniformSwimsuitBlue
+  - ClothingUniformDressRed

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/circuit_imprinter.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/Packs/circuit_imprinter.yml
@@ -25,6 +25,7 @@
   - HotplateMachineCircuitboard
   - PrinterDocMachineCircuitboard  # Corvax-Printer
   - UniformPrinterMachineCircuitboard
+  - AutotailorMachineCircuitboard # DEN
   - FloorGreenCircuit
   - FloorBlueCircuit
   - MicrowaveMachineCircuitboard

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
@@ -333,6 +333,11 @@
 
 - type: latheRecipe
   parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpskirtKimonoColor
+  result: ClothingUniformJumpskirtKimonoColor
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
   id: ClothingKimonoBlue
   result: ClothingKimonoBlue
 
@@ -615,8 +620,8 @@
 
 - type: latheRecipe
   parent: BaseJumpsuitLoadoutDressRecipe
-  id: ClothingUniformJumpskirtPencilSkirtGymBra
-  result: ClothingUniformJumpskirtPencilSkirtGymBra
+  id: ClothingUniformJumpskirtDressPuffy
+  result: ClothingUniformJumpskirtDressPuffy
 
 - type: latheRecipe
   parent: BaseJumpsuitLoadoutDressRecipe

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
@@ -1265,3 +1265,80 @@
   parent: BaseHatEnvirohelmRecipe
   id: ClothingHeadEnvirohelmColorBrown
   result: ClothingHeadEnvirohelmColorBrown
+
+## Enviroslacks
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitEnviroslacks
+  result: ClothingUniformEnvirosuitEnviroslacks
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitEnviroslacksNegative
+  result: ClothingUniformEnvirosuitEnviroslacksNegative
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitEnviroslacksColorRed
+  result: ClothingUniformEnvirosuitEnviroslacksColorRed
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmEnviroslacksColorRed
+  result: ClothingHeadEnvirohelmEnviroslacksColorRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitEnviroslacksColorOrange
+  result: ClothingUniformEnvirosuitEnviroslacksColorOrange
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmEnviroslacksColorOrange
+  result: ClothingHeadEnvirohelmEnviroslacksColorOrange
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitEnviroslacksColorGreen
+  result: ClothingUniformEnvirosuitEnviroslacksColorGreen
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmEnviroslacksColorGreen
+  result: ClothingHeadEnvirohelmEnviroslacksColorGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitEnviroslacksColorBlue
+  result: ClothingUniformEnvirosuitEnviroslacksColorBlue
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmEnviroslacksColorBlue
+  result: ClothingHeadEnvirohelmEnviroslacksColorBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitEnviroslacksColorBrown
+  result: ClothingUniformEnvirosuitEnviroslacksColorBrown
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitEnviroslacksMNK
+  result: ClothingUniformEnvirosuitEnviroslacksMNK
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmEnviroslacksMNK
+  result: ClothingHeadEnvirohelmEnviroslacksMNK
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitEnviroslacksMNKAlt
+  result: ClothingUniformEnvirosuitEnviroslacksMNKAlt
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmEnviroslacksMNKAlt
+  result: ClothingHeadEnvirohelmEnviroslacksMNKAlt

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
@@ -324,6 +324,196 @@
   id: ClothingUniformMartialGi
   result: ClothingUniformMartialGi
 
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitBartenderGrey
+  result: ClothingUniformJumpsuitBartenderGrey
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitCheckered
+  result: ClothingUniformJumpsuitCheckered
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitFlannelOveralls
+  result: ClothingUniformJumpsuitFlannelOveralls
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitCowboyBrown
+  result: ClothingUniformJumpsuitCowboyBrown
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitCowboyGrey
+  result: ClothingUniformJumpsuitCowboyGrey
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitCamouflageShirt
+  result: ClothingUniformJumpsuitCamouflageShirt
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitOliveSweater
+  result: ClothingUniformJumpsuitOliveSweater
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitDesertUniform
+  result: ClothingUniformJumpsuitDesertUniform
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitLumberjack
+  result: ClothingUniformJumpsuitLumberjack
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitLightBlueShirt
+  result: ClothingUniformJumpsuitLightBlueShirt
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitGreyShirt
+  result: ClothingUniformJumpsuitGreyShirt
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitFlannelJeans
+  result: ClothingUniformJumpsuitFlannelJeans
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitFlannelBlackJeans
+  result: ClothingUniformJumpsuitFlannelBlackJeans
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitFlannelKhakis
+  result: ClothingUniformJumpsuitFlannelKhakis
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitFlannelBlackKhakis
+  result: ClothingUniformJumpsuitFlannelBlackKhakis
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitRolledSleeves
+  result: ClothingUniformJumpsuitSuitRolledSleeves
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitAmish
+  result: ClothingUniformJumpsuitSuitAmish
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitAristocratic
+  result: ClothingUniformJumpsuitSuitAristocratic
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitAristocraticTuxedo
+  result: ClothingUniformJumpsuitSuitAristocraticTuxedo
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitAscetic
+  result: ClothingUniformJumpsuitAscetic
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitBarber
+  result: ClothingUniformJumpsuitBarber
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitBlueBlazer
+  result: ClothingUniformJumpsuitSuitBlueBlazer
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitDisheveled
+  result: ClothingUniformJumpsuitDisheveled
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitRegal
+  result: ClothingUniformJumpsuitSuitRegal
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitRegalTuxedo
+  result: ClothingUniformJumpsuitSuitRegalTuxedo
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitRippedPunk
+  result: ClothingUniformJumpsuitRippedPunk
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSailor
+  result: ClothingUniformJumpsuitSailor
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitStriped
+  result: ClothingUniformJumpsuitSuitStriped
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitTrackpants
+  result: ClothingUniformJumpsuitTrackpants
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitTurtleneckGrey
+  result: ClothingUniformJumpsuitTurtleneckGrey
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitVictorianRedBlack
+  result: ClothingUniformJumpsuitSuitVictorianRedBlack
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitVictorianRedVest
+  result: ClothingUniformJumpsuitSuitVictorianRedVest
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitVictorianVest
+  result: ClothingUniformJumpsuitSuitVictorianVest
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitWaiter
+  result: ClothingUniformJumpsuitWaiter
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpskirtWaitress
+  result: ClothingUniformJumpskirtWaitress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitYogaGymBra
+  result: ClothingUniformJumpsuitYogaGymBra
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitBlackTurtleneck
+  result: ClothingUniformJumpsuitBlackTurtleneck
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitBlackTurtleneckFlipped
+  result: ClothingUniformJumpsuitBlackTurtleneckFlipped
+
 ## Kimonos
 
 - type: latheRecipe
@@ -675,16 +865,11 @@
 
 - type: latheRecipe
   parent: BaseJumpsuitLoadoutDressRecipe
-  id: ClothingUniformJumpskirtWaitress
-  result: ClothingUniformJumpskirtWaitress
-
-- type: latheRecipe
-  parent: BaseJumpsuitLoadoutDressRecipe
   id: ClothingUniformJumpskirtDressYellowSwoop
   result: ClothingUniformJumpskirtDressYellowSwoop
 
 - type: latheRecipe
-  parent: BaseJumpsuitLoadoutRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
   id: ClothingUniformDressRed
   result: ClothingUniformDressRed
 

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
@@ -182,6 +182,180 @@
 
 ## Loadout Uniforms
 
+### Generic
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitFlannel
+  result: ClothingUniformJumpsuitFlannel
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitCasualBlue
+  result: ClothingUniformJumpsuitCasualBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpskirtCasualBlue
+  result: ClothingUniformJumpskirtCasualBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitCasualPurple
+  result: ClothingUniformJumpsuitCasualPurple
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpskirtCasualPurple
+  result: ClothingUniformJumpskirtCasualPurple
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitCasualRed
+  result: ClothingUniformJumpsuitCasualRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpskirtCasualRed
+  result: ClothingUniformJumpskirtCasualRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitTshirtJeans
+  result: ClothingUniformJumpsuitTshirtJeans
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitTshirtJeansGray
+  result: ClothingUniformJumpsuitTshirtJeansGray
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitTshirtJeansPeach
+  result: ClothingUniformJumpsuitTshirtJeansPeach
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformTShirtKhakiPants
+  result: ClothingUniformTShirtKhakiPants
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitJeansGreen
+  result: ClothingUniformJumpsuitJeansGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitJeansRed
+  result: ClothingUniformJumpsuitJeansRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitJeansBrown
+  result: ClothingUniformJumpsuitJeansBrown
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitLostTourist
+  result: ClothingUniformJumpsuitLostTourist
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitHawaiBlack
+  result: ClothingUniformJumpsuitHawaiBlack
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitHawaiBlue
+  result: ClothingUniformJumpsuitHawaiBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitHawaiRed
+  result: ClothingUniformJumpsuitHawaiRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitHawaiYellow
+  result: ClothingUniformJumpsuitHawaiYellow
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSober
+  result: ClothingUniformJumpsuitSober
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformSkirtTurtle
+  result: ClothingUniformSkirtTurtle
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: UniformGeisha
+  result: UniformGeisha
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingCostumeArcDress
+  result: ClothingCostumeArcDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingCostumeMioSkirt
+  result: ClothingCostumeMioSkirt
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingCostumeNaota
+  result: ClothingCostumeNaota
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitLoungewear
+  result: ClothingUniformJumpsuitLoungewear
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformKendoHakama
+  result: ClothingUniformKendoHakama
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformMartialGi
+  result: ClothingUniformMartialGi
+
+## Kimonos
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitKimono
+  result: ClothingUniformJumpsuitKimono
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingKimonoBlue
+  result: ClothingKimonoBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingKimonoPink
+  result: ClothingKimonoPink
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingKimonoPurple
+  result: ClothingKimonoPurple
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingKimonoSky
+  result: ClothingKimonoSky
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingKimonoGreen
+  result: ClothingKimonoGreen
+
 ### Dresses
 
 - type: latheRecipe
@@ -406,16 +580,6 @@
 
 - type: latheRecipe
   parent: BaseJumpsuitLoadoutDressRecipe
-  id: ClothingUniformJumpskirtDressFluffy
-  result: ClothingUniformJumpskirtDressFluffy
-
-- type: latheRecipe
-  parent: BaseJumpsuitLoadoutDressRecipe
-  id: ClothingUniformJumpskirtKimonoColor
-  result: ClothingUniformJumpskirtKimonoColor
-
-- type: latheRecipe
-  parent: BaseJumpsuitLoadoutDressRecipe
   id: ClothingUniformJumpskirtDressLacyGown
   result: ClothingUniformJumpskirtDressLacyGown
 
@@ -513,6 +677,11 @@
   parent: BaseJumpsuitLoadoutDressRecipe
   id: ClothingUniformJumpskirtDressYellowSwoop
   result: ClothingUniformJumpskirtDressYellowSwoop
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformDressRed
+  result: ClothingUniformDressRed
 
 ### School
 

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
@@ -14,7 +14,19 @@
   id: BaseJumpsuitGenericRecipe
   category: ColoredUniforms
 
-## Jumpsuits
+- type: latheRecipe
+  abstract: true
+  parent: BaseJumpsuitRecipe
+  id: BaseJumpsuitLoadoutRecipe
+  category: LoadoutJumpsuits
+
+- type: latheRecipe
+  abstract: true
+  parent: BaseJumpsuitRecipe
+  id: BaseJumpsuitLoadoutDressRecipe
+  category: LoadoutDresses
+
+## Color Jumpsuits
 
 - type: latheRecipe
   parent: BaseJumpsuitGenericRecipe
@@ -96,7 +108,8 @@
   id: ClothingUniformColorRainbow
   result: ClothingUniformColorRainbow
 
-## Jumpskirts
+## Color Jumpskirts
+
 - type: latheRecipe
   parent: BaseJumpsuitGenericRecipe
   id: ClothingUniformJumpskirtColorWhite
@@ -166,3 +179,441 @@
   parent: BaseJumpsuitGenericRecipe
   id: ClothingUniformJumpskirtColorMaroon
   result: ClothingUniformJumpskirtColorMaroon
+
+## Loadout Uniforms
+
+### Dresses
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtYellowTurtleneckDress
+  result: ClothingUniformJumpskirtYellowTurtleneckDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressAsymmetric
+  result: ClothingUniformJumpskirtDressAsymmetric
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtBlueTurtleneckDress
+  result: ClothingUniformJumpskirtBlueTurtleneckDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformSwimsuitBlue
+  result: ClothingUniformSwimsuitBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressEvening
+  result: ClothingUniformJumpskirtDressEvening
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtPurpleTurtleneckDress
+  result: ClothingUniformJumpskirtPurpleTurtleneckDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressMidi
+  result: ClothingUniformJumpskirtDressMidi
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtGreenTurtleneckDress
+  result: ClothingUniformJumpskirtGreenTurtleneckDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressOpenShoulder
+  result: ClothingUniformJumpskirtDressOpenShoulder
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtRedTurtleneckDress
+  result: ClothingUniformJumpskirtRedTurtleneckDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressTea
+  result: ClothingUniformJumpskirtDressTea
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtOrangeStripedDress
+  result: ClothingUniformJumpskirtOrangeStripedDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressSleeveless
+  result: ClothingUniformJumpskirtDressSleeveless
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtPinkStripedDress
+  result: ClothingUniformJumpskirtPinkStripedDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressLongSleeve
+  result: ClothingUniformJumpskirtDressLongSleeve
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtGreenStripedDress
+  result: ClothingUniformJumpskirtGreenStripedDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressBlackAndGold
+  result: ClothingUniformJumpskirtDressBlackAndGold
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtRedStripedDress
+  result: ClothingUniformJumpskirtRedStripedDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressBlackTango
+  result: ClothingUniformJumpskirtDressBlackTango
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtCyanStripedDress
+  result: ClothingUniformJumpskirtCyanStripedDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressBlackTangoAlt
+  result: ClothingUniformJumpskirtDressBlackTangoAlt
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtPurpleElegantDress
+  result: ClothingUniformJumpskirtPurpleElegantDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtSuitBlueBlazer
+  result: ClothingUniformJumpskirtSuitBlueBlazer
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressBlueSundress
+  result: ClothingUniformJumpskirtDressBlueSundress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressCheongsamBlue
+  result: ClothingUniformJumpskirtDressCheongsamBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressCheongsamGreen
+  result: ClothingUniformJumpskirtDressCheongsamGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressCheongsamPurple
+  result: ClothingUniformJumpskirtDressCheongsamPurple
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressCheongsamRed
+  result: ClothingUniformJumpskirtDressCheongsamRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtBlueElegantDress
+  result: ClothingUniformJumpskirtBlueElegantDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressCheongsamWhite
+  result: ClothingUniformJumpskirtDressCheongsamWhite
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressClub
+  result: ClothingUniformJumpskirtDressClub
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtGreenElegantDress
+  result: ClothingUniformJumpskirtGreenElegantDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressCoveter
+  result: ClothingUniformJumpskirtDressCoveter
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtRedElegantDress
+  result: ClothingUniformJumpskirtRedElegantDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressFlamenco
+  result: ClothingUniformJumpskirtDressFlamenco
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtBlackElegantDress
+  result: ClothingUniformJumpskirtBlackElegantDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressFire
+  result: ClothingUniformJumpskirtDressFire
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressOrange
+  result: ClothingUniformJumpskirtDressOrange
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressYellow
+  result: ClothingUniformJumpskirtDressYellow
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressFlowergirl
+  result: ClothingUniformJumpskirtDressFlowergirl
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtYellowOldDress
+  result: ClothingUniformJumpskirtYellowOldDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressFluffy
+  result: ClothingUniformJumpskirtDressFluffy
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressFormalRed
+  result: ClothingUniformJumpskirtDressFormalRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressGothic
+  result: ClothingUniformJumpskirtDressGothic
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressFluffy
+  result: ClothingUniformJumpskirtDressFluffy
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtKimonoColor
+  result: ClothingUniformJumpskirtKimonoColor
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressLacyGown
+  result: ClothingUniformJumpskirtDressLacyGown
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressLong
+  result: ClothingUniformJumpskirtDressLong
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressLongFlared
+  result: ClothingUniformJumpskirtDressLongFlared
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtQipao
+  result: ClothingUniformJumpskirtQipao
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtQipaoSlim
+  result: ClothingUniformJumpskirtQipaoSlim
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressRedSwept
+  result: ClothingUniformJumpskirtDressRedSwept
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtPencilSkirtGymBra
+  result: ClothingUniformJumpskirtPencilSkirtGymBra
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtPencilSkirtGymBra
+  result: ClothingUniformJumpskirtPencilSkirtGymBra
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtSailor
+  result: ClothingUniformJumpskirtSailor
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressSariGreen
+  result: ClothingUniformJumpskirtDressSariGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressSariRed
+  result: ClothingUniformJumpskirtDressSariRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressShort
+  result: ClothingUniformJumpskirtDressShort
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressSpider
+  result: ClothingUniformJumpskirtDressSpider
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressStriped
+  result: ClothingUniformJumpskirtDressStriped
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressSundress
+  result: ClothingUniformJumpskirtDressSundress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressSundressWhite
+  result: ClothingUniformJumpskirtDressSundressWhite
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressVictorianBlack
+  result: ClothingUniformJumpskirtDressVictorianBlack
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressVictorianRed
+  result: ClothingUniformJumpskirtDressVictorianRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtWaitress
+  result: ClothingUniformJumpskirtWaitress
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutDressRecipe
+  id: ClothingUniformJumpskirtDressYellowSwoop
+  result: ClothingUniformJumpskirtDressYellowSwoop
+
+### School
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformSchoolGakuranBlack
+  result: ClothingUniformSchoolGakuranBlack
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: UniformSchoolgirlBlack
+  result: UniformSchoolgirlBlack
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: UniformSchoolgirlBlue
+  result: UniformSchoolgirlBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: UniformSchoolgirlCyan
+  result: UniformSchoolgirlCyan
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: UniformSchoolgirlGreen
+  result: UniformSchoolgirlGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: UniformSchoolgirlOrange
+  result: UniformSchoolgirlOrange
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: UniformSchoolgirlPink
+  result: UniformSchoolgirlPink
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: UniformSchoolgirlPurple
+  result: UniformSchoolgirlPurple
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: UniformSchoolgirlRed
+  result: UniformSchoolgirlRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: UniformSchoolgirlDusk
+  result: UniformSchoolgirlDusk
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: UniformSchoolgirlBlazerTan
+  result: UniformSchoolgirlBlazerTan
+
+### Suits
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitBlack
+  result: ClothingUniformJumpsuitSuitBlack
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitBlackAlt
+  result: ClothingUniformJumpsuitSuitBlackAlt
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitBlackMob
+  result: ClothingUniformJumpsuitSuitBlackMob
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitBrown
+  result: ClothingUniformJumpsuitSuitBrown
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitBrownAlt
+  result: ClothingUniformJumpsuitSuitBrownAlt
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitBrownMob
+  result: ClothingUniformJumpsuitSuitBrownMob
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitWhite
+  result: ClothingUniformJumpsuitSuitWhite
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitWhiteAlt
+  result: ClothingUniformJumpsuitSuitWhiteAlt
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitSuitWhiteMob
+  result: ClothingUniformJumpsuitSuitWhiteMob

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
@@ -26,6 +26,18 @@
   id: BaseJumpsuitLoadoutDressRecipe
   category: LoadoutDresses
 
+- type: latheRecipe
+  abstract: true
+  parent: BaseJumpsuitRecipe
+  id: BaseJumpsuitEnvirosuitRecipe
+  category: Envirosuits
+
+- type: latheRecipe
+  abstract: true
+  parent: BaseHatRecipe
+  id: BaseHatEnvirohelmRecipe
+  category: Envirosuits
+
 ## Color Jumpsuits
 
 - type: latheRecipe
@@ -514,6 +526,51 @@
   id: ClothingUniformJumpsuitBlackTurtleneckFlipped
   result: ClothingUniformJumpsuitBlackTurtleneckFlipped
 
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitLederhosen
+  result: ClothingUniformJumpsuitLederhosen
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitCatsuit
+  result: ClothingUniformJumpsuitCatsuit
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitCatsuitShiny
+  result: ClothingUniformJumpsuitCatsuitShiny
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformJumpsuitCatsuitBlank
+  result: ClothingUniformJumpsuitCatsuitBlank
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformShorts
+  result: ClothingUniformShorts
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformBootyShorts
+  result: ClothingUniformBootyShorts
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformSimplePants
+  result: ClothingUniformSimplePants
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformWhiteTurtleneck
+  result: ClothingUniformWhiteTurtleneck
+
+- type: latheRecipe
+  parent: BaseJumpsuitLoadoutRecipe
+  id: ClothingUniformWhiteTurtleskirt
+  result: ClothingUniformWhiteTurtleskirt
+
 ## Kimonos
 
 - type: latheRecipe
@@ -976,3 +1033,235 @@
   parent: BaseJumpsuitLoadoutRecipe
   id: ClothingUniformJumpsuitSuitWhiteMob
   result: ClothingUniformJumpsuitSuitWhiteMob
+
+## Envirosuits
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuit
+  result: ClothingUniformEnvirosuit
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelm
+  result: ClothingHeadEnvirohelm
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitBlackPink
+  result: ClothingUniformEnvirosuitBlackPink
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmBlackPink
+  result: ClothingHeadEnvirohelmBlackPink
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitBlackPinkAlt
+  result: ClothingUniformEnvirosuitBlackPinkAlt
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmBlackPinkAlt
+  result: ClothingHeadEnvirohelmBlackPinkAlt
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitMartialGi
+  result: ClothingUniformEnvirosuitMartialGi
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmMartialGi
+  result: ClothingHeadEnvirohelmMartialGi
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitSafari
+  result: ClothingUniformEnvirosuitSafari
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmSafari
+  result: ClothingHeadEnvirohelmSafari
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitTrans
+  result: ClothingUniformEnvirosuitTrans
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmTrans
+  result: ClothingHeadEnvirohelmTrans
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitAncientVoid
+  result: ClothingUniformEnvirosuitAncientVoid
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmAncientVoid
+  result: ClothingHeadEnvirohelmAncientVoid
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorWhite
+  result: ClothingUniformEnvirosuitColorWhite
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorWhite
+  result: ClothingHeadEnvirohelmColorWhite
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorGrey
+  result: ClothingUniformEnvirosuitColorGrey
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorGrey
+  result: ClothingHeadEnvirohelmColorGrey
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorBlack
+  result: ClothingUniformEnvirosuitColorBlack
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorBlack
+  result: ClothingHeadEnvirohelmColorBlack
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorRed
+  result: ClothingUniformEnvirosuitColorRed
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorRed
+  result: ClothingHeadEnvirohelmColorRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorGreen
+  result: ClothingUniformEnvirosuitColorGreen
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorGreen
+  result: ClothingHeadEnvirohelmColorGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorDarkGreen
+  result: ClothingUniformEnvirosuitColorDarkGreen
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorDarkGreen
+  result: ClothingHeadEnvirohelmColorDarkGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorBlue
+  result: ClothingUniformEnvirosuitColorBlue
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorBlue
+  result: ClothingHeadEnvirohelmColorBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorDarkBlue
+  result: ClothingUniformEnvirosuitColorDarkBlue
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorDarkBlue
+  result: ClothingHeadEnvirohelmColorDarkBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorTeal
+  result: ClothingUniformEnvirosuitColorTeal
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorTeal
+  result: ClothingHeadEnvirohelmColorTeal
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorMaroon
+  result: ClothingUniformEnvirosuitColorMaroon
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorMaroon
+  result: ClothingHeadEnvirohelmColorMaroon
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorPink
+  result: ClothingUniformEnvirosuitColorPink
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorPink
+  result: ClothingHeadEnvirohelmColorPink
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorYellow
+  result: ClothingUniformEnvirosuitColorYellow
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorYellow
+  result: ClothingHeadEnvirohelmColorYellow
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorPurple
+  result: ClothingUniformEnvirosuitColorPurple
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorPurple
+  result: ClothingHeadEnvirohelmColorPurple
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorOrange
+  result: ClothingUniformEnvirosuitColorOrange
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorOrange
+  result: ClothingHeadEnvirohelmColorOrange
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorLightBrown
+  result: ClothingUniformEnvirosuitColorLightBrown
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorLightBrown
+  result: ClothingHeadEnvirohelmColorLightBrown
+
+- type: latheRecipe
+  parent: BaseJumpsuitEnvirosuitRecipe
+  id: ClothingUniformEnvirosuitColorBrown
+  result: ClothingUniformEnvirosuitColorBrown
+
+- type: latheRecipe
+  parent: BaseHatEnvirohelmRecipe
+  id: ClothingHeadEnvirohelmColorBrown
+  result: ClothingHeadEnvirohelmColorBrown

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/autotailor.yml
@@ -1,0 +1,168 @@
+## Base Recipes
+
+- type: latheRecipe
+  abstract: true
+  id: BaseCarpetRecipe
+  category: Carpet
+  completetime: 1
+  materials:
+    Cloth: 100
+
+- type: latheRecipe
+  abstract: true
+  parent: BaseJumpsuitRecipe
+  id: BaseJumpsuitGenericRecipe
+  category: ColoredUniforms
+
+## Jumpsuits
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorWhite
+  result: ClothingUniformJumpsuitColorWhite
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorBlack
+  result: ClothingUniformJumpsuitColorBlack
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorBlue
+  result: ClothingUniformJumpsuitColorBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorDarkBlue
+  result: ClothingUniformJumpsuitColorDarkBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorTeal
+  result: ClothingUniformJumpsuitColorTeal
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorGreen
+  result: ClothingUniformJumpsuitColorGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorDarkGreen
+  result: ClothingUniformJumpsuitColorDarkGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorOrange
+  result: ClothingUniformJumpsuitColorOrange
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorPink
+  result: ClothingUniformJumpsuitColorPink
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorRed
+  result: ClothingUniformJumpsuitColorRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorYellow
+  result: ClothingUniformJumpsuitColorYellow
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorPurple
+  result: ClothingUniformJumpsuitColorPurple
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorLightBrown
+  result: ClothingUniformJumpsuitColorLightBrown
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorBrown
+  result: ClothingUniformJumpsuitColorBrown
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpsuitColorMaroon
+  result: ClothingUniformJumpsuitColorMaroon
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformColorRainbow
+  result: ClothingUniformColorRainbow
+
+## Jumpskirts
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorWhite
+  result: ClothingUniformJumpskirtColorWhite
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorBlack
+  result: ClothingUniformJumpskirtColorBlack
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorBlue
+  result: ClothingUniformJumpskirtColorBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorDarkBlue
+  result: ClothingUniformJumpskirtColorDarkBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorTeal
+  result: ClothingUniformJumpskirtColorTeal
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorGreen
+  result: ClothingUniformJumpskirtColorGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorDarkGreen
+  result: ClothingUniformJumpskirtColorDarkGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorOrange
+  result: ClothingUniformJumpskirtColorOrange
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorPink
+  result: ClothingUniformJumpskirtColorPink
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorRed
+  result: ClothingUniformJumpskirtColorRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorYellow
+  result: ClothingUniformJumpskirtColorYellow
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorPurple
+  result: ClothingUniformJumpskirtColorPurple
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorBrown
+  result: ClothingUniformJumpskirtColorBrown
+
+- type: latheRecipe
+  parent: BaseJumpsuitGenericRecipe
+  id: ClothingUniformJumpskirtColorMaroon
+  result: ClothingUniformJumpskirtColorMaroon

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/categories.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/categories.yml
@@ -17,9 +17,17 @@
   name: lathe-category-carpet
 
 - type: latheCategory
-  id: HygieneProducts
-  name: lathe-category-hygiene-products
-
-- type: latheCategory
   id: ColoredUniforms
   name: lathe-category-colored-uniforms
+
+- type: latheCategory
+  id: LoadoutDresses
+  name: lathe-category-loadout-dresses
+
+- type: latheCategory
+  id: LoadoutJumpsuits
+  name: lathe-category-loadout-jumpsuits
+
+- type: latheCategory
+  id: HygieneProducts
+  name: lathe-category-hygiene-products

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/categories.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/categories.yml
@@ -13,5 +13,9 @@
   name: lathe-category-assistance-devices
 
 - type: latheCategory
+  id: Carpet
+  name: lathe-category-carpet
+
+- type: latheCategory
   id: HygieneProducts
   name: lathe-category-hygiene-products

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/categories.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/categories.yml
@@ -19,3 +19,7 @@
 - type: latheCategory
   id: HygieneProducts
   name: lathe-category-hygiene-products
+
+- type: latheCategory
+  id: ColoredUniforms
+  name: lathe-category-colored-uniforms

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/categories.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/categories.yml
@@ -21,6 +21,10 @@
   name: lathe-category-colored-uniforms
 
 - type: latheCategory
+  id: Envirosuits
+  name: lathe-category-envirosuits
+
+- type: latheCategory
   id: LoadoutDresses
   name: lathe-category-loadout-dresses
 

--- a/Resources/Prototypes/_DEN/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_DEN/Recipes/Lathes/electronics.yml
@@ -1,0 +1,8 @@
+- type: latheRecipe
+  id: AutotailorMachineCircuitboard
+  result: AutotailorMachineCircuitboard
+  category: Circuitry
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 500


### PR DESCRIPTION
## About the PR
This PR adds a new lathe called the **autotailor**, a machine that is exclusively used to produce cosmetic clothing, such as those found in loadouts. It also prints carpet, like the uniform printer. Nothing in the autotailor should be restricted, especially since you can obtain most of the clothing in it through roundstart loadouts, making it safe to give to any crew member.

## Why / Balance
Command is (reasonably!!!) hesitant to give crew access to the uniform printer because it can be used to print command/security/etc clothing that you shouldn't have - however, it is also the only way to obtain carpet. In addition, a massive portion of loadout clothing is literally unobtainable by any other means besides loadouts, which can be restrictive.

## Technical details
Holy YML

## Media
TBA

## Requirements
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have tested any changes or additions.
- [ ] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
Some pre-existing recipes for the uniform printer were reparented and/or given new lathe categories. This doesn't affect the uniform printer much but it did happen.

**Changelog**
:cl:
- add: Epistemics can now print the circuit board for an autotailor, a new lathe that produces carpet and cosmetic clothing items. Nothing in the autotailor is restricted (as you can obtain nearly all of it roundstart via loadouts anyway), making it perfectly fine to distribute for general crew use.