### PR TITLE
Adding Override for Emotes, Fixes pAI's Not Inheriting Plushie Names.

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -731,7 +731,21 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         if (separateNameAndMessage)
             locString = "chat-manager-entity-me-no-separate-wrap-message";
-
+        
+        // DEN: conditional was missing, added so PAis inherit names from the plushies they're put in
+        if (nameOverride != null)
+        {
+            name = nameOverride;
+        }
+        else
+        {
+            var nameEv = new TransformSpeakerNameEvent(source, Name(source));
+            RaiseLocalEvent(source, nameEv);
+            name = nameEv.VoiceName;
+        }
+        name = FormattedMessage.EscapeText(name);
+        // End DEN changes
+        
         // Emotes use Identity.Name, since it doesn't actually involve your voice at all.
         var wrappedMessage = Loc.GetString(locString,
             ("entityName", name),
@@ -786,6 +800,20 @@ public sealed partial class ChatSystem : SharedChatSystem
         if (separateNameAndMessage)
             locString = "chat-manager-entity-subtle-no-separate-wrap-message";
 
+        // DEN: conditional was missing, added so PAis inherit names from the plushies they're put in
+        if (nameOverride != null)
+        {
+            name = nameOverride;
+        }
+        else
+        {
+            var nameEv = new TransformSpeakerNameEvent(source, Name(source));
+            RaiseLocalEvent(source, nameEv);
+            name = nameEv.VoiceName;
+        }
+        name = FormattedMessage.EscapeText(name);
+        // End DEN changes
+        
         // Emotes use Identity.Name, since it doesn't actually involve your voice at all.
         var wrappedMessage = Loc.GetString(locString,
             ("entityName", name),


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Added (missing?) conditional for emote and subtle to be able to receive names of plushies. (Also might affect a few other things but I think it makes sense probably?)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug(?) Requested by Shaman on discord

## Technical details
<!-- Summary of code changes for easier review. -->
small changes to chatsystem.cs

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
<img width="294" height="46" alt="image" src="https://github.com/user-attachments/assets/3b796694-7238-4082-bed9-3c41f6bb5e6e" />
After:
<img width="301" height="71" alt="image" src="https://github.com/user-attachments/assets/b8149dac-e641-464b-9885-559e4f801e17" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: pAIs now inherit the name of the plushie they're put inside. 

