### PR TITLE
Make CentComm Officials Untargetable By Default (+ Make "Marked" Easier To Edit In VV)

### DIFF
--- a/Content.Server/FloofStation/Traits/Components/MarkedComponent.cs
+++ b/Content.Server/FloofStation/Traits/Components/MarkedComponent.cs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Server.Objectives.Components;
+using Content.Shared.Objectives.Components;
 
 namespace Content.Server._Floof.Traits.Components;
 
@@ -13,6 +14,6 @@ namespace Content.Server._Floof.Traits.Components;
 [RegisterComponent]
 public sealed partial class MarkedComponent : Component
 {
-    [DataField, ViewVariables]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public ObjectiveTypes TargetType;
 }

--- a/Content.Server/Objectives/Components/PickRandomPersonComponent.cs
+++ b/Content.Server/Objectives/Components/PickRandomPersonComponent.cs
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 using Content.Server.Objectives.Systems;
+using Content.Shared.Objectives.Components;
 
 namespace Content.Server.Objectives.Components;
 
@@ -22,14 +23,3 @@ public sealed partial class PickRandomPersonComponent : Component
     public ObjectiveTypes ObjectiveType;
     //Floofstation Target Consent Traits: End
 }
-
-//Floofstation Target Consent Traits: Start
-[Flags]
-public enum ObjectiveTypes
-{
-    Unspecified = -1,
-    TraitorNonTargetable = 0,
-    TraitorKill = 1 << 0,
-    TraitorTeach = 1 << 1
-}
-//Floofstation Target Consent Traits: End

--- a/Content.Shared/_Floof/Objectives/ObjectiveTypes.cs
+++ b/Content.Shared/_Floof/Objectives/ObjectiveTypes.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Objectives.Components;
+
+// DEN Change: This was moved from Server to Shared.
+
+//Floofstation Target Consent Traits: Start
+[Flags]
+[Serializable, NetSerializable] // DEN: Needed to make it editable
+public enum ObjectiveTypes : sbyte
+{
+    // Unspecified = -1, # DEN: Commented because unused. Fun fact: selecting this makes flags think they're all selected
+    TraitorNonTargetable = 0,
+    TraitorKill = 1 << 0,
+    TraitorTeach = 1 << 1
+}
+//Floofstation Target Consent Traits: End

--- a/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/centcom_official.yml
@@ -43,6 +43,10 @@
     charges: 10
   - !type:ModifyEnvirohelmSpecial
     powerCell: PowerCellMedium
+  - !type:AddComponentSpecial # DEN - Make CCOs untargetable by traitor objectives.
+    components:
+    - type: Marked
+      targetType: TraitorNonTargetable
 
 - type: startingGear
   id: CentcomGear


### PR DESCRIPTION
## About the PR
This PR makes CentComm Officials untargetable by traitor objectives. It also makes the Marked targeting flag editable through the VV menu so admins can make an entity non-targetable or killable if they wanted to.

## Why / Balance
Horsey found out that CCOs are technically valid objective targets for traitors who have their objectives reassigned.

99% of the time, when a CentComm official is spawned, they are _at_ CentComm, which means they are untouchable as far as objectives go anyway. If you are capable of spawning a CCO character, you're also capable of going into ViewVariables and removing the `Marked` component manually if you actually want to be the target of a traitor objective.

## Technical details
Adds the `Marked` component to the CentComm Official job definition with the objective type flag set to `TraitorNonTargetable`.

Also, I had to do some stuff to make the VV stuff work. ObjectiveTypes was moved to Shared, the type of the enum was set to sbyte, and the enum has been made NetSerializable (which enables VV functionality). I also commented out the `Unspecified` flag value as it was unused and didn't work anyway.

## Media

Spawned-in CCO automatically comes with the Marked component set to TraitorNonTargetable.
Also notice that the TargetType variable in the VV menu has selectable buttons.

<img width="719" height="384" alt="image" src="https://github.com/user-attachments/assets/ea0c44d4-e7a9-44c1-beef-5f2adf1069ad" />

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
I removed an unused value for ObjectiveTypes. I guess.

**Changelog**
:cl:
- fix: Central Command Officials are no longer targetable by traitor objectives by default, because you're not gonna find them anyway.
- tweak: Admins can now edit the "marked for objectives" component easier, to make any entity untargetable or marked for removal.
