### PR TITLE
Fix Magnet Bag Networking and Disable the Trash Bag's Magnet by Default

### DIFF
--- a/Content.Shared/Storage/Components/MagnetPickupComponent.cs
+++ b/Content.Shared/Storage/Components/MagnetPickupComponent.cs
@@ -9,12 +9,13 @@
 using Content.Shared.Inventory;
 using Robust.Shared.GameStates; // Frontier
 
-namespace Content.Server.Storage.Components;
+namespace Content.Shared.Storage.Components;
 
 /// <summary>
 /// Applies an ongoing pickup area around the attached entity.
 /// </summary>
-[RegisterComponent, AutoGenerateComponentPause, AutoGenerateComponentState]
+[RegisterComponent, AutoGenerateComponentPause]
+[NetworkedComponent, AutoGenerateComponentState] // Frontier
 public sealed partial class MagnetPickupComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("nextScan")]

--- a/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/MagnetPickupSystem.cs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
-using Content.Server.Storage.Components;
 using Content.Shared.Storage.Components; // Frontier: Server<Shared
 using Content.Shared.Examine;
 using Content.Shared.Hands.Components;

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/trashbag.yml
@@ -27,7 +27,7 @@
   name: trash bag
   id: TrashBag
   parent: BaseStorageItem
-  description: A plastic garbage bag. Stores another man's treasure. 
+  description: A plastic garbage bag. Stores another man's treasure.
   components:
   - type: Sprite
     sprite: Objects/Specific/Janitorial/trashbag.rsi
@@ -63,15 +63,16 @@
     sprite: Objects/Specific/Janitorial/trashbag.rsi
   - type: Item
     size: Normal
-  - type: MagnetPickup 
+  - type: MagnetPickup
+    magnetEnabled: false # DEN - Disable by default
     range: 1
 
 - type: entity
-  name: trash bag 
+  name: trash bag
   id: TrashBagBlue
   parent: TrashBag
   suffix: Blue # TheDen
-  description: A mundane, blue garbage bag. Stores one or more men's trash. 
+  description: A mundane, blue garbage bag. Stores one or more men's trash.
   components:
   - type: Sprite
     sprite: Objects/Specific/Janitorial/bluetrashbag.rsi
@@ -89,14 +90,14 @@
   name: spell of all-consuming cleanliness
   id: BagOfSummoningGarbage
   parent: TrashBagBlue
-  description: A mystical blue sack that swallows waste whole. Looks smaller on the outside. 
+  description: A mystical blue sack that swallows waste whole. Looks smaller on the outside.
   components:
   - type: Storage
-    maxItemSize: Normal 
+    maxItemSize: Normal
     grid:
     - 0,0,19,9
     quickInsert: true
     areaInsert: true
     areaInsertRadius: 5
-  - type: MagnetPickup 
+  - type: MagnetPickup
     range: 3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
This PR fixes that one really annoying bug where trash bags will constantly attempt to pick up trash even when the magnet is disabled. It also disables the trash bag's magnet by default, requiring it to be switched on before it will attract things.

## Why / Balance
Annoying bug fix + QOL

## Technical details
Magnet storage component was missing NetworkedComponent, so I added it. I also properly put it in the Shared namespace.

1-line YML change to disable the trash bag magnet.

## Media

https://github.com/user-attachments/assets/9da5d6fb-847a-4070-8fa6-959b8f7105a6

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I guess a namespace change

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: I fixed that dumb ass stupid fucking ass moron idiot buttcheeks dumb shit stupid ass bug where trash bags will constantly attract things even when the magnet is disabled. Your welcome
- tweak: Trash bags have their magnet turned off by default.