### PR TITLE
Make Shadowkin Anaerobic

### DIFF
--- a/Content.Shared/_DEN/BloodlossInCrit/BloodlossInCritComponent.cs
+++ b/Content.Shared/_DEN/BloodlossInCrit/BloodlossInCritComponent.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2023 LankLTE <135308300+LankLTE@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
+//
+// SPDX-License-Identifier: MIT
+
+using Content.Shared.Mobs;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Damage.Components;
+
+/// <summary>
+/// Passively damages the entity on a specified interval.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BloodlossInCritComponent : Component
+{
+    /// <summary>
+    /// The entitys' states that passive damage will apply in
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public List<MobState> AllowedStates = new();
+
+    /// <summary>
+    /// Damage / Healing per interval dealt to the entity every interval
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public DamageSpecifier Damage = new();
+
+    /// <summary>
+    /// Delay between damage events in seconds
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public float Interval = 1f;
+
+    /// <summary>
+    /// The maximum HP the damage will be given to. If 0, disabled.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 DamageCap = 0;
+
+    [DataField("nextDamage", customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan NextDamage = TimeSpan.Zero;
+}

--- a/Resources/Prototypes/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/Body/Organs/shadowkin.yml
@@ -39,7 +39,7 @@
 
 - type: entity
   id: OrganShadowkinCore
-  parent: OrganHumanLungs
+  parent: OrganSpaceAnimalLungs
   description: "What is this thing?"
   categories: [ HideSpawnMenu ] # TheDen - Removes from spawn menu
   components:

--- a/Resources/Prototypes/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/Body/Organs/shadowkin.yml
@@ -9,7 +9,7 @@
 - type: entity
   id: OrganShadowkinBrain
   parent: OrganHumanBrain
-  description: "Oops, I should put this back where I found it."
+  description: "The source of incredible, unending intelligence. Mar." #TheDen
   categories: [ HideSpawnMenu ] # TheDen - Removes from spawn menu
   components:
   - type: Sprite
@@ -40,6 +40,7 @@
 - type: entity
   id: OrganShadowkinCore
   parent: OrganSpaceAnimalLungs
+  name: shadowkin core #TheDen
   description: "What is this thing?"
   categories: [ HideSpawnMenu ] # TheDen - Removes from spawn menu
   components:
@@ -47,12 +48,22 @@
     sprite: Mobs/Species/Shadowkin/organs.rsi
     layers:
     - state: core
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: BlackBlood
+          Quantity: 5
+  - type: FlavorProfile
+    flavors:
+      - bitter
 
 
 - type: entity
   id: OrganShadowkinTongue
   parent: OrganHumanTongue
-  description: "What does this do again?"
+  description: "A fleshy muscle mostly used for wurbling." #TheDen
   categories: [ HideSpawnMenu ] # TheDen - Removes from spawn menu
   components:
   - type: Sprite
@@ -63,7 +74,7 @@
 - type: entity
   id: OrganShadowkinAppendix
   parent: OrganHumanAppendix
-  description: "I think it does nothing..."
+  description: "Does this thing do anything?..." #TheDen
   categories: [ HideSpawnMenu ] # TheDen - Removes from spawn menu
   components:
   - type: Sprite
@@ -75,7 +86,7 @@
 - type: entity
   id: OrganShadowkinHeart
   parent: OrganHumanHeart
-  description: "Oops, I think this belongs to someone!"
+  description: "The pitch-black heart of a Shadowkin. How unsettling."
   categories: [ HideSpawnMenu ] # TheDen - Removes from spawn menu
   components:
   - type: Sprite

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -427,7 +427,7 @@
   coefficients:
     Slash: 1.2
     Piercing: 1.1
-    Asphyxiation: 0.5
+    Asphyxiation: 0.0 #Anaerobic in nature.
     Cold: 0.8
     Heat: 1.2
 

--- a/Resources/Prototypes/Entities/Mobs/Player/shadowkin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/shadowkin.yml
@@ -10,4 +10,4 @@
   name: Urist McShadow
   parent: MobShadowkinBase
   id: MobShadowkin
-  description: "Their barrel chest doesn't seem to rise and fall as quickly as a human's, how unnerving."
+  description: "Their chest doesn't seem to rise and fall, always remaining perfectly still. How unnerving."

--- a/Resources/Prototypes/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/shadowkin.yml
@@ -64,6 +64,13 @@
           Heat: -0.07
         groups:
           Brute: -0.07
+    - type: BloodlossInCrit #Take bloodloss instead of airloss in critical condition.
+      allowedStates:
+        - Critical
+      damageCap: 400
+      damage: 
+        types:
+          Bloodloss: 0.5
     - type: StatusEffects
       allowed:
         - Stun
@@ -137,7 +144,7 @@
           Bloodloss: 1
       bloodlossHealDamage:
         types:
-          Bloodloss: -0.25
+          Bloodloss: -0.5 #Takes bloodloss in critical, recovers it faster once out of crit.
       bloodReagent: BlackBlood
     - type: Temperature
       heatDamageThreshold: 330

--- a/Resources/Prototypes/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/shadowkin.yml
@@ -144,7 +144,7 @@
           Bloodloss: 1
       bloodlossHealDamage:
         types:
-          Bloodloss: -0.5 #Takes bloodloss in critical, recovers it faster once out of crit.
+          Bloodloss: -0.5 #Takes bloodloss in critical, recovers it faster to compensate.
       bloodReagent: BlackBlood
     - type: Temperature
       heatDamageThreshold: 330

--- a/Resources/ServerInfo/Guidebook/Mobs/Shadowkin.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Shadowkin.xml
@@ -22,8 +22,8 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
   They natively speak the Marish language.
 
   ## Positive Traits
-  -[color=#1e90ff]Barrel Chested[/color]:
-  Shadowkin, as a result of living in a dimension where there is little air, do not have lungs but instead a core. Their core allows them to more efficiently process oxygen and not use as much as a result.
+  -[color=#1e90ff]Anaerobic Nature[/color]:
+  Shadowkin, as a result of living in a dimension where there is little air, do not have lungs but instead a core. Their core makes it so that they do not need to respirate to survive.
 
   -[color=#1e90ff]Innate Telepathy[/color]:
   Shadowkin are innately telepathic, allowing them to communicate with other psionic individuals at will.
@@ -37,6 +37,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
   ## Negative Traits
   -[color=#ffa500]Glass Cannon[/color]:
   Shadowkin are very vulnerable to damage from an array of sources, preferring speed and agility over direct combat.
+
+  -[color=#ffa500]Breathless[/color]:
+  Since Shadowkin do not breathe, they are incapable from benifiting from the positive effects of gasses like Healium. When a Shadowkin enters critical condition, they accumulate bloodloss damage rather than the asphyxiation that is common to other species.
 
   -[color=#ffa500]Easy Target[/color]:
   Due to the fact they're inherently psionic, they make for easy targets by over-eager epistemics staff... and any other beasts that lurk in the dark.

--- a/Resources/ServerInfo/Guidebook/Mobs/Shadowkin.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Shadowkin.xml
@@ -38,13 +38,13 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
   -[color=#ffa500]Fragile[/color]:
   Shadowkin are vulnerable to damage from an array of sources, taking [color=#ffa500]20% more Slash and Heat damage[/color], as well as an additional [color=#ffa500]10% more pierce damage[/color].
   
-  - Shadowkin enter a critical state at [color=#ffa500] 80 total damage[/color] and die at [color=#ffa500]180 total damage.[/color]
+  - Shadowkin enter a critical state at [color=#ffa500]80 total damage[/color] and die at [color=#ffa500]180 total damage.[/color]
 
   -[color=#ffa500]Breathless[/color]:
-  Since Shadowkin do not breathe, they are incapable from benefiting from the positive effects of gasses like Healium. When a Shadowkin enters critical condition, they accumulate bloodloss damage rather than the asphyxiation that is common to other species.
+  Since Shadowkin do not breathe, they are incapable from benefiting from the positive effects of gasses like Healium. When a Shadowkin enters critical condition, they accumulate bloodloss damage rather than the asphyxiation that is common in other species.
 
   -[color=#ffa500]Easy Target[/color]:
-  Due to the fact that they're inherently psionic, they make for the easy targets of over-eager epistemics staff... and any other malicious noospheric entities.
+  Due to the fact that they're inherently psionic, they make for the easy targets of over-eager epistemics staff... as well as any other malicious noospheric entities.
 
   -[color=#ffa500]Lightweight[/color]:
   Shadowkin are naturally shorter and lighter than most species, making them more easily grabbed, picked up, or thrown.

--- a/Resources/ServerInfo/Guidebook/Mobs/Shadowkin.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Shadowkin.xml
@@ -23,28 +23,30 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
   ## Positive Traits
   -[color=#1e90ff]Anaerobic Nature[/color]:
-  Shadowkin, as a result of living in a dimension where there is little air, do not have lungs but instead a core. Their core makes it so that they do not need to respirate to survive.
+  As a result of living in a dimension with very little air, Shadowkin have a unique organ known as a core instead of a more traditional set of lungs. This core makes it so that they do not need to respirate to survive.
 
   -[color=#1e90ff]Innate Telepathy[/color]:
   Shadowkin are innately telepathic, allowing them to communicate with other psionic individuals at will.
 
   -[color=#1e90ff]Psionic Species[/color]:
-  Shadowkin as a species inhabit a unique ability to more easily learn new psionic abilities, in part owing to their home dimension being incredibly hostile to those who would be considered "normal".
+  Shadowkin as a species are uniquely predisposed to learn new psionic abilities, in part owing to their home dimension being incredibly hostile to those who do not have a strong connection to the noosphere.
 
-  -[color=#1e90ff]Resting[/color]:
-  Shadowkin are able to fall into a deep and powerful sleep to quickly recover mana to use their psionic abilities sooner than others.
+<!--  -[color=#1e90ff]Resting[/color]:
+  Shadowkin are able to fall into a deep and powerful sleep to quickly recover mana to use their psionic abilities sooner than others.-->##
 
-  ## Negative Traits
-  -[color=#ffa500]Glass Cannon[/color]:
-  Shadowkin are very vulnerable to damage from an array of sources, preferring speed and agility over direct combat.
+   Negative Traits
+  -[color=#ffa500]Fragile[/color]:
+  Shadowkin are vulnerable to damage from an array of sources, taking [color=#ffa500]20% more Slash and Heat damage[/color], as well as an additional [color=#ffa500]10% more pierce damage[/color].
+  
+  - Shadowkin enter a critical state at [color=#ffa500] 80 total damage[/color] and die at [color=#ffa500]180 total damage.[/color]
 
   -[color=#ffa500]Breathless[/color]:
-  Since Shadowkin do not breathe, they are incapable from benifiting from the positive effects of gasses like Healium. When a Shadowkin enters critical condition, they accumulate bloodloss damage rather than the asphyxiation that is common to other species.
+  Since Shadowkin do not breathe, they are incapable from benefiting from the positive effects of gasses like Healium. When a Shadowkin enters critical condition, they accumulate bloodloss damage rather than the asphyxiation that is common to other species.
 
   -[color=#ffa500]Easy Target[/color]:
-  Due to the fact they're inherently psionic, they make for easy targets by over-eager epistemics staff... and any other beasts that lurk in the dark.
+  Due to the fact that they're inherently psionic, they make for the easy targets of over-eager epistemics staff... and any other malicious noospheric entities.
 
-  -[color=#ffa500]Unfortunate Evolution[/color]:
-  Most Shadowkin are not very tall, rendering them easy to pick up and throw around. As a result, space wind hits them 20% harder and their bones are not very durable either.
+  -[color=#ffa500]Lightweight[/color]:
+  Shadowkin are naturally shorter and lighter than most species, making them more easily grabbed, picked up, or thrown.
 
 </Document>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
I changed the parent of the Shadowkin Core from Human lungs to Space Animal lungs, along with a few other tweaks. To make sure that things stay balanced, I created a component that causes Shadowkin to take bloodloss damage while in the critical state. (By created I mean I copied the PassiveDamage component code.) Normally, a mob that doesn't need to breathe will never die naturally while in the critical state, as they don't accumulate asphyxiation damage. By having Shadowkin accumulate bloodloss damage instead, I can circumvent that issue, while also ensuring that the Healing Factor and Platelet Factories traits don't allow a Shadowkin to heal out of critical condition.

In addition to those two changes, I have also:

Edited the description of the Shadowkin mob to better reflect the changes. (This is the bit that mentioned that they didn't breathe as much when you shift-clicked them)

Edited the guidebook page to more accurately reflect the pros and cons of the species, including the most recent changes.

Edited the organ names and descriptions (The core's name was just "lungs" because it wasn't set properly, even before I messed with it.)

Increased how quickly Shadowkin naturally recover from bloodloss damage to compensate for the fact that they accumulate it while in the critical state.

## Why / Balance
Shadowkin are already much less resilient than other species, taking an additional 20% heat and slash damage, as well as an additional 10% pierce damage. They also go critical at 80 total damage, and die at 180 total damage instead of the more traditional 100/200 of other species. Currently Shadowkin don't have anything super unique about them, and I feel that this will give them a little more spice, while still remaining in theme with their lore and weird biology.

## Technical details
I created a new component by reusing code from the PassiveDamage component. This is the most shitcode part of the PR, and could definitely do with a revision to make it more streamlined, I just don't really possess the skills to do that. I increased how quickly Shadowkin recover from bloodloss damage in their species yml file, altered their damage resistances to make them immune to asphyxiation damage, and edited their organs, specifically their lungs, to make them not need to breathe.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Does this need media? How would I show that? A video of the features working, maybe?
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Only time will tell.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Made it so that Shadowkin no longer need to breathe, but suffer bloodloss damage while in crit.
-->
