### PR TITLE
Remove Pipe Stacking

### DIFF
--- a/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/PipeRestrictOverlapSystem.cs
@@ -11,12 +11,11 @@ using Content.Server.NodeContainer;
 using Content.Server.NodeContainer.Nodes;
 using Content.Server.Popups;
 using Content.Shared.Atmos;
-using Content.Shared.CCVar;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Construction.Components;
+using Content.Shared.NodeContainer;
 using JetBrains.Annotations;
 using Robust.Server.GameObjects;
-using Robust.Shared.Configuration;
 using Robust.Shared.Map.Components;
 
 namespace Content.Server.Atmos.EntitySystems;
@@ -26,27 +25,20 @@ namespace Content.Server.Atmos.EntitySystems;
 /// </summary>
 public sealed class PipeRestrictOverlapSystem : EntitySystem
 {
-    [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly MapSystem _map = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly TransformSystem _xform = default!;
 
     private readonly List<EntityUid> _anchoredEntities = new();
     private EntityQuery<NodeContainerComponent> _nodeContainerQuery;
-    // Goobstation - Allow device-on-pipe stacking
-    private EntityQuery<PipeRestrictOverlapComponent> _restrictOverlapQuery;
-    public bool StrictPipeStacking = false;
 
     /// <inheritdoc/>
     public override void Initialize()
     {
         SubscribeLocalEvent<PipeRestrictOverlapComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
         SubscribeLocalEvent<PipeRestrictOverlapComponent, AnchorAttemptEvent>(OnAnchorAttempt);
-        Subs.CVar(_cfg, CCVars.StrictPipeStacking, (bool val) => {StrictPipeStacking = val;}, false);
 
         _nodeContainerQuery = GetEntityQuery<NodeContainerComponent>();
-                // Goobstation - Allow device-on-pipe stacking
-        _restrictOverlapQuery = GetEntityQuery<PipeRestrictOverlapComponent>();
     }
 
     private void OnAnchorStateChanged(Entity<PipeRestrictOverlapComponent> ent, ref AnchorStateChangedEvent args)
@@ -95,10 +87,6 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
         _anchoredEntities.Clear();
         _map.GetAnchoredEntities((grid, gridComp), indices, _anchoredEntities);
 
-
-        // ATMOS: change to long if you add more pipe layers than 5 + z levels
-        var takenDirs = PipeDirection.None;
-
         foreach (var otherEnt in _anchoredEntities)
         {
             // this should never actually happen but just for safety
@@ -108,45 +96,28 @@ public sealed class PipeRestrictOverlapSystem : EntitySystem
             if (!_nodeContainerQuery.TryComp(otherEnt, out var otherComp))
                 continue;
 
-            // Goobstation - Allow device-on-pipe stacking
-            if (!_restrictOverlapQuery.HasComp(otherEnt))
-                continue;
-
-            var (overlapping, which) = PipeNodesOverlap(ent, (otherEnt, otherComp, Transform(otherEnt)), takenDirs);
-            takenDirs |= which;
-
-            if (overlapping)
+            if (PipeNodesOverlap(ent, (otherEnt, otherComp, Transform(otherEnt))))
                 return true;
         }
 
         return false;
     }
 
-    public (bool, PipeDirection) PipeNodesOverlap(Entity<NodeContainerComponent, TransformComponent> ent, Entity<NodeContainerComponent, TransformComponent> other, PipeDirection takenDirs)
+    public bool PipeNodesOverlap(Entity<NodeContainerComponent, TransformComponent> ent, Entity<NodeContainerComponent, TransformComponent> other)
     {
         var entDirsAndLayers = GetAllDirectionsAndLayers(ent).ToList();
         var otherDirsAndLayers = GetAllDirectionsAndLayers(other).ToList();
-        var entDirsCollapsed = PipeDirection.None;
 
         foreach (var (dir, layer) in entDirsAndLayers)
         {
-            entDirsCollapsed |= dir;
             foreach (var (otherDir, otherLayer) in otherDirsAndLayers)
             {
-                if (layer != otherLayer) continue;
-                takenDirs |= otherDir;
-                if (StrictPipeStacking)
-                    if ((dir & otherDir) != 0)
-                        return (true, takenDirs);
-                    else
-                    if ((dir ^ otherDir) != 0)
-                        break;
+                if ((dir & otherDir) != 0 && layer == otherLayer)
+                    return true;
             }
         }
 
-        // If no strict pipe stacking, then output ("are all entDirs occupied", takenDirs)
-        return (StrictPipeStacking ? false : ((takenDirs & entDirsCollapsed) == entDirsCollapsed), takenDirs);
-
+        return false;
 
         IEnumerable<(PipeDirection, AtmosPipeLayer)> GetAllDirectionsAndLayers(Entity<NodeContainerComponent, TransformComponent> pipe)
         {

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -97,7 +97,7 @@
   - type: PipeAppearance
   - type: PipeColorVisuals
   - type: NodeContainer
-  # - type: PipeRestrictOverlap - Allow pipe stacking
+  - type: PipeRestrictOverlap
   - type: AtmosUnsafeUnanchor
   - type: AtmosPipeColor
   - type: AtmosMonitoringConsoleDevice
@@ -109,15 +109,6 @@
     bodyType: static
   - type: StaticPrice
     price: 11
-
-# Goobstation - Allow device-on-pipe stacking
-
-- type: entity
-  abstract: true
-  parent: GasPipeBase
-  id: GasPipeNoOverlap
-  components:
-  - type: PipeRestrictOverlap
 
 - type: entity
   abstract: true
@@ -134,7 +125,7 @@
 #Note: The PipeDirection of the PipeNode should be the south-facing version, because the entity starts at an angle of 0 (south)
 
 - type: entity
-  parent: GasPipeNoOverlap
+  parent: GasPipeBase
   id: GasPipeHalf
   suffix: Half
   placement:
@@ -204,7 +195,7 @@
       collection: MetalThud # this NEEDS to changed to the metal pipe falling sound effect on april first every year
 
 - type: entity
-  parent: GasPipeNoOverlap
+  parent: GasPipeBase
   id: GasPipeBend
   suffix: Bend
   placement:
@@ -250,7 +241,7 @@
         Blunt: 3 #This should be 6 but throwing damage is doubled at the moment for some reason so for now it's 3
 
 - type: entity
-  parent: GasPipeNoOverlap
+  parent: GasPipeBase
   id: GasPipeTJunction
   placement:
     mode: AlignAtmosPipeLayers
@@ -289,7 +280,7 @@
       collection: MetalThud
 
 - type: entity
-  parent: GasPipeNoOverlap
+  parent: GasPipeBase
   id: GasPipeFourway
   suffix: Fourway
   placement:
@@ -331,7 +322,7 @@
 
 - type: entity
   id: GasPipeBroken
-  parent: GasPipeNoOverlap
+  parent: GasPipeBase
   name: broken pipe
   description: It used to hold gas.
   components:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -295,7 +295,7 @@
       key: enum.ThermomachineUiKey.Key
     - type: WiresPanel
     - type: WiresVisuals
-    #- type: PipeRestrictOverlap  Allow for pipe stacking
+    - type: PipeRestrictOverlap
     - type: NodeContainer
       nodes:
         pipe:
@@ -480,7 +480,7 @@
         Secondary: Structures/Piping/Atmospherics/condenser_alt1.rsi
         Tertiary: Structures/Piping/Atmospherics/condenser_alt2.rsi
   - type: AtmosDevice
-  #- type: PipeRestrictOverlap # Allow pipe stacking on device.
+  - type: PipeRestrictOverlap
   - type: ApcPowerReceiver
     powerLoad: 10000
   - type: Machine

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
@@ -191,7 +191,7 @@
           nodeGroupID: Teg
 
     - type: AtmosUnsafeUnanchor
-    # - type: PipeRestrictOverlap # Allow pipe stacking
+    - type: PipeRestrictOverlap
     - type: TegCirculator
     - type: StealTarget
       stealGroup: Teg


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Makes the same balance decision as https://github.com/space-wizards/space-station-14/pull/28308 - removes the ability to place multiple pipes on the same layer, facing the same direction. The same goes for machines and other pipe-connected devices.
(The code for it was already present, but unused)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Pipe stacking was a bug, not an intended game feature. While some forks like goob have deliberately reintroduced it, it's unintuitive, visually confusing, and over-trivializes some aspects of atmos gameplay. It also isn't needed with the pipe layering system that was recently introduced.
Even in deliberate re-implementations, it continues to _seem_ like a bug during gameplay, because atmos was never designed (visually or mechanically) to work this way.
It also allowed for situations like dozens of identical straight pipes being layerable in the same spot and position:
![toomanypipes](https://github.com/user-attachments/assets/a14487b7-ce02-4b63-8fa0-ec1670e60321)

## Technical details
<!-- Summary of code changes for easier review. -->
Removes goob code (YAML and modifications to PipeRestrictOverlapSystem) to that allows for pipe stacking. Uncomments PipeRestrictOverlap on various atmos objects.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2df6d408-0d3a-4093-bfb9-b038c16df808


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Multiple pipes facing the same direction can no longer be placed on the same tile. You can still have overlapping straight pipes, corners going in opposite directions, or use pipe layering.

