### PR TITLE
Make the Examine Tooltip's Max Width Configurable

### DIFF
--- a/Content.Client/Examine/ExamineSystem.cs
+++ b/Content.Client/Examine/ExamineSystem.cs
@@ -53,6 +53,8 @@ using static Robust.Client.UserInterface.Controls.BoxContainer;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Direction = Robust.Shared.Maths.Direction;
+using Content.Shared._DEN.CCVars;
+using Robust.Shared.Configuration;
 
 namespace Content.Client.Examine
 {
@@ -61,6 +63,7 @@ namespace Content.Client.Examine
     {
         [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
         [Dependency] private readonly IPlayerManager _playerManager = default!;
+        [Dependency] private readonly IConfigurationManager _cfg = default!; // DEN - For examine tooltip width
         [Dependency] private readonly IEyeManager _eyeManager = default!;
         [Dependency] private readonly VerbSystem _verbSystem = default!;
 
@@ -232,7 +235,9 @@ namespace Content.Client.Examine
             }
 
             // Actually open the tooltip.
-            _examineTooltipOpen = new Popup { MaxWidth = 400 };
+            var maxTooltipWidth = _cfg.GetCVar(DenCCVars.ExamineTooltipWidth); // DEN - Make this a CCVar
+            _examineTooltipOpen = new Popup { MaxWidth = maxTooltipWidth };
+
             _userInterfaceManager.ModalRoot.AddChild(_examineTooltipOpen);
             var panel = new PanelContainer() { Name = "ExaminePopupPanel" };
             panel.AddStyleClass(StyleClassEntityTooltip);

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml
@@ -50,6 +50,18 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
                 <CheckBox Name="EnableColorNameCheckBox" Text="{Loc 'ui-options-enable-color-name'}" />
                 <CheckBox Name="ColorblindFriendlyCheckBox" Text="{Loc 'ui-options-colorblind-friendly'}" />
                 <CheckBox Name="DisableFiltersCheckBox" Text="{Loc 'ui-options-no-filters'}" />
+
+                <!-- Den: Examine tooltip width -->
+                <BoxContainer Orientation="Vertical" Margin="10">
+                    <Label Name="ExamineTooltipWidthLabel" />
+                    <Slider Name="ExamineTooltipWidthSlider"
+                        MinValue="24"
+                        MaxValue="72"
+                        MinWidth="200" />
+                    <!-- Note: These values are multiplied by 10 when converted to/from the CCVar to the slider. -->
+                    <!-- This is so that we can move the slider in increments of 10. -->
+                </BoxContainer>
+
                 <BoxContainer Orientation="Horizontal">
                     <Label Text="{Loc 'ui-options-chatstack'}" />
                     <Control MinSize="4 0" />
@@ -72,6 +84,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
                             MinWidth="200" />
                     <Label Name="ScreenShakeIntensityLabel" Margin="8 0" />
                 </BoxContainer>
+
                 <!-- Chat Highlighting - Den -->
                 <CheckBox Name="AutoFillHighlightsCheckBox" Text="{Loc 'ui-options-auto-fill-highlights'}" />
                 <Label Text="{Loc 'ui-options-highlights-color'}" Margin="0 5 0 0" />

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -19,6 +19,7 @@
 
 using System.Linq;
 using Content.Client.UserInterface.Screens;
+using Content.Shared._DEN.CCVars;
 using Content.Shared._DV.CCVars;
 using Content.Shared._Impstation.CCVar;
 using Content.Shared.CCVar;
@@ -45,6 +46,9 @@ namespace Content.Client.Options.UI.Tabs
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
         private readonly Dictionary<string, int> _hudThemeIdToIndex = new();
+
+        // DEN: Examine tooltip width slider
+        const float ExamineWidthIncrement = 10.0f;
 
         public MiscTab()
         {
@@ -114,6 +118,8 @@ namespace Content.Client.Options.UI.Tabs
             DisableDrunkWarpingCheckBox.OnToggled += OnCheckBoxToggled;
             ChatWindowOpacitySlider.OnValueChanged += OnChatWindowOpacitySliderChanged;
             ScreenShakeIntensitySlider.OnValueChanged += OnScreenShakeIntensitySliderChanged;
+            ExamineTooltipWidthSlider.OnValueChanged += OnExamineTooltipWidthSliderChanged; // DEN: Examine tooltip width
+
             // ToggleWalk.OnToggled += OnCheckBoxToggled;
             StaticStorageUI.OnToggled += OnCheckBoxToggled;
             ModernProgressBar.OnToggled += OnCheckBoxToggled;
@@ -140,6 +146,13 @@ namespace Content.Client.Options.UI.Tabs
             DisableDrunkWarpingCheckBox.Pressed = _cfg.GetCVar(DCCVars.DisableDrunkWarping);//den edit
             ChatWindowOpacitySlider.Value = _cfg.GetCVar(CCVars.ChatWindowOpacity);
             ScreenShakeIntensitySlider.Value = _cfg.GetCVar(CCVars.ScreenShakeIntensity) * 100f;
+
+            // DEN: Examine tooltip width slider
+            var tooltipWidth = _cfg.GetCVar(DenCCVars.ExamineTooltipWidth);
+            var tooltipSliderValue = ToSliderIncrementValue(tooltipWidth, ExamineWidthIncrement);
+            ExamineTooltipWidthSlider.SetValueWithoutEvent(tooltipSliderValue);
+            UpdateExamineTooltipWidthLabel();
+
             // ToggleWalk.Pressed = _cfg.GetCVar(CCVars.ToggleWalk);
             StaticStorageUI.Pressed = _cfg.GetCVar(CCVars.StaticStorageUI);
             ModernProgressBar.Pressed = _cfg.GetCVar(CCVars.ModernProgressBar);
@@ -177,11 +190,32 @@ namespace Content.Client.Options.UI.Tabs
             UpdateApplyButton();
         }
 
+        // DEn Start: Examine tooltip maximum width setting
+        private void OnExamineTooltipWidthSliderChanged(Range obj)
+        {
+            ExamineTooltipWidthSlider.Value = (int) ExamineTooltipWidthSlider.Value;
+            UpdateExamineTooltipWidthLabel();
+            UpdateApplyButton();
+        }
+
+        private void UpdateExamineTooltipWidthLabel()
+        {
+            var pixelWidth = FromSliderIncrementValue(ExamineTooltipWidthSlider.Value, ExamineWidthIncrement);
+            var labelText = Loc.GetString("ui-options-examine-tooltip-width-label",
+                ("width", (int) pixelWidth));
+            ExamineTooltipWidthLabel.Text = labelText;
+        }
+        // End DEN
+
         private void OnChatHighlightingColorpickerChanged()
         {
             ExampleLabel.FontColorOverride = ChatHighlightingColorpicker.Color;
             UpdateApplyButton();
         }
+
+        // DEN: Helper functions for examine tooltip width slider
+        private static float ToSliderIncrementValue(float value, float increment) => value / increment;
+        private static float FromSliderIncrementValue(float value, float increment) => value * increment;
 
         private void OnApplyButtonPressed(BaseButton.ButtonEventArgs args)
         {
@@ -205,11 +239,16 @@ namespace Content.Client.Options.UI.Tabs
             _cfg.SetCVar(CCVars.ChatEnableColorName, EnableColorNameCheckBox.Pressed);
             _cfg.SetCVar(CCVars.AccessibilityColorblindFriendly, ColorblindFriendlyCheckBox.Pressed);
             _cfg.SetCVar(CCVars.ReducedMotion, ReducedMotionCheckBox.Pressed);
-            _cfg.SetCVar(ImpCCVars.DisableSinguloWarping,DisableSinguloWarpingCheckBox.Pressed);
-            _cfg.SetCVar(DCCVars.DisableDrugWarping,DisableDrugWarpingCheckBox.Pressed);//den edit
-            _cfg.SetCVar(DCCVars.DisableDrunkWarping,DisableDrunkWarpingCheckBox.Pressed);//den edit
+            _cfg.SetCVar(ImpCCVars.DisableSinguloWarping, DisableSinguloWarpingCheckBox.Pressed);
+            _cfg.SetCVar(DCCVars.DisableDrugWarping, DisableDrugWarpingCheckBox.Pressed);//den edit
+            _cfg.SetCVar(DCCVars.DisableDrunkWarping, DisableDrunkWarpingCheckBox.Pressed);//den edit
             _cfg.SetCVar(CCVars.ChatWindowOpacity, ChatWindowOpacitySlider.Value);
             _cfg.SetCVar(CCVars.ScreenShakeIntensity, ScreenShakeIntensitySlider.Value / 100f);
+
+            // DEN: Examine tooltip maximum width
+            var examineWidth = FromSliderIncrementValue(ExamineTooltipWidthSlider.Value, ExamineWidthIncrement);
+            _cfg.SetCVar(DenCCVars.ExamineTooltipWidth, examineWidth);
+
             // _cfg.SetCVar(CCVars.ToggleWalk, ToggleWalk.Pressed);
             _cfg.SetCVar(CCVars.StaticStorageUI, StaticStorageUI.Pressed);
             _cfg.SetCVar(CCVars.ModernProgressBar, ModernProgressBar.Pressed);
@@ -249,6 +288,11 @@ namespace Content.Client.Options.UI.Tabs
             var isDisableDrunkWarpingSame = DisableDrunkWarpingCheckBox.Pressed == _cfg.GetCVar(DCCVars.DisableDrunkWarping);//den edit
             var isChatWindowOpacitySame = Math.Abs(ChatWindowOpacitySlider.Value - _cfg.GetCVar(CCVars.ChatWindowOpacity)) < 0.01f;
             var isScreenShakeIntensitySame = Math.Abs(ScreenShakeIntensitySlider.Value / 100f - _cfg.GetCVar(CCVars.ScreenShakeIntensity)) < 0.01f;
+
+            // DEN: Examine tooltip maximum width
+            var examineSliderWidth = FromSliderIncrementValue(ExamineTooltipWidthSlider.Value, ExamineWidthIncrement);
+            var isExamineTooltipWidthSame = examineSliderWidth == _cfg.GetCVar(DenCCVars.ExamineTooltipWidth);
+
             // var isToggleWalkSame = ToggleWalk.Pressed == _cfg.GetCVar(CCVars.ToggleWalk);
             var isStaticStorageUISame = StaticStorageUI.Pressed == _cfg.GetCVar(CCVars.StaticStorageUI);
             var isModernProgressBarSame = ModernProgressBar.Pressed == _cfg.GetCVar(CCVars.ModernProgressBar);
@@ -277,6 +321,7 @@ namespace Content.Client.Options.UI.Tabs
                                    isDisableDrunkWarpingSame && //den edit
                                    isChatWindowOpacitySame &&
                                    isScreenShakeIntensitySame &&
+                                   isExamineTooltipWidthSame && // DEN: Examine tooltip maximum width
                                    // isToggleWalkSame &&
                                    isStaticStorageUISame &&
                                    isModernProgressBarSame &&

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -193,7 +193,7 @@ namespace Content.Client.Options.UI.Tabs
         // DEn Start: Examine tooltip maximum width setting
         private void OnExamineTooltipWidthSliderChanged(Range obj)
         {
-            var intValue = (int)ExamineTooltipWidthSlider.Value;
+            var intValue = (int) ExamineTooltipWidthSlider.Value;
             ExamineTooltipWidthSlider.SetValueWithoutEvent(intValue);
             UpdateExamineTooltipWidthLabel();
             UpdateApplyButton();

--- a/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/MiscTab.xaml.cs
@@ -193,7 +193,8 @@ namespace Content.Client.Options.UI.Tabs
         // DEn Start: Examine tooltip maximum width setting
         private void OnExamineTooltipWidthSliderChanged(Range obj)
         {
-            ExamineTooltipWidthSlider.Value = (int) ExamineTooltipWidthSlider.Value;
+            var intValue = (int)ExamineTooltipWidthSlider.Value;
+            ExamineTooltipWidthSlider.SetValueWithoutEvent(intValue);
             UpdateExamineTooltipWidthLabel();
             UpdateApplyButton();
         }

--- a/Content.Shared/_DEN/CCVars/DenCCVars.cs
+++ b/Content.Shared/_DEN/CCVars/DenCCVars.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._DEN.CCVars;
+
+[CVarDefs]
+public sealed class DenCCVars
+{
+    /// <summary>
+    /// The maximum width of the examine tooltip.
+    /// </summary>
+    public static readonly CVarDef<float> ExamineTooltipWidth =
+        CVarDef.Create("ui.examine_tooltip_width", 400.0f, CVar.CLIENTONLY | CVar.ARCHIVE);
+}

--- a/Resources/Locale/en-US/_DEN/escape-menu/options-menu.ftl
+++ b/Resources/Locale/en-US/_DEN/escape-menu/options-menu.ftl
@@ -14,3 +14,5 @@ ui-options-blue = Blue
 ui-options-auto-fill-highlights = Auto-fill the highlights with the character's information
 ui-options-highlights-color = Highlights color:
 ui-options-highlights-color-example = This is a highlighted text.
+
+ui-options-examine-tooltip-width-label = Examine tooltip width: {$width}


### PR DESCRIPTION
## About the PR
This PR adds a new option to configure the maximum width of the examine tooltip.

## Why / Balance
That shit takes up so much vertical space sometimes are you kidding me

## Technical details
New CVar, added a new slider to the options menu, updated examine code.
Note that the options menu UI code is a little odd because I wanted the slider to move in increments of 10 pixels rather than 1 pixel. It's a lot more visually polished that way.

This value is not validated, because if you go into your client config and change the value to be less than 240 or more than 720, that is not my problem.

## Media

https://github.com/user-attachments/assets/1258d153-d06d-4718-994a-e16adb289f47

These screenshots are not from this PR specifically but they are from an identical PR that did the same thing that I wrote before my computer exploded:

<img width="405" height="466" alt="image" src="https://github.com/user-attachments/assets/ea6655b7-bb74-4b80-a08d-9210488c745e" />

<img width="518" height="402" alt="image" src="https://github.com/user-attachments/assets/9a92a2db-4a2a-4cf7-92d0-04deb666e6d3" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Not to my knowledge?

**Changelog**
:cl:
- add: You can now configure the maximum width of the examine tooltip in the options menu.