### PR TITLE
Fixing Door Remotes and Blast Doors

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -55,6 +55,8 @@
     - board
   - type: StaticPrice
     price: 280
+  - type: ApcPowerReceiver
+  - type: ExtensionCableReceiver
 
 - type: entity
   id: BlastDoorOpen


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Door remotes never worked with blast doors giving a "not powered" message. Made it so blast doors now receive power to allow door remotes to open/close them.

## Why / Balance
I figured this was a bug or was overlooked. I remember being able to open blast doors with door remotes on other servers. This will mainly affect atmos techs and CE to finally be able to vent burn chambers or other rooms that have blast doors.

## Technical details
Simply added ApcPowerReceiver and ExtensionCableReceiver to allow door remotes to open blast doors if there is power.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None that I know of.

**Changelog**
:cl: LilNutters
- tweak: Blast doors now receive power in order to allow door remotes to open/close them!
