### PR TITLE
Make Passports Use Custom Species

### DIFF
--- a/Content.Shared/_EE/Contractors/Systems/SharedPassportSystem.cs
+++ b/Content.Shared/_EE/Contractors/Systems/SharedPassportSystem.cs
@@ -4,9 +4,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
+using System.Globalization;
 using Content.Shared._EE.Contractors.Components;
 using Content.Shared._EE.Contractors.Prototypes;
 using Content.Shared.Administration.Logs;
+using Content.Shared.Chat;
 using Content.Shared.Clothing.Loadouts.Systems;
 using Content.Shared.Database;
 using Content.Shared.Examine;
@@ -34,6 +36,7 @@ public class SharedPassportSystem : EntitySystem
     [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
     [Dependency] private readonly SharedTransformSystem _sharedTransformSystem = default!;
+    [Dependency] private readonly SharedChatSystem _chat = default!; // DEN
 
     public override void Initialize()
     {
@@ -52,9 +55,14 @@ public class SharedPassportSystem : EntitySystem
             return;
 
         var species = _prototypeManager.Index<SpeciesPrototype>(component.OwnerProfile.Species);
+        // DEN - Use custom species name instead
+        var speciesName = !string.IsNullOrWhiteSpace(component.OwnerProfile.Customspeciename)
+            ? _chat.SanitizeMessageCapital(component.OwnerProfile.Customspeciename)
+            : Loc.GetString(species.Name);
+        // End DEN
 
         args.PushMarkup($"Registered to: {component.OwnerProfile.Name}", 50);
-        args.PushMarkup($"Species: {Loc.GetString(species.Name)}", 49);
+        args.PushMarkup($"Species: {speciesName}", 49); // DEN - Use custom species name
         args.PushMarkup($"Sex: {component.OwnerProfile.Gender}", 48);
         args.PushMarkup($"Height: {MathF.Round(component.OwnerProfile.Height * species.AverageHeight)} cm", 47);
         args.PushMarkup($"Year of Birth: {CurrentYear - component.OwnerProfile.Age}", 46);


### PR DESCRIPTION
## About the PR
This PR makes passports use the custom species field on their examine description.

## Why / Balance
Passports are entirely a lore/roleplay item; it makes more sense for it to read in accordance to the cosmetic species label.

## Technical details
Tiny little C# tweak. If the character has a custom species name, it will use it (capitalizing the first letter if needed). Otherwise if the custom species is null or whitespace, it will fallback to their base species' name.

## Media
Custom species:
<img width="493" height="265" alt="image" src="https://github.com/user-attachments/assets/5ed25dcd-7851-4436-a63b-57722c7479e8" />

No custom species:
<img width="507" height="273" alt="image" src="https://github.com/user-attachments/assets/f722c59e-5ad3-4c85-ae15-c81ac5da0a4e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
If you were roleplaying out the fact the species label was incorrect, it is no longer incorrect. Or if your species name would make little sense to be on a passport. Oopsy!!!!!! I think most people just ignore the passport, though.

**Changelog**
:cl:
- tweak: Passports now use your characters' custom species label, if one is defined.