### PR TITLE
Remove Brightness Restriction on "Hues" Skin Tone

### DIFF
--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -21,7 +21,7 @@ public static class SkinColor
     public const float MaxTintedHuesSaturation = 0.1f;
     public const float MinTintedHuesLightness = 0.85f;
 
-    public const float MinHuesLightness = 0.175f;
+    public const float MinHuesLightness = 0.0f; // DEN - Remove brightness restriction on skin tones
 
     public const float MinFeathersHue = 29f / 360;
     public const float MaxFeathersHue = 174f / 360;


### PR DESCRIPTION
## About the PR
This PR removes the 17.5% minimum lightness on skin tone values for the "Hues" (RGB slider) skin tone type, allowing players to make characters that have #000000 black skin if they desire.

## Why / Balance
Markings already lack this limitation entirely. A discussion thread was held on this and approved by Jenn.

https://discord.com/channels/1301753657024319488/1425419715681193984/1425419715681193984

<img width="708" height="190" alt="image" src="https://github.com/user-attachments/assets/0c243c14-3708-4e34-b1e0-f1e4a87362c9" />

## Technical details
One line C# change warrior

## Media
<img width="1558" height="931" alt="image" src="https://github.com/user-attachments/assets/5b86e85a-0df1-4a02-a3bc-27c3e39d92ad" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
- tweak: Species no longer have a minimum brightness limit on their skin tones, allowing one to make characters with pitch-black base sprites if they so desired.