### PR TITLE
Removes Asimov From Roundstart Laws

### DIFF
--- a/Resources/Migrations/denMigrations.yml
+++ b/Resources/Migrations/denMigrations.yml
@@ -137,3 +137,6 @@ SyringeCognizine: null
 Bible: HolyBookBible
 BibleMystagogue: HolyBookMystagogue
 BibleNecronomicon: HolyBookNecronomicon
+
+# October 18th 2025 - Remove Asimov laws
+AsimovCircuitBoard: null

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -367,7 +367,7 @@
         prob: 0.3
       - id: PsiWatchCartridge
       - id: StationAiUploadCircuitboard
-      - id: AsimovCircuitBoard
+#      - id: AsimovCircuitBoard
       - id: AugustineCircuitBoard
       - id: CrewsimovCircuitBoard
       - id: AntimovCircuitBoard
@@ -398,7 +398,7 @@
         prob: 0.3
       - id: PsiWatchCartridge
       - id: StationAiUploadCircuitboard
-      - id: AsimovCircuitBoard
+#      - id: AsimovCircuitBoard
       - id: AugustineCircuitBoard
       - id: CrewsimovCircuitBoard
       - id: AntimovCircuitBoard

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -353,7 +353,7 @@
     factions:
     - NanoTrasen
   - type: SiliconLawProvider
-    laws: Asimov
+    laws: Crewsimov
   - type: Access
     enabled: false
     groups:

--- a/Resources/Prototypes/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/Entities/Stations/nanotrasen.yml
@@ -40,7 +40,7 @@
     - BaseStationAlertLevels
     - BaseStationMagnet
     - BaseStationExpeditions
-    - BaseStationSiliconLawAsimov
+    - BaseStationSiliconLawCrewsimov
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
     - BaseRandomStation
@@ -87,7 +87,7 @@
     - BaseStationAlertLevels
     - BaseStationMagnet
     - BaseStationExpeditions
-    - BaseStationSiliconLawAsimov
+    - BaseStationSiliconLawCrewsimov
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
     - BaseRandomStation
@@ -111,7 +111,7 @@
     - BaseStationAlertLevels
     - BaseStationMagnet
     - BaseStationExpeditions
-    - BaseStationSiliconLawAsimov
+    - BaseStationSiliconLawCrewsimov
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
     - BaseRandomStation
@@ -136,7 +136,7 @@
     - BaseStationAlertLevels
     - BaseStationMagnet
     - BaseStationExpeditions
-    - BaseStationSiliconLawAsimov
+    - BaseStationSiliconLawCrewsimov
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
     - BaseRandomStation


### PR DESCRIPTION
speciesism

:cl:
- remove: Asimov is no longer the default lawset (replaced by Crewsimov) and was removed from the default spawn pool, making it admin-only.