### PR TITLE
Fix Blocked UI Interaction on Unpowered Devices (#36319)

### DIFF
--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Held.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.Held.cs
@@ -134,18 +134,19 @@ public abstract partial class SharedStationAiSystem
         if (ev.Actor == ev.Target)
             return;
 
-        // no need to show menu if device is not powered.
-        if (!PowerReceiver.IsPowered(ev.Target))
-        {
-            ShowDeviceNotRespondingPopup(ev.Actor);
-            ev.Cancel();
-            return;
-        }
-
         if (TryComp(ev.Actor, out StationAiHeldComponent? aiComp) &&
            (!TryComp(ev.Target, out StationAiWhitelistComponent? whitelistComponent) ||
             !ValidateAi((ev.Actor, aiComp))))
         {
+            // Don't allow the AI to interact with anything that isn't powered.
+            if (!PowerReceiver.IsPowered(ev.Target))
+            {
+                ShowDeviceNotRespondingPopup(ev.Actor);
+                ev.Cancel();
+                return;
+            }
+
+            // Don't allow the AI to interact with anything that it isn't allowed to (ex. AI wire is cut)
             if (whitelistComponent is { Enabled: false })
             {
                 ShowDeviceNotRespondingPopup(ev.Actor);


### PR DESCRIPTION
https://github.com/space-wizards/space-station-14/pull/36319

:cl: ArtisticRoomba
- fix: Fixed players being unable to interact with or open any machine UI if the machine is unpowered (ex. wirepanels).