### PR TITLE
Give Service Worker Hydroponics, Bar, and Kitchen Access (without Extended Access)

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -44,10 +44,9 @@
   access:
   - Service
   - Maintenance
-  extendedAccess:
-  - Hydroponics
-  - Bar # DeltaV - moved to extended access
-  - Kitchen # DeltaV - moved to extended access
+  - Hydroponics # DEN - Moved to regular access
+  - Bar # DEN - Moved to regular access
+  - Kitchen # DEN - Moved to regular access
 
 - type: startingGear
   id: ServiceWorkerGear


### PR DESCRIPTION
## About the PR
This PR moves hydroponics, bar, and kitchen accesses from "skeleton crew" access into default access for Service Worker.

## Why / Balance
Service Worker already has these accesses on a majority of shifts, as incredibly few shifts have more than >15 characters roundstart. On the few exceptions, this mostly just creates a mild hassle for Service Workers and Command who have to get their ID accesses sorted out.

In addition, this change was made on Delta-V last year, and it allowed mappers to create maps where Service Worker made up the service department, instead of specific chef/bar/botany roles - namely on Chibi Station. With plans for Eternity where the division of concerns among a department's staff are incredibly downplayed, it would be useful to make Service Worker more flexible here too.

## Technical details
3-5 line YML change. 

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [ ] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Service Workers now have Bar, Hydroponics, and Kitchen access by default - not just on skeleton crew access.