### PR TITLE
Fix Empty RCDs Lacking Most of Their Options, Including Deconstruct

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -774,20 +774,6 @@
   components:
   - type: LimitedCharges
     charges: 0
-  - type: RCD
-    availablePrototypes:
-    - WallSolid
-    - FloorSteel
-    - Plating
-    - Catwalk
-    - Grille
-    - Window
-    - WindowDirectional
-    - WindowReinforcedDirectional
-    - ReinforcedWindow
-    - Airlock
-    - AirlockGlass
-    - Firelock
 
 - type: entity
   id: RPDEmpty


### PR DESCRIPTION
## About the PR
RCDs printed from the engifab (RCDEmpty) were lacking a lot of buttons in their action wheel for some reason. I notice that empty RCDs have a different prototype list than roundstart RCDs, which is weird and unintuitive, so I nuked the redundant list so it uses the same as full (roundstart) RCDs.

## Why / Balance
This is a bug

## Technical details
Deleted a component definition in RCDEmpty so that it inherits from its parent.

## Media
Before:
<img width="452" height="441" alt="image" src="https://github.com/user-attachments/assets/a69cf979-6b2e-4389-9f65-628edb8f15e2" />


After:
<img width="411" height="413" alt="image" src="https://github.com/user-attachments/assets/a139849b-c5c0-4f52-82ad-9b8c603cf888" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
More like fixing changes

**Changelog**
:cl:
- fix: RCDs printed at the engineering fabricator now have all of their options.