### PR TITLE
Remove Species Language Trait

### DIFF
--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -46,6 +46,7 @@ using Content.Shared.Humanoid;
 using Content.Shared.Speech;
 using Robust.Shared.Utility;
 using Robust.Shared.GameStates;
+using Content.Shared.Language;
 
 namespace Content.Server.Traits;
 
@@ -237,12 +238,32 @@ public sealed partial class TraitModifyLanguages : TraitFunction
     [DataField, AlwaysPushInheritance]
     public List<string>? RemoveLanguagesUnderstood { get; private set; } = default!;
 
+    /// <summary>
+    /// DEN: Before anything else is processed, all languages except these are removed from the "Spoken" list.
+    /// </summary>
+    [DataField, AlwaysPushInheritance]
+    public List<ProtoId<LanguagePrototype>>? KeepLanguagesSpoken { get; private set; } = null;
+
+    /// <summary>
+    /// DEN: Before anything else is processed, all languages except these are removed from the "Understood" list.
+    /// </summary>
+    [DataField, AlwaysPushInheritance]
+    public List<ProtoId<LanguagePrototype>>? KeepLanguagesUnderstood { get; private set; } = null;
+
     public override void OnPlayerSpawn(EntityUid uid,
         IComponentFactory factory,
         IEntityManager entityManager,
         ISerializationManager serializationManager)
     {
         var language = entityManager.System<LanguageSystem>();
+
+        // DEN start: remove species languages
+        if (KeepLanguagesSpoken is not null)
+            language.ReplaceLanguagesSpoken(uid, KeepLanguagesSpoken);
+
+        if (KeepLanguagesUnderstood is not null)
+            language.ReplaceLanguagesSpoken(uid, KeepLanguagesUnderstood);
+        // DEN end
 
         if (RemoveLanguagesSpoken is not null)
             foreach (var lang in RemoveLanguagesSpoken)

--- a/Content.Server/_DEN/Language/LanguageSystem.cs
+++ b/Content.Server/_DEN/Language/LanguageSystem.cs
@@ -1,0 +1,28 @@
+using Content.Shared.Language;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Language;
+
+public sealed partial class LanguageSystem
+{
+    // i hope our last few remaining friends give up on trying to save us
+    public void ReplaceLanguagesUnderstood(Entity<LanguageKnowledgeComponent?> ent,
+        List<ProtoId<LanguagePrototype>> languages)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return;
+
+        ent.Comp.UnderstoodLanguages = languages;
+        UpdateEntityLanguages(ent.Owner);
+    }
+
+    public void ReplaceLanguagesSpoken(Entity<LanguageKnowledgeComponent?> ent,
+        List<ProtoId<LanguagePrototype>> languages)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return;
+
+        ent.Comp.SpokenLanguages = languages;
+        UpdateEntityLanguages(ent.Owner);
+    }
+}

--- a/Resources/Locale/en-US/_DEN/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/traits.ftl
@@ -107,3 +107,11 @@ trait-name-Chittin = Chittin
 trait-description-Chittin =
     A language consisting of clicks, buzzes, and some variety of harsh insect sounds.
     Most of what makes up their speech comes from their antennae, making it a near-impossible language for those without to learn.
+
+trait-name-RemoveSpeciesLanguage = No Species Language
+trait-description-RemoveSpeciesLanguage =
+    You cannot speak or understand your species' cultural language - only Tau-Ceti Basic.
+
+trait-name-RemoveSpeciesLanguageLight = No Species Language (Light)
+trait-description-RemoveSpeciesLanguageLight =
+    You cannot speak your species' cultural language, but you can still understand them.

--- a/Resources/Prototypes/Traits/inconveniences.yml
+++ b/Resources/Prototypes/Traits/inconveniences.yml
@@ -85,6 +85,8 @@
       traits:
         - Foreigner
         - XenoglossyPower
+        - RemoveSpeciesLanguage # DEN - Remove species language traits
+        - RemoveSpeciesLanguageLight # DEN - Remove species language traits
     - !type:CharacterItemGroupRequirement
       group: TraitsMuted
     - !type:CharacterJobRequirement
@@ -114,6 +116,8 @@
       traits:
         - ForeignerLight
         - XenoglossyPower
+        - RemoveSpeciesLanguage # DEN - Remove species language traits
+        - RemoveSpeciesLanguageLight # DEN - Remove species language traits
     - !type:CharacterItemGroupRequirement
       group: TraitsMuted
     - !type:CharacterJobRequirement

--- a/Resources/Prototypes/Traits/mental.yml
+++ b/Resources/Prototypes/Traits/mental.yml
@@ -443,6 +443,8 @@
       traits:
         - Foreigner
         - ForeignerLight
+        - RemoveSpeciesLanguage # DEN - Remove species language traits
+        - RemoveSpeciesLanguageLight # DEN - Remove species language traits
     - !type:CharacterLogicOrRequirement
       requirements:
         - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/_DEN/Traits/languages.yml
+++ b/Resources/Prototypes/_DEN/Traits/languages.yml
@@ -15,7 +15,6 @@
       inverted: true
       species:
         - Felinid
-        - Oni
   functions:
     - !type:TraitModifyLanguages
       languagesSpoken:
@@ -264,3 +263,50 @@
         - Chittin
       languagesUnderstood:
         - Chittin
+
+- type: trait
+  id: RemoveSpeciesLanguage
+  category: TraitsSpeechLanguages
+  priority: -10 # come before all species language traits
+  points: 2
+  requirements:
+  - !type:CharacterTraitRequirement
+    inverted: true
+    traits:
+    - RemoveSpeciesLanguageLight
+    - Foreigner
+    - ForeignerLight
+    - XenoglossyPower
+  - !type:CharacterSpeciesRequirement
+    inverted: true
+    species:
+    # NO FREE POINTS FOR YOU
+    - Oni
+    - Resomi
+  functions:
+  - !type:TraitModifyLanguages
+    keepLanguagesSpoken: [TauCetiBasic]
+    keepLanguagesUnderstood: [TauCetiBasic]
+
+- type: trait
+  id: RemoveSpeciesLanguageLight
+  category: TraitsSpeechLanguages
+  priority: -10 # come before all species language traits
+  points: 1
+  requirements:
+  - !type:CharacterTraitRequirement
+    inverted: true
+    traits:
+    - RemoveSpeciesLanguage
+    - Foreigner
+    - ForeignerLight
+    - XenoglossyPower
+  - !type:CharacterSpeciesRequirement
+    inverted: true
+    species:
+    # NO FREE POINTS FOR YOU
+    - Oni
+    - Resomi
+  functions:
+  - !type:TraitModifyLanguages
+    keepLanguagesSpoken: [TauCetiBasic] # Can't speak anything else, but can understand them


### PR DESCRIPTION
## About the PR
This PR adds a trait that removes a character's species-specific language.

## Why / Balance
Popular request

## Technical details
She extending my system until I stop speaking my first language

## Media
<img width="898" height="152" alt="image" src="https://github.com/user-attachments/assets/57246ba2-1c33-4897-b8e6-6325297b656a" />

Thaven that can use TCB, Sol Common, Arachnic, and TCB-SL, but not Aural:
<img width="783" height="477" alt="image" src="https://github.com/user-attachments/assets/621ecc3f-bd87-449b-8c83-81b1cf7dc723" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Don't think so

**Changelog**
:cl:
- add: The "No Species Language" traits will remove your character's innate species language - for example, a human that cannot speak Sol Common. The "light" version will allow you to understand, but not speak it.