### PR TITLE
[PORT] Copy Thresholds Added to Air Alarms

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -156,8 +156,8 @@ public sealed partial class AirAlarmWindow : FancyWindow
                 if (!_pumps.TryGetValue(addr, out var pumpControl))
                 {
                     var control= new PumpControl(pump, addr);
-                    control.PumpDataChanged += AtmosDeviceDataChanged!.Invoke;
-					control.PumpDataCopied += AtmosDeviceDataCopied!.Invoke;
+                    control.PumpDataChanged += AtmosDeviceDataChanged;
+					control.PumpDataCopied += AtmosDeviceDataCopied;
                     _pumps.Add(addr, control);
                     CVentContainer.AddChild(control);
                 }
@@ -171,8 +171,8 @@ public sealed partial class AirAlarmWindow : FancyWindow
                 if (!_scrubbers.TryGetValue(addr, out var scrubberControl))
                 {
                     var control = new ScrubberControl(scrubber, addr);
-                    control.ScrubberDataChanged += AtmosDeviceDataChanged!.Invoke;
-					control.ScrubberDataCopied += AtmosDeviceDataCopied!.Invoke;
+                    control.ScrubberDataChanged += AtmosDeviceDataChanged;
+					control.ScrubberDataCopied += AtmosDeviceDataCopied;
                     _scrubbers.Add(addr, control);
                     CScrubberContainer.AddChild(control);
                 }
@@ -187,6 +187,7 @@ public sealed partial class AirAlarmWindow : FancyWindow
                 {
                     var control = new SensorInfo(sensor, addr);
                     control.OnThresholdUpdate += AtmosAlarmThresholdChanged;
+                    control.SensorDataCopied += AtmosDeviceDataCopied;
                     _sensors.Add(addr, control);
                     CSensorContainer.AddChild(control);
                 }

--- a/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml
@@ -13,6 +13,9 @@ SPDX-License-Identifier: MIT
         <CollapsibleHeading Name="SensorAddress" />
         <CollapsibleBody Margin="20 2 2 2">
             <BoxContainer Orientation="Vertical" HorizontalExpand="True">
+                <BoxContainer Orientation="Horizontal" Margin ="0 0 0 2">
+                    <Button Name="CCopySettings" Text="{Loc 'air-alarm-ui-thresholds-copy'}" ToolTip="{Loc 'air-alarm-ui-thresholds-copy-tooltip'}" />
+                </BoxContainer>
                 <BoxContainer Orientation="Vertical" Margin="0 0 2 0" HorizontalExpand="True">
                     <RichTextLabel Name="AlarmStateLabel" />
                     <RichTextLabel Name="PressureLabel" />

--- a/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
@@ -21,12 +21,14 @@ namespace Content.Client.Atmos.Monitor.UI.Widgets;
 public sealed partial class SensorInfo : BoxContainer
 {
     public Action<string, AtmosMonitorThresholdType, AtmosAlarmThreshold, Gas?>? OnThresholdUpdate;
+    public event Action<AtmosSensorData>? SensorDataCopied;
     private string _address;
 
     private ThresholdControl _pressureThreshold;
     private ThresholdControl _temperatureThreshold;
     private Dictionary<Gas, ThresholdControl> _gasThresholds = new();
     private Dictionary<Gas, RichTextLabel> _gasLabels = new();
+    private Button _copySettings => CCopySettings;
 
     public SensorInfo(AtmosSensorData data, string address)
     {
@@ -64,7 +66,7 @@ public sealed partial class SensorInfo : BoxContainer
             gasThresholdControl.Margin = new Thickness(20, 2, 2, 2);
             gasThresholdControl.ThresholdDataChanged += (type, threshold, arg3) =>
             {
-                OnThresholdUpdate!(_address, type, threshold, arg3);
+                OnThresholdUpdate?.Invoke(_address, type, threshold, arg3);
             };
 
             _gasThresholds.Add(gas, gasThresholdControl);
@@ -79,12 +81,17 @@ public sealed partial class SensorInfo : BoxContainer
 
         _pressureThreshold.ThresholdDataChanged += (type, threshold, arg3) =>
         {
-            OnThresholdUpdate!(_address, type, threshold, arg3);
+            OnThresholdUpdate?.Invoke(_address, type, threshold, arg3);
         };
 
         _temperatureThreshold.ThresholdDataChanged += (type, threshold, arg3) =>
         {
-            OnThresholdUpdate!(_address, type, threshold, arg3);
+            OnThresholdUpdate?.Invoke(_address, type, threshold, arg3);
+        };
+
+        _copySettings.OnPressed += _ =>
+        {
+            SensorDataCopied?.Invoke(data);
         };
     }
 

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -158,6 +158,19 @@ public sealed class AirAlarmSystem : EntitySystem
         SyncDevice(uid, address);
     }
 
+    private void SetAllThresholds(EntityUid uid, string address, AtmosSensorData data)
+    {
+        var payload = new NetworkPayload
+        {
+            [DeviceNetworkConstants.Command] = AtmosMonitorSystem.AtmosMonitorSetAllThresholdsCmd,
+            [AtmosMonitorSystem.AtmosMonitorAllThresholdData] = data
+        };
+
+        _deviceNet.QueuePacket(uid, address, payload);
+
+        SyncDevice(uid, address);
+    }
+
     /// <summary>
     ///     Sync this air alarm's mode with the rest of the network.
     /// </summary>
@@ -373,6 +386,14 @@ public sealed class AirAlarmSystem : EntitySystem
                 foreach (string addr in component.ScrubberData.Keys)
                 {
                     SetData(uid, addr, args.Data);
+                }
+                break;
+
+
+            case AtmosSensorData sensorData:
+                foreach (string addr in component.SensorData.Keys)
+                {
+                    SetAllThresholds(uid, addr, sensorData);
                 }
                 break;
         }

--- a/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
@@ -50,8 +50,12 @@ public sealed class AtmosMonitorSystem : EntitySystem
     // Commands
     public const string AtmosMonitorSetThresholdCmd = "atmos_monitor_set_threshold";
 
+    public const string AtmosMonitorSetAllThresholdsCmd = "atmos_monitor_set_all_thresholds";
+
     // Packet data
     public const string AtmosMonitorThresholdData = "atmos_monitor_threshold_data";
+
+    public const string AtmosMonitorAllThresholdData = "atmos_monitor_all_threshold_data";
 
     public const string AtmosMonitorThresholdDataType = "atmos_monitor_threshold_type";
 
@@ -153,6 +157,12 @@ public sealed class AtmosMonitorSystem : EntitySystem
                 {
                     args.Data.TryGetValue(AtmosMonitorThresholdGasType, out Gas? gas);
                     SetThreshold(uid, thresholdType.Value, thresholdData, gas);
+                }
+                break;
+            case AtmosMonitorSetAllThresholdsCmd:
+                if (args.Data.TryGetValue(AtmosMonitorAllThresholdData, out AtmosSensorData? allThresholdData))
+                {
+                    SetAllThresholds(uid, allThresholdData);
                 }
 
                 break;
@@ -417,5 +427,21 @@ public sealed class AtmosMonitorSystem : EntitySystem
                 break;
         }
 
+    }
+
+    /// <summary>
+    ///     Sets all of a monitor's thresholds at once according to the incoming
+    ///     AtmosSensorData object's thresholds.
+    /// </summary>
+    /// <param name="uid">The entity's uid</param>
+    /// <param name="allThresholdData">An AtmosSensorData object from which the thresholds will be loaded.</param>
+    public void SetAllThresholds(EntityUid uid, AtmosSensorData allThresholdData)
+    {
+        SetThreshold(uid, AtmosMonitorThresholdType.Temperature, allThresholdData.TemperatureThreshold);
+        SetThreshold(uid, AtmosMonitorThresholdType.Pressure, allThresholdData.PressureThreshold);
+        foreach (var gas in Enum.GetValues<Gas>())
+        {
+            SetThreshold(uid, AtmosMonitorThresholdType.Gas, allThresholdData.GasThresholds[gas], gas);
+        }
     }
 }

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -80,3 +80,5 @@ air-alarm-ui-thresholds-upper-bound = Danger above
 air-alarm-ui-thresholds-lower-bound = Danger below
 air-alarm-ui-thresholds-upper-warning-bound = Warning above
 air-alarm-ui-thresholds-lower-warning-bound = Warning below
+air-alarm-ui-thresholds-copy = Copy thresholds to all devices
+air-alarm-ui-thresholds-copy-tooltip = Copies the sensor thresholds of this device to all devices in this air alarm tab.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
"Air alarms can now have the sensor threshold settings copied from one sensor on their network to all other sensors."
(https://github.com/space-wizards/space-station-14/pull/34346)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Wizden QoL

## Technical details
<!-- Summary of code changes for easier review. -->
All covered in original PR. I'm not smart with this stuff so I won't pretend to know

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Southbridge
- add: Air Alarms can now copy sensor thresholds to all attached sensors.
