### PR TITLE
Make Candy Cigarettes Actually Get Smoket

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -49,3 +49,5 @@
         reagents:
           - ReagentId: Sugar
             Quantity: 10
+  - type: Smokable # DEN - Make candy cigarettes actually burn through contents
+    solution: food


### PR DESCRIPTION
theyre still edible dont worry

<img width="630" height="491" alt="image" src="https://github.com/user-attachments/assets/24ac5217-77f7-4f31-9aee-89fdb9a27720" />

:cl:
- fix: Candy cigarettes actually burn through their contents now - like other cigarettes, they will eventually run out.