### PR TITLE
Fix One Bug Related to "Remove Species Lanaguage" Trait

### DIFF
--- a/Content.Server/Traits/TraitSystem.Functions.cs
+++ b/Content.Server/Traits/TraitSystem.Functions.cs
@@ -262,7 +262,7 @@ public sealed partial class TraitModifyLanguages : TraitFunction
             language.ReplaceLanguagesSpoken(uid, KeepLanguagesSpoken);
 
         if (KeepLanguagesUnderstood is not null)
-            language.ReplaceLanguagesSpoken(uid, KeepLanguagesUnderstood);
+            language.ReplaceLanguagesUnderstood(uid, KeepLanguagesUnderstood);
         // DEN end
 
         if (RemoveLanguagesSpoken is not null)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I) used the wrong function here

:cl:
- fix: The "Remove Species Language" trait should work closer to how it's intended.
