### PR TITLE
Add the Ability to Enter Cryo without an Announcement.

### DIFF
--- a/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
+++ b/Content.Server/Bed/Cryostorage/CryostorageSystem.cs
@@ -42,6 +42,8 @@ using Robust.Shared.Enums;
 using Robust.Shared.Network;
 using Robust.Shared.Player;
 using System.Globalization;
+using Content.Shared._DEN.Bed.Cryostorage.Components;
+
 
 namespace Content.Server.Bed.Cryostorage;
 
@@ -250,14 +252,20 @@ public sealed class CryostorageSystem : SharedCryostorageSystem
             _stationRecords.RemoveRecord(key, stationRecords);
         }
 
-        _chatSystem.DispatchStationAnnouncement(station.Value,
-            Loc.GetString(
-                "earlyleave-cryo-announcement",
-                ("character", name),
-                ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName))
-            ), Loc.GetString("earlyleave-cryo-sender"),
-            playDefaultSound: false
-        );
+        // DEN - Don't broadcast if the person chose to enter cryo silently.
+        if (!TryComp<CryoingSilentlyComponent>(ent, out var silentCryo))
+            _chatSystem.DispatchStationAnnouncement(
+                station.Value,
+                Loc.GetString(
+                    "earlyleave-cryo-announcement",
+                    ("character", name),
+                    ("job", CultureInfo.CurrentCulture.TextInfo.ToTitleCase(jobName))
+                ),
+                Loc.GetString("earlyleave-cryo-sender"),
+                playDefaultSound: false
+            );
+        else
+            RemCompDeferred(ent, silentCryo);
     }
 
     private void HandleCryostorageReconnection(Entity<CryostorageContainedComponent> entity)

--- a/Content.Shared/Bed/Cryostorage/SharedCryostorageSystem.cs
+++ b/Content.Shared/Bed/Cryostorage/SharedCryostorageSystem.cs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
+using Content.Shared._DEN.Bed.Cryostorage.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CCVar;
 using Content.Shared.DragDrop;
@@ -79,6 +80,8 @@ public abstract class SharedCryostorageSystem : EntitySystem
         var (_, comp) = ent;
         if (args.Container.ID != comp.ContainerId)
             return;
+
+        RemCompDeferred<CryoingSilentlyComponent>(args.Entity); // DEN - Don't persist silent cryo after leaving.
 
         _appearance.SetData(ent, CryostorageVisuals.Full, args.Container.ContainedEntities.Count > 0);
     }

--- a/Content.Shared/_DEN/Bed/Cryostorage/Components/CryoingSilentlyComponent.cs
+++ b/Content.Shared/_DEN/Bed/Cryostorage/Components/CryoingSilentlyComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DEN.Bed.Cryostorage.Components;
+
+/// <summary>
+/// Marker component that indicates a user has requested not to have their cryo announced.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CryoingSilentlyComponent : Component { }

--- a/Content.Shared/_DEN/Bed/Cryostorage/Components/CryostorageSilentlyComponent.cs
+++ b/Content.Shared/_DEN/Bed/Cryostorage/Components/CryostorageSilentlyComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared._DEN.Bed.Cryostorage.Systems;
+using Robust.Shared.GameStates;
+
+
+namespace Content.Shared._DEN.Bed.Cryostorage.Components;
+
+
+/// <summary>
+/// Used to add the ability to silently cryo to cryostorage.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(CryoSilentlySystem))]
+public sealed partial class CryostorageSilentlyComponent : Component
+{
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public string ContainerId;
+}

--- a/Content.Shared/_DEN/Bed/Cryostorage/Systems/CryoSilentlySystem.cs
+++ b/Content.Shared/_DEN/Bed/Cryostorage/Systems/CryoSilentlySystem.cs
@@ -1,0 +1,61 @@
+using Content.Shared._DEN.Bed.Cryostorage.Components;
+using Content.Shared.ActionBlocker;
+using Content.Shared.Containers;
+using Content.Shared.Verbs;
+using Robust.Shared.Containers;
+
+
+namespace Content.Shared._DEN.Bed.Cryostorage.Systems;
+
+public sealed class CryoSilentlySystem : EntitySystem
+{
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly DragInsertContainerSystem _dragInsertContainer = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CryostorageSilentlyComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAlternativeVerb);
+    }
+
+    // This function is almost the same as the DragInsertContainer system,
+    // it just sets the user to be silently inserted first.
+    private void OnGetAlternativeVerb(Entity<CryostorageSilentlyComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        var (uid, comp) = ent;
+
+        // If we're on an entity that doesn't have a DragInsertContainerComponent something is wrong.
+        if (!TryComp<DragInsertContainerComponent>(uid, out var dragInsert))
+            return;
+
+        if (!args.CanInteract || !args.CanAccess || args.Hands == null)
+            return;
+
+        if (!_container.TryGetContainer(uid, comp.ContainerId, out var container))
+            return;
+
+        var user = args.User;
+        if (!_actionBlocker.CanInteract(user, ent))
+            return;
+
+        // Self-insert silently verb.
+        if (_container.CanInsert(user, container) &&
+            _actionBlocker.CanMove(user))
+        {
+            AlternativeVerb verb = new()
+            {
+                Act = () =>
+                {
+                    AddComp(user, new CryoingSilentlyComponent());
+                    _dragInsertContainer.Insert(user, user, ent, container);
+                },
+                Text = Loc.GetString("cryo-silently-verb-text"),
+                Message = Loc.GetString("cryo-silently-verb-message"),
+                Priority = 1
+            };
+            args.Verbs.Add(verb);
+        }
+    }
+}

--- a/Resources/Locale/en-US/_DEN/containers/containers.ftl
+++ b/Resources/Locale/en-US/_DEN/containers/containers.ftl
@@ -1,0 +1,2 @@
+cryo-silently-verb-text = Enter silently
+cryo-silently-verb-message = Enter Cryo without broadcasting a message to the entire station

--- a/Resources/Prototypes/Entities/Structures/cryopod.yml
+++ b/Resources/Prototypes/Entities/Structures/cryopod.yml
@@ -32,6 +32,8 @@
     access: [["Cryogenics"]]
   - type: InteractionOutline
   - type: Cryostorage
+  - type: CryostorageSilently # DEN - Allow silently entering Cryostorage
+    containerId: storage
   - type: Physics
     canCollide: false
   - type: DragInsertContainer


### PR DESCRIPTION
## About the PR
Added an option to crypods that prevents the announcement to the entire station.

## Why / Balance
People were asking for the announcement to be removed completely, this provides the best of both worlds, where by default people still announce, but have the option to do it silently if they intentionally choose to.

## Technical details
Adds a component to the cryogenic pod that provides an 'enter silently' verb, which does the same thing as enter, except it also sets a marker component on the player indicating that they would like to not be announced. The Cryogenic system checks for this marker and doesn't broadcast if it is present. The component is removed either when the player leaves the pod, or when it eats the announcement.

## Media

https://github.com/user-attachments/assets/0e1f2274-d2b8-46a6-a110-9e4c3feea144



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
Shouldn't break anything.

**Changelog**
:cl:
- add: Added the ability to cryo without broadcasting an announcement to the entire station.
