### PR TITLE
Don't Buckle Things to Themselves It Makes the Engine Very Angry.

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -248,6 +248,9 @@ public abstract partial class SharedBuckleSystem
         if (!Resolve(strapUid, ref strapComp, false))
             return false;
 
+        if(buckleUid == strapUid)
+            return false;
+
         // Does it pass the Whitelist
         if (_whitelistSystem.IsWhitelistFail(strapComp.Whitelist, buckleUid) ||
             _whitelistSystem.IsBlacklistPass(strapComp.Blacklist, buckleUid))


### PR DESCRIPTION
## About the PR
Buckling an entity to itself crashes the game. Now you can't do that.

## Why / Balance
@ElusiveCoin needs this for later.

## Technical details
Just check if the entity being strapped and the entity being buckled are the same entity

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes

**Changelog**