### PR TITLE
Add Human Body Sprite Overlay Markings (for Oni)

### DIFF
--- a/Resources/Locale/en-US/_DEN/markings/overlay.ftl
+++ b/Resources/Locale/en-US/_DEN/markings/overlay.ftl
@@ -1,0 +1,12 @@
+marking-BodyOverlayHumanHeadMale = Body Sprite - Human Head (M)
+marking-BodyOverlayHumanHeadFemale = Body Sprite - Human Head (F)
+marking-BodyOverlayHumanChestMale = Body Sprite - Human Chest (M)
+marking-BodyOverlayHumanChestFemale = Body Sprite - Human Chest (F)
+marking-BodyOverlayHumanArmLeft = Body Sprite - Human Left Arm
+marking-BodyOverlayHumanArmRight = Body Sprite - Human Right Arm
+marking-BodyOverlayHumanHandLeft = Body Sprite - Human Left Hand
+marking-BodyOverlayHumanHandRight = Body Sprite - Human Right Hand
+marking-BodyOverlayHumanLegLeft = Body Sprite - Human Left Leg
+marking-BodyOverlayHumanLegRight = Body Sprite - Human Right Leg
+marking-BodyOverlayHumanFootLeft = Body Sprite - Human Left Foot
+marking-BodyOverlayHumanFootRight = Body Sprite - Human Right Foot

--- a/Resources/Prototypes/_DEN/Entities/Mobs/Customization/Markings/overlay.yml
+++ b/Resources/Prototypes/_DEN/Entities/Mobs/Customization/Markings/overlay.yml
@@ -1,0 +1,115 @@
+- type: marking
+  abstract: true
+  id: BaseBodyOverlay
+  markingCategory: Overlay
+  followSkinColor: true
+  forcedColoring: true
+
+# Head
+
+- type: marking
+  parent: [BaseSpeciesHeadHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanHeadMale
+  bodyPart: Head
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: head_m
+
+- type: marking
+  parent: [BaseSpeciesHeadHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanHeadFemale
+  bodyPart: Head
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: head_f
+
+# Chest
+
+- type: marking
+  parent: [BaseSpeciesChestHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanChestMale
+  bodyPart: Chest
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: torso_m
+
+- type: marking
+  parent: [BaseSpeciesChestHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanChestFemale
+  sexRestriction: [Female] # sorry, but the body shape breaks it
+  bodyPart: Chest
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: torso_f
+
+# Arm
+
+- type: marking
+  parent: [BaseSpeciesArmsHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanArmLeft
+  bodyPart: LArm
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: l_arm
+
+- type: marking
+  parent: [BaseSpeciesArmsHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanArmRight
+  bodyPart: RArm
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: r_arm
+
+# Hand
+
+- type: marking
+  parent: [BaseSpeciesArmsHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanHandLeft
+  bodyPart: LHand
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: l_hand
+
+- type: marking
+  parent: [BaseSpeciesArmsHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanHandRight
+  bodyPart: RHand
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: r_hand
+
+# Leg
+
+- type: marking
+  parent: [BaseSpeciesLegsHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanLegLeft
+  bodyPart: LLeg
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: l_leg
+
+- type: marking
+  parent: [BaseSpeciesLegsHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanLegRight
+  bodyPart: RLeg
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: r_leg
+
+# Foot
+
+- type: marking
+  parent: [BaseSpeciesLegsHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanFootLeft
+  bodyPart: LFoot
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: l_foot
+
+- type: marking
+  parent: [BaseSpeciesLegsHuman, BaseBodyOverlay]
+  id: BodyOverlayHumanFootRight
+  bodyPart: RFoot
+  sprites:
+  - sprite: Mobs/Species/Human/parts.rsi
+    state: r_foot


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
This PR adds a bunch of markings that add the human base sprite on your body, effectively "replacing" your base sprite.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Server vote decided this was the other half of the resolution to #2014, for those who prefer the human red overlay on their Oni characters.

## Technical details
<!-- Summary of code changes for easier review. -->
It's just YML and locales.
The female chest sprite is sex-restricted because it can't account for displacements on male body sprites.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Demonstrating a mix of grayscale and human sprites:

<img width="1531" height="529" alt="image" src="https://github.com/user-attachments/assets/8a9556ca-0f05-40d3-b96d-115c9588507f" />

Oni with all sprites replaced:

<img width="880" height="534" alt="image" src="https://github.com/user-attachments/assets/373d9948-0458-4970-a3ec-49d3a2657714" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Nada.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Oni (and the rest of the "human base sprite" species like Canid and Felinid, but it's only actually relevant for Oni) now have Overlay markings that re-adds the human base sprites to your Oni character - that is to say, slightly-red shading.