### PR TITLE
+2 Vox Chest Markings

### DIFF
--- a/Resources/Prototypes/Species/vox.yml
+++ b/Resources/Prototypes/Species/vox.yml
@@ -22,7 +22,7 @@
 - type: species
   id: Vox
   name: species-name-vox
-  roundStart: true # sad...
+  roundStart: true
   prototype: MobVox
   sprites: MobVoxSprites
   markingLimits: MobVoxMarkingLimits
@@ -72,8 +72,8 @@
       required: false
     Head:
       points: 2
-      required: false #imp
-    HeadSide: #imp
+      required: false # imp
+    HeadSide: # imp
       points: 2
       required: false
     Snout:
@@ -119,15 +119,15 @@
       points: 1 # den
       required: false
     Chest:
-      points: 1
+      points: 3 # Den
       required: false
     Overlay: # imp
       points: 4
       required: false
     Tail:
       points: 1
-      required: false #imp
-      #defaultMarkings: [ VoxTail ]
+      required: false # imp
+      # defaultMarkings: [ VoxTail ]
 
 - type: humanoidBaseSprite
   id: MobVoxEyes
@@ -156,7 +156,7 @@
 - type: humanoidBaseSprite
   id: MobVoxTorso
   baseSprite:
-    sprite: _Impstation/Mobs/Species/Vox/parts.rsi #imp
+    sprite: _Impstation/Mobs/Species/Vox/parts.rsi # imp
     state: torso
 
 - type: humanoidBaseSprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Gives vox two more chest marking slots. Now they can have more than one like every other species.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Now vox can have a chest coloring and scars.

## Technical details
<!-- Summary of code changes for easier review. -->
Single yml file edit. Also added spaces in comments for Den standard.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="466" height="187" alt="image" src="https://github.com/user-attachments/assets/0a54d691-cbfd-4a85-af8a-7107ebb77d59" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Vox are allowed two more chest markings; they are no longer restricted to just one.
