### PR TITLE
Change Purple Galoshes' Group in Janitor Loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Service/janitor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Service/janitor.yml
@@ -76,7 +76,7 @@
   exclusive: true
   requirements:
     - !type:CharacterItemGroupRequirement
-      group: LoadoutJanitorOuter
+      group: LoadoutJanitorShoes
     - !type:CharacterJobRequirement
       jobs:
         - Janitor


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Changed purple galoshes' loadout group from outerwear to shoes
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As outerwear, it is impossible to wear a janitor winter coat and purple galoshes at the same time because of their mutually exclusive grouping. Placing them correctly into the shoes group fixes this.
## Technical details
<!-- Summary of code changes for easier review. -->
Changed `group: LoadoutJanitorOuter` to `group: LoadoutJanitorShoes`
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="484" height="150" alt="image" src="https://github.com/user-attachments/assets/4e535c74-a1a9-483a-a465-454c0a2de808" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Domino
- fix: Purple galoshes under the Janitor loadout are now considered shoes instead of outerwear.
