### PR TITLE
MAKE HIGH DANGER REQUIRE A MINIMUM OF 40 PLAYERS

### DIFF
--- a/Resources/Prototypes/_DEN/game_presets.yml
+++ b/Resources/Prototypes/_DEN/game_presets.yml
@@ -32,6 +32,7 @@
   name: roundstart-antags-title
   showInVote: true
   highDanger: true
+  minPlayers: 40
   description: roundstart-antags-description
   rules:
     - BasicRoundstartVariation

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -30,6 +30,7 @@
   name: survival-title
   showInVote: true # secret # DeltaV - Me when the survival. Used for periapsis.
   highDanger: true
+  minPlayers: 40 # DEN: Minimum population for high-danger presets to account for lack of security
   description: survival-description
   rules:
     - RampingStationEventScheduler


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
TITLE

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
ADMIN VOTE

<img width="528" height="181" alt="image" src="https://github.com/user-attachments/assets/c8bf0521-db76-40a6-b1f1-8269c67b3482" />

**Changelog**
:cl:
- tweak: The Heightened Risk gamemode now requires a minimum of 40 players, as per admin vote.