### PR TITLE
Let Moths Eat Candy

### DIFF
--- a/Resources/Prototypes/Body/Organs/moth.yml
+++ b/Resources/Prototypes/Body/Organs/moth.yml
@@ -24,6 +24,7 @@
       - Fruit # DeltaV - Moth can eat fruits.
       - Paper
       - Pill
+      - Candy
   - type: SolutionContainerManager
     solutions:
       stomach:


### PR DESCRIPTION
<!--- LICENSE: MIT -->
## About the PR
what it says on the tin

## Why / Balance
Candy is mainly sugar, insects like moths should absolutely be able to eat it. You know what happens when you spill sugar in the kitchen, right?

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

**Changelog**
:cl: MajorMoth
- tweak: Moths can now eat candy!