### PR TITLE
Survival Medpen Tweak

### DIFF
--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Specific/Medical/hypospray.yml
@@ -25,8 +25,6 @@
     transferAmount: 40
     onlyAffectsMobs: false
     injectOnly: true
-    maxPressure: 50 
-    injectTime: 5
   - type: SolutionContainerManager
     solutions:
       pen:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
A simple yaml change to make the survival pen not have a doafter and removed a useless maxpressure line.

## Why / Balance
Make the Survival Medpen in line with other autoinjectors which don't have a doafter.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl: Oberonics
- tweak: Survival Medpens are now 5x faster!

