### PR TITLE
Marked for Removal Fix

### DIFF
--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -123,24 +123,26 @@ public sealed class KillPersonConditionSystem : EntitySystem
         {
             foreach (var mind in markedList)
             {
-                if (!TryComp<MarkedComponent>(mind.Comp.CurrentEntity, out var targetMarked)
-                    || targetMarked.TargetType.HasFlag(ObjectiveTypes.TraitorNonTargetable))
+                if (TryComp<MarkedComponent>(mind.Comp.CurrentEntity, out var markedComp)
+                    && markedComp.TargetType == ObjectiveTypes.TraitorNonTargetable)
                 {
                     markedList.Remove(mind);
                 }
             }
         }
+
         if (objType.HasFlag(ObjectiveTypes.TraitorTeach))//Culls from the list of all alive minds anyone that hasn't opted into teach targetting.
         {
             foreach (var mind in markedList)
             {
-                if (TryComp<MarkedComponent>(mind.Comp.CurrentEntity, out var targetMarked)
-                    && targetMarked.TargetType.HasFlag(ObjectiveTypes.TraitorNonTargetable))
+                if (TryComp<MarkedComponent>(mind.Comp.CurrentEntity, out var markedComp)
+                    && markedComp.TargetType == ObjectiveTypes.TraitorNonTargetable)
                 {
                     markedList.Remove(mind);
                 }
             }
         }
+
         return markedList;
     }
     private void OnHeadAssigned(EntityUid uid, PickRandomHeadComponent comp, ref ObjectiveAssignedEvent args)


### PR DESCRIPTION
## About the PR
Two line change that makes it so those with the Marked for Removal trait aren't removed from the pool of kill targets.

## Media
<img width="1051" height="629" alt="imaadweaDAWFASDdge" src="https://github.com/user-attachments/assets/1196f64d-afc7-42f3-b73f-679cd2eaa5ee" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl: Oberonics
- fix: Fixed a Syndicate paperwork mix up that made it so those Marked for Removal weren't targeted by their agents.

