### PR TITLE
Reapply "Make WSPR Usable for 85 TC (#2094)" (#2096)

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -124,14 +124,8 @@
   - type: Clothing
     sprite: _Goobstation/Objects/Weapons/Guns/Rifles/wspr.rsi
   - type: Gun
-    availableModes:
-    - FullAuto
-    - Burst
-    selectedMode: Burst
-    burstFireRate: 16
-    burstCooldown: 0.5
-    fireRate: 8
-    projectileSpeed: 15
+    fireRate: 5.5
+    projectileSpeed: 35
     soundGunshot:
       path: /Audio/_Goobstation/Weapons/Guns/Gunshots/bwuh.ogg
       params:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
mald PR

WSPR changes:
1. No longer a burst weapon. It's difficult to balance, otherwise.
2. Fire rate is 5.5, damage is 18, which leads to ~99 DPS. This weapon does NOT fire often, so it's very much still a stealth weapon, but you also need to aim properly or have a target in a hallway to kill them
3. Bullet velocity was changed from 15 to 35 to be a bit better than other rifles. This is mostly because I can't make the damage better and otherwise the subsonic round is just Worse in every category

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The WSPR is 85 TC for a gun that is literally so dogshit you couldn't kill xenos at 10 feet before dying.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The WSPR was buffed to be a faster firing auto rifle instead of a burst weapon. It now does 99 DPS.