### PR TITLE
[TWEAK]: Adds Conspirators Back to Even More Antatgs, but Like Less of Them

### DIFF
--- a/Resources/Prototypes/_DEN/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_DEN/GameRules/roundstart.yml
@@ -24,3 +24,36 @@
   - type: SubGamemodes
     rules:
     - id: Thief
+
+- type: entity
+  parent: Conspirators
+  categories: [ HideSpawnMenu ]
+  id: LessConspirator
+  components:
+  - type: GameRule
+    # minPlayers: 20 # minimum of 2 conspirators
+    delay:
+      min: 1800
+      max: 2400
+  - type: ConspiratorRule
+  - type: AntagSelection
+    # selectionTime: IntraPlayerSpawn
+    definitions:
+    - prefRoles: [ Conspirator ]
+      min: 4
+      max: 6
+      playerRatio: 15
+      briefing:
+        text: conspirator-role-greeting
+        color: SaddleBrown
+        sound: /Audio/_Harmony/Misc/conspirator_greeting.ogg
+      blacklist:
+        components:
+        - AntagImmune
+      components:
+      - type: Conspirator
+      - type: AutoImplant
+        implants:
+        - RadioImplantConspiracy
+      mindRoles:
+      - MindRoleConspirator

--- a/Resources/Prototypes/_DEN/game_presets.yml
+++ b/Resources/Prototypes/_DEN/game_presets.yml
@@ -39,6 +39,7 @@
   rules:
     - BasicRoundstartVariation
     - MoreTraitor
+    - LessConspirator
     - Thief
     - SubGamemodesRule
     - LavalandStormScheduler # Lavaland Change


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers
SPDX-FileCopyrightText: 2021 Swept
SPDX-FileCopyrightText: 2021 mirrorcult
SPDX-FileCopyrightText: 2022 AJCM-git
SPDX-FileCopyrightText: 2022 Kara
SPDX-FileCopyrightText: 2023 DrSmugleaf
SPDX-FileCopyrightText: 2023 Kevin Zheng
SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT
SPDX-FileCopyrightText: 2025 sleepyyapril
SPDX-FileCopyrightText: 2026 portfiend

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
LICENSE: MIT
## About the PR
<!-- What did you change? -->
Created a new game rule with few conspirators, made it available in Even More Antags.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
@sleepyyapril asked me to do it.

## Technical details
<!-- Summary of code changes for easier review. -->
.yml changes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

### Licensing
- [X] (OPTIONAL) This pull request contains code or assets that are owned by me, and I give permission for my own contributions to be re-licensed under MIT.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Jakumba
- add: Added Conspiracy back to Even More Antags, however fewer will roll.

