### PR TITLE
[BOUNTY] Rickenbacker Tweaks

### DIFF
--- a/Resources/Prototypes/Loadouts/Generic/items.yml
+++ b/Resources/Prototypes/Loadouts/Generic/items.yml
@@ -334,7 +334,7 @@
 - type: loadout
   id: LoadoutItemRickenbacker
   category: GeneralInstruments
-  cost: 10
+  cost: 5
   items:
     - Rickenbacker4003Instrument
   requirements:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Fun/instruments.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Fun/instruments.yml
@@ -39,6 +39,11 @@
       types:
         Blunt: 7
     bluntStaminaDamageFactor: 1.50 #13.5 stamina damage
+  - type: Clothing
+    quickEquip: false
+    slots:
+    - Back
+    - suitStorage
 
 - type: entity
   parent: Rickenbacker4003Instrument


### PR DESCRIPTION
<!--- LICENSE: MIT -->
## About the PR
Makes the Rickenbacker wearable on your back, and reduced its cost to be the same as the rock guitar.

## Why / Balance
This makes sense.

## Media

https://github.com/user-attachments/assets/c17a0d5b-54a8-4f6d-9b58-7f3d79499c4d



## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

### Licensing
- [x] (OPTIONAL) This pull request contains code or assets that are owned by me, and I give permission for my own contributions to be re-licensed under MIT.

**Changelog**
:cl:
- tweak: The Rickenbacker is cheaper in loadouts to get for non-musicians and can be worn on your back (no sprite though...) 