### PR TITLE
Added Equipment for Senior Positions in Their Loadouts

### DIFF
--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/seniorEngineer.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Engineering/seniorEngineer.yml
@@ -43,6 +43,10 @@
     - type: loadout
       id: LoadoutSeniorEngineerEquipmentPowerDrill
     - type: loadout
+      id: LoadoutSeniorEngineerEquipmentWelderExperimental
+    - type: loadout
+      id: LoadoutSeniorEngineerEquipmentHandHeldPowerMonitor
+    - type: loadout
       id: LoadoutSeniorEngineerEquipmentSheetSteel
     - type: loadout
       id: LoadoutSeniorEngineerEquipmentSheetSteel10

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/mystic.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Epistemics/mystic.yml
@@ -29,6 +29,12 @@
       id: LoadoutMysticEquipmentCandlesSmall
     - type: loadout
       id: LoadoutMysticPillCanisterSpaceDrugs
+    - type: loadout
+      id: LoadoutMysticWeaponPistolCHIMP
+    - type: loadout
+      id: LoadoutMysticAnomalyScanner
+    - type: loadout
+      id: LoadoutMysticNodeScanner
 
 #- type: characterItemGroup
 #  id: LoadoutMysticEyes

--- a/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/seniorPhysician.yml
+++ b/Resources/Prototypes/CharacterItemGroups/Jobs/Medical/seniorPhysician.yml
@@ -23,10 +23,16 @@
 #  maxItems: 1
 #  items:
 #
-#- type: characterItemGroup
-#  id: LoadoutSeniorPhysicianEquipment
-#  maxItems: 1
-#  items:
+- type: characterItemGroup
+  id: LoadoutSeniorPhysicianEquipment
+  maxItems: 3
+  items:
+  - type: loadout
+    id: LoadoutSeniorPhysicianJetInjector
+  - type: loadout
+    id: LoadoutSeniorPhysicianEpinephrineBottle
+  - type: loadout
+    id: LoadoutSeniorPhysicianPillCanisterTricordrazine
 #
 #- type: characterItemGroup
 #  id: LoadoutSeniorPhysicianEyes

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/seniorEngineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/seniorEngineer.yml
@@ -133,6 +133,32 @@
     - PowerDrill
 
 - type: loadout
+  id: LoadoutSeniorEngineerEquipmentWelderExperimental
+  category: JobsEngineeringSeniorEngineer
+  cost: 0
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutSeniorEngineerEquipment
+  - !type:CharacterJobRequirement
+    jobs:
+    - SeniorEngineer
+  items:
+  - WelderExperimental
+
+- type: loadout
+  id: LoadoutSeniorEngineerEquipmentHandHeldPowerMonitor
+  category: JobsEngineeringSeniorEngineer
+  cost: 2
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutSeniorEngineerEquipment
+  - !type:CharacterJobRequirement
+    jobs:
+    - SeniorEngineer
+  items:
+  - HandHeldPowerMonitor
+
+- type: loadout
   id: LoadoutSeniorEngineerEquipmentSheetSteel
   category: JobsEngineeringSeniorEngineer
   cost: 1

--- a/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystic.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Epistemics/mystic.yml
@@ -53,6 +53,48 @@
   items:
     - PillCanisterSpaceDrugs
 
+- type: loadout
+  id: LoadoutMysticWeaponPistolCHIMP
+  category: JobsEpistemicsMystic
+  cost: 0
+  guideEntry: Psionics
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutMysticEquipment
+  - !type:CharacterJobRequirement
+    jobs:
+    - SeniorResearcher
+  items:
+  - WeaponPistolCHIMP
+
+- type: loadout
+  id: LoadoutMysticNodeScanner
+  category: JobsEpistemicsMystic
+  cost: 0
+  guideEntry: Psionics
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutMysticEquipment
+  - !type:CharacterJobRequirement
+    jobs:
+    - SeniorResearcher
+  items:
+  - NodeScanner
+
+- type: loadout
+  id: LoadoutMysticAnomalyScanner
+  category: JobsEpistemicsMystic
+  cost: 0
+  guideEntry: Psionics
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutMysticEquipment
+  - !type:CharacterJobRequirement
+    jobs:
+    - SeniorResearcher
+  items:
+  - AnomalyScanner
+
 # Eyes
 
 # Gloves

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/seniorPhysician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/seniorPhysician.yml
@@ -40,6 +40,45 @@
   items:
     - ClothingBeltMedicalAdvancedFilled
 
+- type: loadout
+  id: LoadoutSeniorPhysicianJetInjector
+  category: JobsMedicalSeniorPhysician
+  cost: 4
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutSeniorPhysicianEquipment
+  - !type:CharacterJobRequirement
+    jobs:
+    - SeniorPhysician
+  items:
+  - JetInjector
+
+- type: loadout
+  id: LoadoutSeniorPhysicianEpinephrineBottle
+  category: JobsMedicalSeniorPhysician
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutSeniorPhysicianEquipment
+  - !type:CharacterJobRequirement
+    jobs:
+    - SeniorPhysician
+  items:
+  - EpinephrineChemistryBottle
+
+- type: loadout
+  id: LoadoutSeniorPhysicianPillCanisterTricordrazine
+  category: JobsMedicalSeniorPhysician
+  cost: 1
+  requirements:
+  - !type:CharacterItemGroupRequirement
+    group: LoadoutSeniorPhysicianEquipment
+  - !type:CharacterJobRequirement
+    jobs:
+    - SeniorPhysician
+  items:
+  - PillCanisterTricordrazine
+
 # Eyes
 
 # Gloves


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers
SPDX-FileCopyrightText: 2021 Swept
SPDX-FileCopyrightText: 2021 mirrorcult
SPDX-FileCopyrightText: 2022 AJCM-git
SPDX-FileCopyrightText: 2022 Kara
SPDX-FileCopyrightText: 2023 DrSmugleaf
SPDX-FileCopyrightText: 2023 Kevin Zheng
SPDX-FileCopyrightText: 2024 DEATHB4DEFEAT
SPDX-FileCopyrightText: 2025 sleepyyapril
SPDX-FileCopyrightText: 2026 portfiend

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Added several pieces of equipment to 3/4 of the senior positions for each department. (Security exempt)

**Senior Physician**: Jet Injector, Epinephrine Bottle, Tricordrazine Pill canister.
**Senior Researcher**: CHIMP, Anomaly Scanner, Node Scanner.
**Senior Engineer**: Experimental Welder, Handheld Power Monitor.
## Why / Balance
Shouldn't effect balance *that* much, additions are either available roundstart or slightly better versions of roundstart equipment. [All additions discussed with direction](https://discord.com/channels/1301753657024319488/1433986564450680982). Also I just think Seniors should have a bit of a reward outside of recolored jumpsuits :)

## Technical details
Really just a handful of additions to loadouts and characteritemgroups, whoops all yaml changes!

## Media
<img width="673" height="228" alt="image" src="https://github.com/user-attachments/assets/89970e78-de77-44a2-9130-1dea134c5ec5" />
<img width="712" height="482" alt="image" src="https://github.com/user-attachments/assets/627188a3-ad9d-4739-8272-c2469d7b3442" />
<img width="758" height="117" alt="image" src="https://github.com/user-attachments/assets/9f9caae4-34ca-4f9a-8c9a-8040f518f78d" />
<img width="730" height="206" alt="image" src="https://github.com/user-attachments/assets/aba8991c-7f29-48e0-b829-7c4ecd5879df" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

### Licensing
- [ ] (OPTIONAL) This pull request contains code or assets that are owned by me, and I give permission for my own contributions to be re-licensed under MIT.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- add: Senior Physician, Senior Researcher, and Senior Engineer now have some new toys! Check your loadouts.
