### PR TITLE
Add the Monochromatic Vision Trait.

### DIFF
--- a/Content.Client/_DEN/Overlays/MonochromaticVisionOverlay.cs
+++ b/Content.Client/_DEN/Overlays/MonochromaticVisionOverlay.cs
@@ -1,0 +1,49 @@
+using System.Numerics;
+using Content.Shared._DEN.Traits.Components;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._DEN.Overlays;
+
+public sealed partial class MonochromaticVisionOverlay : Overlay
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] IEntityManager _entityManager = default!;
+
+    public override bool RequestScreenTexture => true;
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+    private readonly ShaderInstance _monoVisionShader;
+    
+    public MonochromaticVisionOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _monoVisionShader = _prototypeManager.Index<ShaderPrototype>("GreyscaleFullscreen").Instance().Duplicate();
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (_playerManager.LocalEntity is not { Valid: true } player
+            || !_entityManager.HasComponent<MonochromaticVisionComponent>(player))
+            return false;
+        
+        return base.BeforeDraw(in args);
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (ScreenTexture is null)
+            return;
+        
+        _monoVisionShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
+        
+        var worldHandle = args.WorldHandle;
+        var viewport = args.WorldBounds;
+        worldHandle.SetTransform(Matrix3x2.Identity);
+        worldHandle.UseShader(_monoVisionShader);
+        worldHandle.DrawRect(viewport, Color.White);
+        worldHandle.UseShader(null);
+    }
+}

--- a/Content.Client/_DEN/Overlays/MonochromaticVisionSystem.cs
+++ b/Content.Client/_DEN/Overlays/MonochromaticVisionSystem.cs
@@ -1,0 +1,68 @@
+using Content.Shared._DEN.Traits.Components;
+using Content.Shared.CCVar;
+using Robust.Client.Graphics;
+using Robust.Shared.Configuration;
+using Robust.Shared.Player;
+
+
+namespace Content.Client._DEN.Overlays;
+
+
+public sealed partial class MonochromaticVisionSystem : EntitySystem
+{
+    [Dependency] private readonly IOverlayManager _overlayManager = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
+
+    private MonochromaticVisionOverlay _overlay = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        
+        SubscribeLocalEvent<MonochromaticVisionComponent, ComponentInit>(OnMonochromaticVisionInit);
+        SubscribeLocalEvent<MonochromaticVisionComponent, ComponentShutdown>(OnMonochromaticVisionShutdown);
+        SubscribeLocalEvent<MonochromaticVisionComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<MonochromaticVisionComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
+        
+        Subs.CVar(_cfg, CCVars.NoVisionFilters, OnNoVisionFiltersChanged);
+
+        _overlay = new();
+    }
+
+    private void OnMonochromaticVisionInit(Entity<MonochromaticVisionComponent> entity, ref ComponentInit args)
+    {
+        if (entity != _playerManager.LocalEntity)
+            return;
+
+        if (!_cfg.GetCVar(CCVars.NoVisionFilters))
+            _overlayManager.AddOverlay(_overlay);
+    }
+    
+    private void OnMonochromaticVisionShutdown(Entity<MonochromaticVisionComponent> entity, ref ComponentShutdown args)
+    {
+        if (entity != _playerManager.LocalEntity)
+            return;
+        
+        _overlayManager.RemoveOverlay(_overlay);
+    }
+
+    private void OnPlayerAttached(Entity<MonochromaticVisionComponent> entity, ref LocalPlayerAttachedEvent evt)
+    {
+        if (!_cfg.GetCVar(CCVars.NoVisionFilters))
+            _overlayManager.AddOverlay(_overlay);
+    }
+
+    private void OnPlayerDetached(Entity<MonochromaticVisionComponent> entity, ref LocalPlayerDetachedEvent evt)
+    {
+        _overlayManager.RemoveOverlay(_overlay);
+    }
+
+    private void OnNoVisionFiltersChanged(bool enabled)
+    {
+        if (enabled)
+            _overlayManager.RemoveOverlay(_overlay);
+        else
+            _overlayManager.AddOverlay(_overlay);
+    }
+}

--- a/Content.Shared/_DEN/Traits/Components/MonochromaticVisionComponent.cs
+++ b/Content.Shared/_DEN/Traits/Components/MonochromaticVisionComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DEN.Traits.Components;
+
+/// <summary>
+/// Causes someone to see the world in monochromatic view.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class MonochromaticVisionComponent : Component;

--- a/Resources/Locale/en-US/_DEN/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/traits.ftl
@@ -160,3 +160,8 @@ trait-name-NoosphericOpposedMood = Noospheric Opposed Mood
 trait-description-NoosphericOpposedMood =
     Something about the connection to the noosphere grates on your psyche.
     Low glimmer improves your mood. High glimmer dampens your mood.
+
+trait-name-MonochromaticVision = Monochromatic Vision
+trait-description-MonochromaticVision =
+    Either through unique anatomy or perhaps damage, you are no longer able to perceive color.
+    You will see the entire world in shades of gray.

--- a/Resources/Prototypes/_DEN/Traits/Misc/visual.yml
+++ b/Resources/Prototypes/_DEN/Traits/Misc/visual.yml
@@ -1,0 +1,19 @@
+- type: trait
+  id: MonochromaticVision
+  category: Visual
+  requirements:
+    - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - StationAi
+        - Borg
+        - MedicalBorg
+    - !type:CharacterTraitRequirement
+      inverted: true
+      traits:
+        - DogVision
+        - UltraVision
+  functions:
+    - !type:TraitAddComponent
+      components:
+        - type: MonochromaticVision

--- a/Resources/Prototypes/_DV/Traits/altvision.yml
+++ b/Resources/Prototypes/_DV/Traits/altvision.yml
@@ -31,6 +31,7 @@
       inverted: true
       traits:
         - DogVision
+        - MonochromaticVision # Den
   functions:
     - !type:TraitAddComponent
       components:
@@ -57,6 +58,7 @@
       inverted: true
       traits:
         - UltraVision
+        - MonochromaticVision # Den
   functions:
     - !type:TraitAddComponent
       components:


### PR DESCRIPTION
## About the PR
Added a shader that makes the world greyscale, and a trait that enables it.

## Why / Balance
Some other forks have this and I was asked for it.

## Technical details
Adds an overlay that uses the already existing GreyscaleFullscreen shader to draw the world in black and white.

## Media

https://github.com/user-attachments/assets/cbe511d6-5ca7-45ec-ac4c-9e3f57a3eabb

<img width="1384" height="252" alt="image" src="https://github.com/user-attachments/assets/5dcfccfe-8cd7-4de5-b64a-c24c1d5a2b4a" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

### Licensing
- [X] (OPTIONAL) This pull request contains code or assets that are owned by me, and I give permission for my own contributions to be re-licensed under MIT.

## Breaking changes

**Changelog**
:cl:
- add: Added a Monochromatic Vision trait.
