### PR TITLE
Blood Reagent Trait Part 2: Refactors And Bugfixing (Plus a Feature)

### DIFF
--- a/Content.Server/_CD/Traits/SynthSystem.cs
+++ b/Content.Server/_CD/Traits/SynthSystem.cs
@@ -28,6 +28,6 @@ public sealed class SynthSystem : EntitySystem
         }
 
         // Give them synth blood. Ion storm notif is handled in that system
-        _bloodstream.ChangeBloodReagent(uid, "SynthBlood");
+        // _bloodstream.ChangeBloodReagent(uid, "SynthBlood"); DEN Change - Blood refactoring, killing duplicate code due to traits
     }
 }

--- a/Resources/Locale/en-US/_DEN/traits/bloods.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/bloods.ftl
@@ -1,0 +1,43 @@
+trait-name-BlackBlood = Black Blood
+trait-description-BlackBlood =
+    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
+    Your body produces Black Blood instead of whatever blood your species normally generates.
+
+trait-name-InsectBlood = Insect Blood
+trait-description-InsectBlood =
+    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
+    Your body produces Insect Blood instead of whatever blood your species normally generates.
+
+trait-name-BlueBlood = Blue Blood
+trait-description-BlueBlood =
+    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
+    Your body produces Blue Blood instead of whatever blood your species normally generates.
+
+trait-name-SlimeBlood = Slime Blood
+trait-description-SlimeBlood =
+    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
+    Your body produces slime instead of whatever blood your species normally generates.
+
+trait-name-RedBlood = Red Blood
+trait-description-RedBlood =
+    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
+    Your body produces regular blood instead of whatever blood your species normally generates.
+
+trait-name-AmmoniaBlood = Ammonia Blood
+trait-description-AmmoniaBlood =
+    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
+    Your body produces Ammonia Blood instead of whatever blood your species normally generates.
+
+trait-name-ShimmeringBlood = Psychedelic Blood
+trait-description-ShimmeringBlood =
+    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
+    Your body produces Psychedelic Blood instead of whatever blood your species normally generates. [color=red]Note:[/color] Due to Psychedelic Blood being hallucinogenic, this comes with additional trait cost.
+
+trait-name-IntoxicatingBlood = Intoxicating Blood
+trait-description-IntoxicatingBlood =
+    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
+    Your body produces Intoxicating Blood instead of whatever blood your species normally generates. [color=red]Note:[/color] Due to Intoxicating Blood causing drunkness, this comes with additional trait cost.
+
+## Blood group type
+
+character-item-group-TraitsBloods = Blood Types

--- a/Resources/Locale/en-US/_DEN/traits/bloods.ftl
+++ b/Resources/Locale/en-US/_DEN/traits/bloods.ftl
@@ -38,6 +38,11 @@ trait-description-IntoxicatingBlood =
     Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
     Your body produces Intoxicating Blood instead of whatever blood your species normally generates. [color=red]Note:[/color] Due to Intoxicating Blood causing drunkness, this comes with additional trait cost.
 
+trait-name-SynthBlood = Synth Blood
+trait-description-SynthBlood =
+    Either due to a blood transfusion, a procedure done on you, or some other reason, your body contains different blood than usual.
+    Your body produces Synth Blood instead of whatever blood your species normally generates.
+
 ## Blood group type
 
 character-item-group-TraitsBloods = Blood Types

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -763,8 +763,9 @@ trait-description-EggLaying = You have an organ capable of laying eggs at the co
 trait-name-Caprine = Caprine
 trait-description-Caprine = A language spoken by the Ovinia, the language is composed of many loose bleating and baahing noises strung together to create words.
 
+# DEN Change - Change description of Synthetic trait, blood changing is decoupled
 trait-name-Synthetic = Synthetic
-trait-description-Synthetic = You are a biomechanical construct, who bleeds coolant and is notified of ongoing Ion Storms.
+trait-description-Synthetic = You are a biomechanical construct, who is notified of ongoing Ion Storms.
 
 trait-name-SyntheticVoicebox = Synthetic Voicebox
 trait-description-SyntheticVoicebox = Your vocal apparatus is itself synthetic, and starts to malfunction when you are injured.

--- a/Resources/Locale/en-US/traits/traits.ftl
+++ b/Resources/Locale/en-US/traits/traits.ftl
@@ -787,38 +787,3 @@ trait-name-PainNumbness = Pain Numbness
 trait-description-PainNumbness =
     Whether due to a rare mutation, freak medical accident, or some other reason, you're not able to feel pain
     making it much eaiser to miss possibly life threatening injuries.
-
-trait-name-BlackBlood = Black Blood
-trait-description-BlackBlood =
-    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
-    Your body produces Black Blood instead of whatever blood your species normally generates.
-
-trait-name-InsectBlood = Insect Blood
-trait-description-InsectBlood =
-    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
-    Your body produces Insect Blood instead of whatever blood your species normally generates.
-
-trait-name-BlueBlood = Blue Blood
-trait-description-BlueBlood =
-    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
-    Your body produces Blue Blood instead of whatever blood your species normally generates.
-
-trait-name-SlimeBlood = Slime Blood
-trait-description-SlimeBlood =
-    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
-    Your body produces slime instead of whatever blood your species normally generates.
-
-trait-name-RedBlood = Red Blood
-trait-description-RedBlood =
-    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
-    Your body produces regular blood instead of whatever blood your species normally generates.
-
-trait-name-AmmoniaBlood = Ammonia Blood
-trait-description-AmmoniaBlood =
-    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
-    Your body produces Ammonia Blood instead of whatever blood your species normally generates.
-
-trait-name-ShimmeringBlood = Psychedelic Blood
-trait-description-ShimmeringBlood =
-    Either due to a blood transfusion, inheritance from your parents, or some other reason, your body contains different blood than usual.
-    Your body produces Psychedelic Blood instead of whatever blood your species normally generates. [color=red]Note:[/color] Due to Psychedelic Blood being hallucinogenic, this comes with additional trait cost.

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1637,10 +1637,6 @@
         - StationAi
         - Borg
         - MedicalBorg
-    # DEN START - Add Blood group exclusion
-    - !type:CharacterItemGroupRequirement
-      group: TraitsBloods
-    # DEN END
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1640,7 +1640,7 @@
     # DEN START - Add Blood group exclusion
     - !type:CharacterItemGroupRequirement
       inverted: true
-      group: TraitsBlood
+      group: TraitsBloods
     # DEN END
     - !type:CharacterSpeciesRequirement
       inverted: true

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1637,6 +1637,11 @@
         - StationAi
         - Borg
         - MedicalBorg
+    # DEN START - Add Blood group exclusion
+    - !type:CharacterItemGroupRequirement
+      inverted: true
+      group: TraitsBlood
+    # DEN END
     - !type:CharacterSpeciesRequirement
       inverted: true
       species:

--- a/Resources/Prototypes/Traits/physical.yml
+++ b/Resources/Prototypes/Traits/physical.yml
@@ -1639,7 +1639,6 @@
         - MedicalBorg
     # DEN START - Add Blood group exclusion
     - !type:CharacterItemGroupRequirement
-      inverted: true
       group: TraitsBloods
     # DEN END
     - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/_DEN/CharacterItemGroups/Traits/bloods.yml
+++ b/Resources/Prototypes/_DEN/CharacterItemGroups/Traits/bloods.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 somekindofbox
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+- type: characterItemGroup
+  id: TraitsBloods
+  maxItems: 1
+  items:
+    - type: trait
+      id: AmmoniaBlood
+    - type: trait
+      id: BlackBlood
+    - type: trait
+      id: BlueBlood
+    - type: trait
+      id: InsectBlood
+    - type: trait
+      id: SlimeBlood
+    - type: trait
+      id: RedBlood
+    - type: trait
+      id: ShimmeringBlood

--- a/Resources/Prototypes/_DEN/CharacterItemGroups/Traits/bloods.yml
+++ b/Resources/Prototypes/_DEN/CharacterItemGroups/Traits/bloods.yml
@@ -20,3 +20,7 @@
       id: RedBlood
     - type: trait
       id: ShimmeringBlood
+    - type: trait
+      id: IntoxicatingBlood
+    - type: trait
+      id: Synthetic

--- a/Resources/Prototypes/_DEN/CharacterItemGroups/Traits/bloods.yml
+++ b/Resources/Prototypes/_DEN/CharacterItemGroups/Traits/bloods.yml
@@ -23,4 +23,4 @@
     - type: trait
       id: IntoxicatingBlood
     - type: trait
-      id: Synthetic
+      id: SynthBlood

--- a/Resources/Prototypes/_DEN/Traits/bloods.yml
+++ b/Resources/Prototypes/_DEN/Traits/bloods.yml
@@ -173,6 +173,7 @@
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
+    - IPC
     - Plasmaman
   functions:
   - !type:TraitModifyBloodstream

--- a/Resources/Prototypes/_DEN/Traits/bloods.yml
+++ b/Resources/Prototypes/_DEN/Traits/bloods.yml
@@ -156,6 +156,27 @@
   - !type:TraitModifyBloodstream
     bloodReagent: Blood
 
+# I killed the hardcoded blood reagent code in SynthSystem.cs because this is duplicate code, atomizing it into its own trait
+- type: trait
+  id: SynthBlood
+  category: TraitsBloods
+  points: -2
+  requirements:
+  - !type:CharacterJobRequirement
+    inverted: true
+    jobs:
+    - StationAi
+    - Borg
+    - MedicalBorg
+  - !type:CharacterItemGroupRequirement
+    group: TraitsBloods
+  - !type:CharacterSpeciesRequirement
+    inverted: true
+    species:
+    - Plasmaman
+  functions:
+  - !type:TraitModifyBloodstream
+    bloodReagent: SynthBlood
 
 # Thaven blood is hallucinogenic, which can grant psionics. For this reason, they cost points.
 - type: trait
@@ -203,4 +224,4 @@
     - Plasmaman
   functions:
   - !type:TraitModifyBloodstream
-    bloodReagent: IntoxicatingBlood 
+    bloodReagent: IntoxicatingBlood

--- a/Resources/Prototypes/_DEN/Traits/bloods.yml
+++ b/Resources/Prototypes/_DEN/Traits/bloods.yml
@@ -17,6 +17,8 @@
         - StationAi
         - Borg
         - MedicalBorg
+  - !type:CharacterItemGroupRequirement
+    group: TraitsBloods
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -39,6 +41,8 @@
         - StationAi
         - Borg
         - MedicalBorg
+  - !type:CharacterItemGroupRequirement
+    group: TraitsBloods
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -60,6 +64,8 @@
         - StationAi
         - Borg
         - MedicalBorg
+  - !type:CharacterItemGroupRequirement
+    group: TraitsBloods
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -81,6 +87,8 @@
         - StationAi
         - Borg
         - MedicalBorg
+  - !type:CharacterItemGroupRequirement
+    group: TraitsBloods
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -103,6 +111,8 @@
         - StationAi
         - Borg
         - MedicalBorg
+  - !type:CharacterItemGroupRequirement
+    group: TraitsBloods
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -124,6 +134,8 @@
         - StationAi
         - Borg
         - MedicalBorg
+  - !type:CharacterItemGroupRequirement
+    group: TraitsBloods
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -157,6 +169,8 @@
         - StationAi
         - Borg
         - MedicalBorg
+  - !type:CharacterItemGroupRequirement
+    group: TraitsBloods
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:

--- a/Resources/Prototypes/_DEN/Traits/bloods.yml
+++ b/Resources/Prototypes/_DEN/Traits/bloods.yml
@@ -4,7 +4,7 @@
 
 ## These get sorted alphabetically within the menu.
 ## If you do add more blood reagents in the future, be *absolutely* sure to include the exclusions for the other bloods.
-## It's boilerplatey as hell, but we do not have trait group requirements. A future refactor might help with this.
+## It's boilerplatey as hell, but group exclusions now have to be made in _DEN/CharcterItemGroups/Traits/bloods.yml.
 
 - type: trait
   id: AmmoniaBlood
@@ -17,15 +17,6 @@
         - StationAi
         - Borg
         - MedicalBorg
-  - !type:CharacterTraitRequirement
-    inverted: true
-    traits:
-    - Synthetic
-    - BlackBlood
-    - InsectBlood
-    - BlueBlood
-    - SlimeBlood
-    - ShimmeringBlood
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -48,16 +39,6 @@
         - StationAi
         - Borg
         - MedicalBorg
-  - !type:CharacterTraitRequirement
-    inverted: true
-    traits:
-    - Synthetic
-    - InsectBlood
-    - BlueBlood
-    - SlimeBlood
-    - RedBlood
-    - AmmoniaBlood
-    - ShimmeringBlood
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -79,16 +60,6 @@
         - StationAi
         - Borg
         - MedicalBorg
-  - !type:CharacterTraitRequirement
-    inverted: true
-    traits:
-    - Synthetic
-    - BlackBlood
-    - InsectBlood
-    - RedBlood
-    - SlimeBlood
-    - AmmoniaBlood
-    - ShimmeringBlood
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -110,16 +81,6 @@
         - StationAi
         - Borg
         - MedicalBorg
-  - !type:CharacterTraitRequirement
-    inverted: true
-    traits:
-    - Synthetic
-    - BlackBlood
-    - BlueBlood
-    - RedBlood
-    - SlimeBlood
-    - AmmoniaBlood
-    - ShimmeringBlood
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -142,16 +103,6 @@
         - StationAi
         - Borg
         - MedicalBorg
-  - !type:CharacterTraitRequirement
-    inverted: true
-    traits:
-    - Synthetic
-    - BlackBlood
-    - InsectBlood
-    - BlueBlood
-    - RedBlood
-    - AmmoniaBlood
-    - ShimmeringBlood
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -173,16 +124,6 @@
         - StationAi
         - Borg
         - MedicalBorg
-  - !type:CharacterTraitRequirement
-    inverted: true
-    traits:
-    - Synthetic
-    - BlackBlood
-    - InsectBlood
-    - BlueBlood
-    - SlimeBlood
-    - AmmoniaBlood
-    - ShimmeringBlood
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:
@@ -216,15 +157,6 @@
         - StationAi
         - Borg
         - MedicalBorg
-  - !type:CharacterTraitRequirement
-    inverted: true
-    traits:
-    - Synthetic
-    - BlackBlood
-    - InsectBlood
-    - BlueBlood
-    - SlimeBlood
-    - AmmoniaBlood
   - !type:CharacterSpeciesRequirement
     inverted: true
     species:

--- a/Resources/Prototypes/_DEN/Traits/bloods.yml
+++ b/Resources/Prototypes/_DEN/Traits/bloods.yml
@@ -180,3 +180,27 @@
   functions:
   - !type:TraitModifyBloodstream
     bloodReagent: ShimmeringBlood
+
+# Intoxicating blood can cause entities to become drunk. For this reason, they cost points.
+- type: trait
+  id: IntoxicatingBlood
+  category: TraitsBloods
+  points: -2
+  requirements:
+  - !type:CharacterJobRequirement
+      inverted: true
+      jobs:
+        - StationAi
+        - Borg
+        - MedicalBorg
+  - !type:CharacterItemGroupRequirement
+    group: TraitsBloods
+  - !type:CharacterSpeciesRequirement
+    inverted: true
+    species:
+    - IPC
+    - Thaven
+    - Plasmaman
+  functions:
+  - !type:TraitModifyBloodstream
+    bloodReagent: IntoxicatingBlood 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Refactoring a bunch of stuff related to the original blood reagent PR I made a bit ago.
This also adds Intoxicating blood, and decouples the hardcoded synth blood swap in the Synthetic code. 
FTLs have been edited to reflect this, making Synthetic a trait that only notifies you of ion storms.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Few reasons as to why this refactor is due:
- Gives more agency to players.
- Makes the boilerplate code not AS bad.
- Kills hardcoded and duplicate code that is no longer needed due to newer system code.

The original PR had a lot of exclusions that could easily be lumped into `CharacterItemGroupRequirement`, and thus has been done so. This also reorganizes a lot of back end things so that grouping and localization makes a lot more sense.

## Technical details
<!-- Summary of code changes for easier review. -->
Moved localization related to blood types from `traits.ftl` into the Den namespace.
Nuked duplicate code in `SynthSystem.cs`. We do not need hard-coded solutions like this anymore due to the fact we can change it through a trait.
Added new traits into `bloods.yml`, and changed exclusions from per-trait to group.
Added new Item Groups in `Resources/Prototypes/_DEN/CharacterItemGroups/Traits/bloods.yml`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1294" height="373" alt="image" src="https://github.com/user-attachments/assets/94b3678c-d6b7-4a40-8f9f-46487051b29d" />
<img width="679" height="92" alt="image" src="https://github.com/user-attachments/assets/8691796c-c8dc-4489-90c8-53bbc80afd32" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
This decouples a pre-existing feature of a trait into the general Blood Type category. This *may* cause characters who liked having the synthetic blood to no longer have it. The easiest way to get it back is by taking the new trait.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added the ability to take Synth Blood as a new blood type.
- remove: Removed the Synthetic trait changing your blood to Synth Blood.
- tweak: Cleaned up a bunch of code related to the Blood Type system. You won't notice many changes forward-facing.
