### PR TITLE
Give Resomi Earrings Back

### DIFF
--- a/Resources/Prototypes/_DEN/Entities/Mobs/Customization/Markings/base.yml
+++ b/Resources/Prototypes/_DEN/Entities/Mobs/Customization/Markings/base.yml
@@ -114,7 +114,7 @@
   abstract: true
   id: BaseEarrings
   invertSpeciesRestriction: true
-  speciesRestriction: [Vox, Shadowkin, Plasmaman, Thaven, Moth, Chitinid, Tajaran, Rodentia, Resomi]
+  speciesRestriction: [Vox, Shadowkin, Plasmaman, Thaven, Moth, Chitinid, Tajaran, Rodentia]
   bodyPart: HeadSide
   markingCategory: HeadSide
 


### PR DESCRIPTION
## About the PR
Removed the species restriction on Resomi using earrings.

## Why / Balance
It seemed to have been added to the species restrictions in a previous PR accidentally.

## Technical details

## Media
<img width="943" height="388" alt="image" src="https://github.com/user-attachments/assets/2a9a26aa-2b50-4658-9aec-9375b154f416" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

### Licensing
- [X] (OPTIONAL) This pull request contains code or assets that are owned by me, and I give permission for my own contributions to be re-licensed under MIT.

## Breaking changes

**Changelog**
:cl:
- fix: Gave Resomi their earrings back.