### PR TITLE
Fix Industrial Ore Processor Getting Reduced Materials

### DIFF
--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -290,7 +290,8 @@ namespace Content.Server.Lathe
                     var result = Spawn(resultProto, Transform(uid).Coordinates);
                     // DEN: Part upgrades, prevent surplus materials.
                     // We used less materials to make the item, it physically contains less materials.
-                    if (TryComp<PhysicalCompositionComponent>(result, out var physicalComposition))
+                    if (!comp.IgnoreMaterialPenalty 
+                        && TryComp<PhysicalCompositionComponent>(result, out var physicalComposition))
                     {
                         foreach(var (mat, amount) in physicalComposition.MaterialComposition)
                             physicalComposition.MaterialComposition[mat] = (int) Math.Floor(amount * comp.FinalMaterialUseMultiplier);

--- a/Content.Shared/Lathe/LatheComponent.cs
+++ b/Content.Shared/Lathe/LatheComponent.cs
@@ -128,6 +128,12 @@ namespace Content.Shared.Lathe
         /// </summary>
         [DataField]
         public float PartRatingMaterialUseMultiplier = 0.85f;
+
+        /// <summary>
+        /// Causes produced items to not have their material quantities reduced by the input cost discount.
+        /// </summary>
+        [DataField] public bool IgnoreMaterialPenalty = false; // DEN: Ore processor upgrades produce more mats.
+
         #endregion
     }
 

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -984,6 +984,7 @@
     defaultProductionAmount: 10
     staticPacks:
     - OreProcessorStaticAwfulDen
+    ignoreMaterialPenalty: true
   - type: MaterialStorageMagnetPickup # Delta V - Summary: Adds magnet pull from Frontier
     magnetEnabled: True
     range: 0.30 # Delta V - End Magnet Pull


### PR DESCRIPTION
## About the PR
Fixed the industrial ore processor producing reduced materials.

## Why / Balance
Upgrading the ore processor does nothing at the moment, this fixes that.

## Technical details
Added a flag to the LatheComponent that allows it to ignore the MaterialComposition penalty that is applied when upgraded in order to make material arbitrage happy.

## Media

https://github.com/user-attachments/assets/8eb46473-27ab-4476-a1db-1796d15d33dd


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

### Licensing

## Breaking changes

**Changelog**
:cl:
- fix: Fixed ore processor upgrades being net neutral.
