### PR TITLE
Make the Flatpacker Able to Have Its Speed Upgraded with Parts.

### DIFF
--- a/Content.Server/Construction/FlatpackSystem.cs
+++ b/Content.Server/Construction/FlatpackSystem.cs
@@ -31,6 +31,9 @@ public sealed class FlatpackSystem : SharedFlatpackSystem
 
         SubscribeLocalEvent<FlatpackCreatorComponent, FlatpackCreatorStartPackBuiMessage>(OnStartPack);
         SubscribeLocalEvent<FlatpackCreatorComponent, PowerChangedEvent>(OnPowerChanged);
+
+        SubscribeLocalEvent<FlatpackCreatorComponent, RefreshPartsEvent>(OnPartsRefresh); // DEN: Part upgrades
+        SubscribeLocalEvent<FlatpackCreatorComponent, UpgradeExamineEvent>(OnUpgradeExamine); // DEN: Part upgrades
     }
 
     private void OnStartPack(Entity<FlatpackCreatorComponent> ent, ref FlatpackCreatorStartPackBuiMessage args)
@@ -51,11 +54,18 @@ public sealed class FlatpackSystem : SharedFlatpackSystem
         if (cost is null)
             return;
 
+        // DEN: Part Upgrades
+        foreach (var (mat, amount) in cost)
+        {
+            var adjustedAmount = amount * ent.Comp.FinalMaterialUseMultiplier;
+            cost[mat] = (int)adjustedAmount;
+        }
+
         if (!MaterialStorage.CanChangeMaterialAmount(uid, cost))
             return;
 
         comp.Packing = true;
-        comp.PackEndTime = _timing.CurTime + comp.PackDuration;
+        comp.PackEndTime = _timing.CurTime + (comp.PackDuration * comp.FinalTimeMultiplier); // DEN: Part upgrades.
         Appearance.SetData(uid, FlatpackCreatorVisuals.Packing, true);
         _ambientSound.SetAmbience(uid, true);
         Dirty(uid, comp);
@@ -66,6 +76,24 @@ public sealed class FlatpackSystem : SharedFlatpackSystem
         if (args.Powered)
             return;
         FinishPacking(ent, true);
+    }
+
+    // DEN: Part upgrades
+    private void OnPartsRefresh(Entity<FlatpackCreatorComponent> ent, ref RefreshPartsEvent args)
+    {
+        var printTimeRating = args.PartRatings[ent.Comp.MachinePartPrintSpeed];
+        var materialUseRating = args.PartRatings[ent.Comp.MachinePartMaterialUse];
+
+        ent.Comp.FinalTimeMultiplier= MathF.Pow(ent.Comp.PartRatingPrintTimeMultiplier, printTimeRating - 1);
+        ent.Comp.FinalMaterialUseMultiplier = MathF.Pow(ent.Comp.PartRatingMaterialUseMultiplier, materialUseRating - 1);
+        Dirty(ent);
+    }
+
+    // DEN: Part upgrades
+    private void OnUpgradeExamine(Entity<FlatpackCreatorComponent> ent, ref UpgradeExamineEvent args)
+    {
+        args.AddPercentageUpgrade("lathe-component-upgrade-speed", 1 / ent.Comp.FinalTimeMultiplier);
+        args.AddPercentageUpgrade("lathe-component-upgrade-material-use", ent.Comp.FinalMaterialUseMultiplier);
     }
 
     private void FinishPacking(Entity<FlatpackCreatorComponent> ent, bool interrupted)

--- a/Content.Shared/Construction/Components/FlatpackCreatorComponent.cs
+++ b/Content.Shared/Construction/Components/FlatpackCreatorComponent.cs
@@ -64,6 +64,42 @@ public sealed partial class FlatpackCreatorComponent : Component
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public string SlotId = "board_slot";
+
+    // DEN: Part upgrades.
+    /// <summary>
+    /// The part that influences the flatpacker's speed.
+    /// </summary>
+    [DataField]
+    public string MachinePartPrintSpeed = "Manipulator";
+
+    /// <summary>
+    /// Controls how much of an impact an upgraded part has on the print time.
+    /// </summary>
+    [DataField] public float PartRatingPrintTimeMultiplier = 0.5f;
+    
+    /// <summary>
+    /// The part that influences the flatpacker's material use.
+    /// </summary>
+    [DataField]
+    public string MachinePartMaterialUse = "MatterBin";
+
+    /// <summary>
+    /// Controls how much of an impact an upgraded part has on the material cost.
+    /// </summary>
+    [DataField] public float PartRatingMaterialUseMultiplier = 1.0f;
+    
+    /// <summary>
+    /// The multiplier for the amount of time the packing takes with upgrades.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float FinalTimeMultiplier = 1.0f;
+    
+    /// <summary>
+    /// The multiplier for the amount of material the packing takes with upgrades.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float FinalMaterialUseMultiplier = 1.0f;
+    // DEN end
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Lathe/LatheComponent.cs
+++ b/Content.Shared/Lathe/LatheComponent.cs
@@ -128,6 +128,12 @@ namespace Content.Shared.Lathe
         /// </summary>
         [DataField]
         public float PartRatingMaterialUseMultiplier = 0.85f;
+
+        /// <summary>
+        /// Causes produced items to not have their material quantities reduced by the input cost discount.
+        /// </summary>
+        [DataField] public bool IgnoreMaterialPenalty = false; // DEN: Ore processor upgrades produce more mats.
+
         #endregion
     }
 


### PR DESCRIPTION
## About the PR
Made it so that manipulator upgrades speed up the flatpacker.

## Why / Balance
It's nice to be able to upgrade machines with better parts as you get them. This one had been left out until now.
The material cost multiplier is 1.0 for now, so storage bins do nothing, but this could be changed easily at any point.

## Technical details
Pretty much exactly what LatheSystem does but applying to the flatpacker.

## Media

https://github.com/user-attachments/assets/d0b44235-2ee2-438d-b5b8-3bdead306eef



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

### Licensing

## Breaking changes

**Changelog**
:cl:
- add: Made the flatpacker's speed upgradeable with parts.
