### PR TITLE
[BugFix] Projector Slot Whitelist

### DIFF
--- a/Content.Shared/PDA/PdaComponent.cs
+++ b/Content.Shared/PDA/PdaComponent.cs
@@ -67,7 +67,7 @@ namespace Content.Shared.PDA
         public ItemSlot PaiSlot = new();
         [DataField("passportSlot")]     // The Den
         public ItemSlot PassportSlot = new();
-        [DataField("projectSlot")]     // The Den
+        [DataField("projectorSlot")]     // The Den
         public ItemSlot ProjectorSlot = new();
 
         // Really this should just be using ItemSlot.StartingItem. However, seeing as we have so many different starting

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -128,7 +128,7 @@
     projectorSlot:
       priority: -2
       whitelist:
-        components:
+        tags:
         - CivilianHoloprojector
     # End The Den Changes
     penSlot:


### PR DESCRIPTION
## About the PR
The whitelist on the projector slot on the PDA wasn't applying because of a typo.

## Why / Balance
Bug bad.

## Technical details
projectSlot vs. projectorSlot
(also components vs. tags but that should have made NOTHING fit and I would have noticed that in testing at least :( )

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

### Licensing
- [X] (OPTIONAL) This pull request contains code or assets that are owned by me, and I give permission for my own contributions to be re-licensed under MIT.

## Breaking changes

**Changelog**