### PR TITLE
Command Playtime Increases

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -53,7 +53,7 @@
   playTimeTracker: JobQuartermaster
   requirements:
     - !type:CharacterPlaytimeRequirement #Den
-      role: JobCargoTechnician
+      tracker: JobCargoTechnician
       time: 32400 #9 hrs
     - !type:CharacterPlaytimeRequirement
       tracker: JobSalvageSpecialist

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -53,8 +53,8 @@
   playTimeTracker: JobQuartermaster
   requirements:
     - !type:CharacterPlaytimeRequirement #Den
-      role: JobCargoTechnician
-      time: 32400 #9 hrs
+      tracker: JobCargoTechnician
+      min: 32400 #9 hrs
     - !type:CharacterPlaytimeRequirement
       tracker: JobSalvageSpecialist
       min: 32400 #9 hrs

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -52,18 +52,18 @@
   description: job-description-qm
   playTimeTracker: JobQuartermaster
   requirements:
-  #  - !type:RoleTimeRequirement #DeltaV
-  #    role: JobCargoTechnician
-  #    time: 21600 #6 hrs
+    - !type:RoleTimeRequirement #Den
+      role: JobCargoTechnician
+      time: 32400 #9 hrs
     - !type:CharacterPlaytimeRequirement
       tracker: JobSalvageSpecialist
       min: 32400 #9 hrs
     - !type:CharacterPlaytimeRequirement # DeltaV - Courier role time requirement
       tracker: JobMailCarrier
-      min: 21600 # 6 hours
+      min: 10800 # 3 hours
     - !type:CharacterDepartmentTimeRequirement
       department: Logistics # DeltaV - Logistics Department replacing Cargo
-      min: 72000 #Den, 20 hours
+      min: 108000 #Den, 30 hours
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -57,13 +57,13 @@
   #    time: 21600 #6 hrs
     - !type:CharacterPlaytimeRequirement
       tracker: JobSalvageSpecialist
-      min: 10800 #3 hrs
+      min: 32400 #9 hrs
     - !type:CharacterPlaytimeRequirement # DeltaV - Courier role time requirement
       tracker: JobMailCarrier
-      min: 7200 # 2 hours
+      min: 21600 # 6 hours
     - !type:CharacterDepartmentTimeRequirement
       department: Logistics # DeltaV - Logistics Department replacing Cargo
-      min: 43200 #DeltaV 12 hours
+      min: 72000 #Den, 20 hours
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -52,7 +52,7 @@
   description: job-description-qm
   playTimeTracker: JobQuartermaster
   requirements:
-    - !type:RoleTimeRequirement #Den
+    - !type:CharacterPlaytimeRequirement #Den
       role: JobCargoTechnician
       time: 32400 #9 hrs
     - !type:CharacterPlaytimeRequirement

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -51,26 +51,24 @@
   description: job-description-captain
   playTimeTracker: JobCaptain
   requirements:
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobQuartermaster # DeltaV - Logistics Department replacing Cargo
-      min: 7200 # The Den - 2 hour
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobChiefEngineer
-      min: 7200 # The Den - 2 hour
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobChiefMedicalOfficer
-      min: 7200 # The Den - 2 hour
-    - !type:CharacterPlaytimeRequirement
-      tracker: JobHeadOfSecurity
-      min: 7200 # The Den - 2 hour
-    - !type:CharacterPlaytimeRequirement # DeltaV - Epistemics dept time requirement
-      tracker: JobResearchDirector # DeltaV - Epistemics Department replacing Science
-      min: 7200 # The Den - 2 hour
-    - !type:CharacterPlaytimeRequirement # DeltaV - Epistemics dept time requirement
-      tracker: JobHeadOfPersonnel # DeltaV - Epistemics Department replacing Science
-      min: 7200 # The Den - 2 hour
-    - !type:CharacterOverallTimeRequirement
-      min: 144000 # The Den - 40 hour
+     - !type:CharacterDepartmentTimeRequirement
+       department: Security
+       min: 36000
+     - !type:CharacterDepartmentTimeRequirement
+       department: Logistics
+       min: 36000
+     - !type:CharacterDepartmentTimeRequirement
+       department: Engineering
+       min: 36000
+     - !type:CharacterDepartmentTimeRequirement
+       department: Medical
+       min: 36000
+     - !type:CharacterDepartmentTimeRequirement
+       department: Epistemics
+       min: 36000
+     - !type:CharacterDepartmentTimeRequirement
+       department: Civilian
+       min: 36000
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -61,7 +61,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement # DeltaV - Civilian dept time requirement
       department: Civilian
-      min: 72000 # The Den - 20 hours
+      min: 108000 # The Den - 30 hours
     - !type:CharacterPlaytimeRequirement
       tracker: JobChef
       min: 7200 # The Den - 2 hour

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -61,7 +61,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement # DeltaV - Civilian dept time requirement
       department: Civilian
-      min: 28800 # The Den - 8 hours
+      min: 72000 # The Den - 20 hours
     - !type:CharacterPlaytimeRequirement
       tracker: JobChef
       min: 7200 # The Den - 2 hour

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -53,7 +53,7 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement # Den - Engineering dept time requirement
       department: Engineering
-      min: 72000 # The Den - 20 hours
+      min: 144000 # The Den - 40 hours
     - !type:CharacterPlaytimeRequirement
       tracker: JobAtmosphericTechnician
       min: 28800 # The Den - 8 hours

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -51,9 +51,12 @@
   description: job-description-ce
   playTimeTracker: JobChiefEngineer
   requirements:
+    - !type:CharacterDepartmentTimeRequirement # Den - Engineering dept time requirement
+      department: Engineering
+      min: 72000 # The Den - 20 hours
     - !type:CharacterPlaytimeRequirement
       tracker: JobAtmosphericTechnician
-      min: 28800 # The Den - 8 hour
+      min: 28800 # The Den - 8 hours
 #    - !type:OverallPlaytimeRequirement
 #      time: 72000 # DeltaV - 20 hours
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -57,10 +57,10 @@
   requirements:
     - !type:CharacterDepartmentTimeRequirement # Den - Medical dept time requirement
       department: Medical
-      min: 108000 # The Den - 30 hours (higher than other heads due to the high impact this role can have in slowing/preventing the revival ot other players)
+      min: 144000 # The Den - 40 hours (higher than other heads due to the high impact this role can have in slowing/preventing the revival ot other players)
     - !type:CharacterPlaytimeRequirement
       tracker: JobChemist
-      min: 28800 # The Den - 8 hour
+      min: 36000 # The Den - 10 hour
     - !type:CharacterPlaytimeRequirement
       tracker: JobParamedic
       min: 10800 # The Den - 3 hour

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -55,8 +55,17 @@
   description: job-description-cmo
   playTimeTracker: JobChiefMedicalOfficer
   requirements:
+    - !type:CharacterDepartmentTimeRequirement # Den - Medical dept time requirement
+      department: Medical
+      min: 108000 # The Den - 30 hours (higher than other heads due to the high impact this role can have in slowing/preventing the revival ot other players)
     - !type:CharacterPlaytimeRequirement
       tracker: JobChemist
+      min: 28800 # The Den - 8 hour
+    - !type:CharacterPlaytimeRequirement
+      tracker: JobParamedic
+      min: 10800 # The Den - 3 hour
+    - !type:CharacterPlaytimeRequirement
+      tracker: JobMedicalDoctor
       min: 28800 # The Den - 8 hour
   weight: 10
   startingGear: CMOGear

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -62,9 +62,12 @@
     - !type:CharacterPlaytimeRequirement
       tracker: JobForensicMantis
       min: 14400 # The Den - 4 hour
+    - !type:CharacterPlaytimeRequirement
+      tracker: JobScientist
+      min: 36000 # The Den - 10 hour
     - !type:CharacterDepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
-      min: 72000 # The Den - 20 hour
+      min: 108000 # The Den - 30 hour
     - !type:CharacterLogicOrRequirement
       requirements:
       - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -64,7 +64,7 @@
       min: 14400 # The Den - 4 hour
     - !type:CharacterDepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
-      min: 28800 # The Den - 8 hour
+      min: 72000 # The Den - 20 hour
     - !type:CharacterLogicOrRequirement
       requirements:
       - !type:CharacterSpeciesRequirement

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -65,9 +65,9 @@
       min: 28800 # The Den - 8 hours
     - !type:CharacterDepartmentTimeRequirement
       department: Security
-      min: 108000 # The Den - 30 hours (higher than other command due to the impact this can have on others shifts)
+      min: 144000 # The Den - 40 hours (higher than other command due to the impact this can have on others shifts)
     - !type:CharacterOverallTimeRequirement
-      min: 180000 # The Den - 50 hours
+      min: 360000 # The Den - 100 hours
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -62,10 +62,10 @@
   requirements:
     - !type:CharacterPlaytimeRequirement
       tracker: JobDetective
-      min: 10800 # The Den - 3 hours
+      min: 28800 # The Den - 8 hours
     - !type:CharacterDepartmentTimeRequirement
       department: Security
-      min: 72000 # The Den - 20 hours
+      min: 108000 # The Den - 30 hours (higher than other command due to the impact this can have on others shifts)
     - !type:CharacterOverallTimeRequirement
       min: 180000 # The Den - 50 hours
   startingGear: WardenGear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
This is a draft PR to coincide with this thread created by someone else on the Discord
https://discord.com/channels/1301753657024319488/1494577214262608062

Based on discussions, increasing the time requirements for command on Den.  I've set them to where I'd feel reasonable, but it's largely a community discussion and feedback is valuable.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The general feeling is that command roles can via people taking them before they have sufficient experience are causing a negative experience.  As they directly impact others, especially because the time requirement allows people to pick them thinking they're ready, but end up sinking under responsibilities they weren't fully expecting.  

## Technical details
<!-- Summary of code changes for easier review. -->
Sets all command to 30 hours, with some additional requirements, with the exception of CE, CMO and Warden, which are each set to 40 hours in their respective departments. (And 100 overall Den hours for Warden, so they can properly get a feel for the culture)

Previous times ranged between 8-12 hours before a command position could be taken.

Has been updated to match general consensus in the discussion thread.  

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

### Licensing
- [ ] (OPTIONAL) This pull request contains code or assets that are owned by me, and I give permission for my own contributions to be re-licensed under MIT.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Command Playtimes adjusted.
