### PR TITLE
Fix Climbing Through Doors and Walls.

### DIFF
--- a/Resources/Prototypes/_DEN/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/_DEN/Entities/Structures/Holographic/projections.yml
@@ -18,7 +18,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.5,-0.5,0.5,0.5"
+          bounds: "-0.45,-0.45,0.45,0.45"
         mask:
         - TableMask
         layer:


### PR DESCRIPTION
## About the PR
Made it so you can't flop into or drag onto barriers that are in walls and airlocks.

## Why / Balance
Noclip bad.

## Technical details
Turns out being the same size as the wall makes the physics system just skip all of the wall's checks. Who knew.

## Media

https://github.com/user-attachments/assets/b90ddd14-e6bb-4376-b1fc-4607558e9111



## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

### Licensing
- [X] (OPTIONAL) This pull request contains code or assets that are owned by me, and I give permission for my own contributions to be re-licensed under MIT.

## Breaking changes

**Changelog**