### PR TITLE
Change Syndicate Communication Console Header

### DIFF
--- a/Resources/Locale/en-US/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/communications/communications-console-component.ftl
@@ -41,6 +41,7 @@ comms-console-announcement-unknown-sender = Unknown
 comms-console-announcement-title-station = Communications Console
 comms-console-announcement-title-centcom = Central Command
 comms-console-announcement-title-nukie = Gorlex Marauder
+comms-console-announcement-title-lpo = Pirate Broadcast
 comms-console-announcement-title-station-ai = Station AI
 comms-console-announcement-title-wizard = Wizard
 

--- a/Resources/Locale/en-US/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/communications/communications-console-component.ftl
@@ -40,7 +40,7 @@ comms-console-announcement-unknown-sender = Unknown
 # Comms console variant titles
 comms-console-announcement-title-station = Communications Console
 comms-console-announcement-title-centcom = Central Command
-comms-console-announcement-title-nukie = Syndicate Nuclear Operative
+comms-console-announcement-title-nukie = Gorlex Marauder
 comms-console-announcement-title-station-ai = Station AI
 comms-console-announcement-title-wizard = Wizard
 

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -459,6 +459,19 @@
   - type: ComputerBoard
     prototype: SyndicateComputerComms
 
+# DEN start
+- type: entity
+  parent: SyndicateCommsComputerCircuitboard
+  id: LPOCommsComputerCircuitboard
+  name: LPO communications computer board
+  description: A computer printed circuit board for an LPO communications console.
+  components:
+  - type: Sprite
+    state: cpu_security
+  - type: ComputerBoard
+    prototype: LPOComputerComms
+# DEN end
+
 - type: entity
   parent: BaseComputerCircuitboard
   id: RadarConsoleCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -876,7 +876,7 @@
   - type: CommunicationsConsole
     title: comms-console-announcement-title-station
   - type: DeviceNetwork
-    deviceNetId: Wireless    
+    deviceNetId: Wireless
     transmitFrequencyId: ShuttleTimer
   - type: ActivatableUI
     key: enum.CommunicationsConsoleUiKey.Key
@@ -928,6 +928,30 @@
     radius: 1.5
     energy: 1.6
     color: "#f71713"
+
+# DEN start
+- type: entity
+  parent: SyndicateComputerComms
+  id: LPOComputerComms
+  components:
+  - type: CommunicationsConsole
+    title: comms-console-announcement-title-lpo
+    sound: !type:SoundPathSpecifier
+      params:
+        variation: null
+        playOffsetSeconds: 0
+        loop: False
+        referenceDistance: 1
+        rolloffFactor: 1
+        maxDistance: 15
+        pitch: 1
+        volume: 0
+      path: /Audio/Floof/Announcements/pirateannounce.ogg
+      delay: 300
+      color: '#FFD700FF'
+  - type: Computer
+    board: LPOCommsComputerCircuitboard
+# DEN end
 
 - type: entity
   parent: BaseComputerAiAccess

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -936,19 +936,8 @@
   components:
   - type: CommunicationsConsole
     title: comms-console-announcement-title-lpo
-    sound: !type:SoundPathSpecifier
-      params:
-        variation: null
-        playOffsetSeconds: 0
-        loop: False
-        referenceDistance: 1
-        rolloffFactor: 1
-        maxDistance: 15
-        pitch: 1
-        volume: 0
-      path: /Audio/Floof/Announcements/pirateannounce.ogg
-      delay: 300
-      color: '#FFD700FF'
+    delay: 300
+    color: '#FFD700FF'
   - type: Computer
     board: LPOCommsComputerCircuitboard
 # DEN end


### PR DESCRIPTION
<!--- LICENSE: MIT -->
## About the PR
what it says on tin

## Why / Balance
From direction thread:
>Change Syndicate Communication Console's Header
>From Syndicate Nuclear Operative to Gorlex Marauder Announcement or something. 90% of the time the nuke isn't going to be the objective.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have tested any changes or additions.
- [x] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

### Licensing
- [x] (OPTIONAL) This pull request contains code or assets that are owned by me, and I give permission for my own contributions to be re-licensed under MIT.

**Changelog**
:cl:
- tweak: The syndicate communication console's header will now say "Gorlex Marauder Announcement" instead of "Syndicate Nuclear Operative Annoucement".