### PR TITLE
Game Mode Tweaks and Additions

### DIFF
--- a/Resources/Locale/en-US/_DEN/game-ticking/game-presets/preset-redshift.ftl
+++ b/Resources/Locale/en-US/_DEN/game-ticking/game-presets/preset-redshift.ftl
@@ -1,0 +1,2 @@
+redshift-title = Redshift
+redshift-description = No default scheduled events. Admin-curated high danger round, likely to strain the station. Any and all threats may be active, and there is a higher than usual chance for special events.

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -191,7 +191,7 @@
   components:
   - type: GameRule
     delay:
-      min: 1800
+      min: 2200
       max: 2400
   - type: AntagSelection
     definitions:

--- a/Resources/Prototypes/_DEN/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_DEN/GameRules/roundstart.yml
@@ -36,7 +36,7 @@
     # minPlayers: 20 # minimum of 2 conspirators
     delay:
       min: 1800
-      max: 2400
+      max: 2100
   - type: ConspiratorRule
   - type: AntagSelection
     # selectionTime: IntraPlayerSpawn
@@ -59,3 +59,16 @@
         - RadioImplantConspiracy
       mindRoles:
       - MindRoleConspirator
+
+- type: entity
+  id: ListeningOutpostDelayedRandomSpawn
+  parent: BaseGameRule
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubGamemodes
+    rules:
+    - id: PirateRadioSpawn
+      prob: 0.5
+      delay:
+        min: 2400
+        max: 3600

--- a/Resources/Prototypes/_DEN/game_presets.yml
+++ b/Resources/Prototypes/_DEN/game_presets.yml
@@ -39,9 +39,8 @@
   description: roundstart-antags-description
   rules:
     - BasicRoundstartVariation
-    - MoreTraitor
+    - Traitor
     - LessConspirator
-    - Thief
     - SubGamemodesRule
     - LavalandStormScheduler # Lavaland Change
     - IrregularExtendedStationEventScheduler
@@ -65,7 +64,7 @@
   description: conspiracy-description
   showInVote: true
   highDanger: true
-  minPlayers: 40
+  minPlayers: 25 # DEN: Minimum population for medium-danger presets to account for lack of security
   rules:
   - Conspirators
   - BasicRoundstartVariation
@@ -83,3 +82,14 @@
   showInVote: false
   highDanger: false
   minPlayers: 0
+
+- type: gamePreset
+  id: Redshift
+  alias:
+  - redshift
+  name: redshift-title
+  showInVote: true
+  highDanger: true
+  description: redshift-description
+  rules:
+  - LavalandStormScheduler # Lavaland Change

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -35,12 +35,11 @@
   name: survival-title
   showInVote: true # secret # DeltaV - Me when the survival. Used for periapsis.
   highDanger: true
-  minPlayers: 40 # DEN: Minimum population for high-danger presets to account for lack of security
+  minPlayers: 25 # DEN: Minimum population for medium-danger presets to account for lack of security
   description: survival-description
   rules:
     - RampingStationEventScheduler
     - BasicRoundstartVariation
-    - Traitor
     - SubGamemodesRule
     - LavalandStormScheduler # Lavaland Change
 
@@ -177,7 +176,8 @@
   highDanger: true
   minPlayers: 40 # DEN: Minimum population for high-danger presets to account for lack of security
   rules:
-    - Traitor
+    - MoreTraitor
+    - ListeningOutpostDelayedRandomSpawn
     - SubGamemodesRule
     - BasicStationEventScheduler
     - BasicRoundstartVariation


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I've been working on some changes to our game presets to try to differentiate them a bit and add a bit more "medium danger" options. 

**New Game Mode - "Redshift":**
In game description: "No default scheduled events. Admin-curated high danger round, likely to strain the station. Any and all threats may be active, and there is a higher than usual chance for special events."

Identical to Greenshift mechanically, but a way for the community to request admin-curated high danger, or for admins to indicate a high impact event is taking place. Intended to be dangerous, but more "unusual/unpredictable, or tailored to how the station is staffed" kind of danger and not necessarily Hellshift-style antag spam.

**Survival:**
Removed the guaranteed traitor spawns. It is now accurate to its description of no internal threats (unless it rolls sleeper agents).
Survival is available at 25 population minimum, down from 40.

**Conspiracy:**
Available at 25 population, down from 40.

**Traitor:**
Increased maximum traitors from 4 to 6.
Added an extra chance for a Listening Post to spawn at 40-60 minutes into the round.

**Even More Antags:**
Maximum antags reduced from 18 to 13 and tweaked it to give Conspirators a better chance to fill the team.
Made Conspirators roll before traitors so they're more likely to get a full team (up to 6).
Reduced maximum traitors from 6 to 4.
Removed the guaranteed Thief slots. There is still a random chance it has thieves.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Attempting to differentiate the game modes a bit, and allow a bit of "medium danger" into lower/mid population rounds. The survival change has been requested for a very long time. Redshift gives a lot of options.

## Technical details
<!-- Summary of code changes for easier review. -->
Handful of yml changes across 5 files.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

### Licensing
- [ ] (OPTIONAL) This pull request contains code or assets that are owned by me, and I give permission for my own contributions to be re-licensed under MIT.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Kelaris
- add: "Redshift" game mode added, for players to vote to request an admin curated higher risk round. Threats may be unusual custom events, or selected from existing game rules.
- tweak: Survival now more closely matches its description, and has a high risk of external threats, but has no guaranteed crew antagonists.
- tweak: Survival can be voted on at a minimum of 25 population, down from 40.
- tweak: Conspiracy can be voted on at a minimum of 25 population, down from 40.
- tweak: Even More Antags has slightly less maximum traitors, and less guaranteed thieves. (Still the most antag slots of any game mode)
- tweak: Even More Antags guarantees rolling conspirators before traitors, to try to ensure the conspirator team gets filled if possible.
- tweak: Traitor game mode has slightly more traitors.
- tweak: Traitor game mode now has an extra chance of a Listening Post spawning shortly after traitors are rolled. Consider buying those Syndicate comms!