### PR TITLE
Make ForceField Projectors Use a Doafter

### DIFF
--- a/Content.Shared/_DV/Holosign/ChargeHolosignProjectorComponent.cs
+++ b/Content.Shared/_DV/Holosign/ChargeHolosignProjectorComponent.cs
@@ -30,4 +30,6 @@ public sealed partial class ChargeHolosignProjectorComponent : Component
     public string SignComponentName;
 
     public Type SignComponent = default!;
+
+    [DataField] public TimeSpan PlaceTime = TimeSpan.Zero;
 }

--- a/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
+++ b/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
@@ -13,9 +13,13 @@ using Content.Shared.Storage;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
 using System.Linq;
+using Content.Shared.DoAfter;
 // Start TheDen - Add sounds to holofan
 using Content.Shared.Sound;
 using Content.Shared.Sound.Components;
+using Robust.Shared.Serialization;
+
+
 // End TheDen
 
 namespace Content.Shared._DV.Holosign;
@@ -28,6 +32,8 @@ public sealed class ChargeHolosignSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedEmitSoundSystem _sound = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!; // DEN: Sign placement doafters.
+    [Dependency] private readonly SharedTransformSystem _xforms = default!; // DEN: Sign placement doafters.
 
     private HashSet<Entity<IComponent>> _signs = new();
 
@@ -38,6 +44,8 @@ public sealed class ChargeHolosignSystem : EntitySystem
         SubscribeLocalEvent<ChargeHolosignProjectorComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<ChargeHolosignProjectorComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<ChargeHolosignProjectorComponent, BeforeRangedInteractEvent>(OnBeforeInteract);
+
+        SubscribeLocalEvent<ChargeHolosignProjectorComponent, SignPlaceActionEvent>(OnSignPlaceAction); // DEN: Place doafters
     }
 
     private void OnInit(Entity<ChargeHolosignProjectorComponent> ent, ref ComponentInit args)
@@ -71,22 +79,73 @@ public sealed class ChargeHolosignSystem : EntitySystem
         _lookup.GetEntitiesInRange(ent.Comp.SignComponent, mapCoords, 0.25f, _signs);
 
         if (_signs.Count == 0)
-            TryPlaceSign((ent, ent, charges), args);
+        {
+            // DEN Start: Sign placement doafters.
+            if (ent.Comp.PlaceTime > TimeSpan.Zero)
+            {
+                TryStartDoafter((ent, ent, charges), args);
+            }
+            else
+            {
+                TryPlaceSign(
+                    (ent, ent, charges), 
+                    args.User, 
+                    _xforms.ToMapCoordinates(args.ClickLocation.SnapToGrid(EntityManager)));
+            }
+            // DEN End
+        }
         else
             TryRemoveSign((ent, ent, charges), _signs.First(), args.User);
 
         args.Handled = true;
     }
 
-    public bool TryPlaceSign(Entity<ChargeHolosignProjectorComponent, LimitedChargesComponent> ent, BeforeRangedInteractEvent args)
+    // DEN Start: Sign placement doafters
+    public void TryStartDoafter(
+        Entity<ChargeHolosignProjectorComponent, LimitedChargesComponent> ent, BeforeRangedInteractEvent args
+    )
+    {
+        if (_charges.HasInsufficientCharges(ent.Owner, 1, ent.Comp2))
+        {
+            _popup.PopupClient(Loc.GetString("charge-holoprojector-no-charges", ("item", ent)), ent, args.User);
+            return;
+        }
+
+        _doAfterSystem.TryStartDoAfter(
+            new(
+                    EntityManager,
+                    args.User,
+                    ent.Comp1.PlaceTime,
+                    new SignPlaceActionEvent(_xforms.ToMapCoordinates(args.ClickLocation.SnapToGrid(EntityManager))),
+                    ent.Owner,
+                    used: ent.Owner)
+            {
+                BreakOnMove = true,
+                BreakOnWeightlessMove = false
+            });
+    }
+
+    public void OnSignPlaceAction(Entity<ChargeHolosignProjectorComponent> ent, ref SignPlaceActionEvent args)
+    {
+        if (args.Cancelled)
+            return;
+        
+        if (!TryComp<LimitedChargesComponent>(ent, out var charges))
+            return;
+
+        TryPlaceSign((ent, ent.Comp, charges), args.User, args.Location);
+    }
+    // DEN End
+    
+    public bool TryPlaceSign(Entity<ChargeHolosignProjectorComponent, LimitedChargesComponent> ent, EntityUid user, MapCoordinates location) // DEN: Change arguments to not take ranged event.
     {
         if (!_charges.TryUseCharge((ent, ent.Comp2)))
         {
-            _popup.PopupClient(Loc.GetString("charge-holoprojector-no-charges", ("item", ent)), ent, args.User);
+            _popup.PopupClient(Loc.GetString("charge-holoprojector-no-charges", ("item", ent)), ent, user);
             return false;
         }
 
-        var holoUid = EntityManager.PredictedSpawnAtPosition(ent.Comp1.SignProto, args.ClickLocation.SnapToGrid(EntityManager));
+        var holoUid = EntityManager.PredictedSpawn(ent.Comp1.SignProto, location);
         var xform = Transform(holoUid);
         if (!xform.Anchored)
             _transform.AnchorEntity(holoUid, xform); // anchor to prevent any tempering with (don't know what could even interact with it)
@@ -112,4 +171,13 @@ public sealed class ChargeHolosignSystem : EntitySystem
         EntityManager.PredictedDeleteEntity(sign);
         return true;
     }
+}
+
+// DEN: Sign placement doafter
+[Serializable, NetSerializable]
+public sealed partial class SignPlaceActionEvent : SimpleDoAfterEvent
+{
+    public MapCoordinates Location { get; set; }
+
+    public SignPlaceActionEvent(MapCoordinates location) : this() => Location = location;
 }

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -134,14 +134,15 @@
   #      name: power-cell-slot-component-slot-name-default
 
 - type: entity
-  parent: Holoprojector
+  parent: HolofanProjector
   id: HoloprojectorField
   name: force field projector
   description: Creates an impassable forcefield that won't let anything through. Close proximity may or may not cause cancer.
   components:
-    - type: HolosignProjector
+    - type: ChargeHolosignProjector
       signProto: HolosignForcefield
-      chargeUse: 120
+      signComponentName: Holobarrier
+      placeTime: 1.5
     - type: Sprite
       sprite: Objects/Devices/Holoprojectors/field.rsi
       state: icon
@@ -158,12 +159,13 @@
 - type: entity
   parent: HoloprojectorField
   id: HoloprojectorFieldEmpty
+  categories: [ HideSpawnMenu ] # DEN - identical to a normal one.
   suffix: Empty
-  components:
-  - type: ItemSlots
-    slots:
-      cell_slot:
-        name: power-cell-slot-component-slot-name-default
+#  components: # DEN - No cell slot for an empty one.
+#  - type: ItemSlots
+#    slots:
+#      cell_slot:
+#        name: power-cell-slot-component-slot-name-default
 
 - type: entity
   parent: [ BaseSecurityBlueshieldOfficerContraband, BaseItem ] # Den - Remove powercell requirement

--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -152,6 +152,7 @@
   - type: Clickable
   - type: ContainmentField
     throwForce: 0
+  - type: Holobarrier # DEN - for whitelisting
   - type: Destructible
     thresholds:
       - trigger:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Makes it so that Force Field projectors have a doafter to spawn their field.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The force field projectors are not intended to be just a better version of the security holobarrier.

## Technical details
<!-- Summary of code changes for easier review. -->
Switched them to a charge based projector, added a TimeSpan to the component for placement time. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/208c8df1-84ef-4b11-b73f-f6f0cb386ee7



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have tested any changes or additions.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

### Licensing
- [ ] (OPTIONAL) This pull request contains code or assets that are owned by me, and I give permission for my own contributions to be re-licensed under MIT.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Made Force Field Projectors have a doafter to place their fields.

